### PR TITLE
override default available()  method which is coming from InputStream…

### DIFF
--- a/components/analytics-core/org.wso2.carbon.analytics.datasource.core/src/main/java/org/wso2/carbon/analytics/datasource/core/util/GenericUtils.java
+++ b/components/analytics-core/org.wso2.carbon.analytics.datasource.core/src/main/java/org/wso2/carbon/analytics/datasource/core/util/GenericUtils.java
@@ -417,10 +417,10 @@ public class GenericUtils {
         if (in == null) {
             return null;
         }
-        if (in.available() == 0) {
+        DataInputStream dataIn = new DataInputStream(new PushbackInputStream(in));
+        if (dataIn.available() == 0) {
             throw new EOFException();
         }
-        DataInputStream dataIn = new DataInputStream(in);
         int size = dataIn.readInt();
         byte[] buff = new byte[size];
         dataIn.readFully(buff);


### PR DESCRIPTION
available() method which is available in InputStream[1] doesn't check anything. It always returns 0. Normally, the available() method returns number of remaining bytes that can be read from a given input stream without blocking by the next method call for this input stream. It only checks if there is data available (in input buffers) in the current process. Because .available() can not be used in inter-process communication.