### PR TITLE
Upgraging analytics to use latest carbon-data dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1269,12 +1269,12 @@
         <!-- WSO2 repository versions -->
         <carbon.commons.version>4.5.4</carbon.commons.version>
         <carbon.commons.imp.pkg.version>[4.5, 5)</carbon.commons.imp.pkg.version>
-        <carbon.data.version>4.3.5</carbon.data.version>
+        <carbon.data.version>4.4.0-SNAPSHOT</carbon.data.version>
         <carbon.event-processing.version>2.1.4</carbon.event-processing.version>
         <carbon.analytics.common.version>5.1.3</carbon.analytics.common.version>
         <carbon.analytics.common.imp.pkg.version>[5.0, 6.0)</carbon.analytics.common.imp.pkg.version>
 
-        <carbon.data.import.pkg.version>[4.3, 5)</carbon.data.import.pkg.version>
+        <carbon.data.import.pkg.version>[4.4, 5)</carbon.data.import.pkg.version>
 
         <!-- Axis2 Version -->
         <axis2.version>1.6.1-wso2v11</axis2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1269,7 +1269,7 @@
         <!-- WSO2 repository versions -->
         <carbon.commons.version>4.5.4</carbon.commons.version>
         <carbon.commons.imp.pkg.version>[4.5, 5)</carbon.commons.imp.pkg.version>
-        <carbon.data.version>4.4.0-SNAPSHOT</carbon.data.version>
+        <carbon.data.version>4.3.6-SNAPSHOT</carbon.data.version>
         <carbon.event-processing.version>2.1.4</carbon.event-processing.version>
         <carbon.analytics.common.version>5.1.3</carbon.analytics.common.version>
         <carbon.analytics.common.imp.pkg.version>[5.0, 6.0)</carbon.analytics.common.imp.pkg.version>


### PR DESCRIPTION
Upgraging analytics to use latest carbon-data dependencies as per [orbit PR](https://github.com/wso2/orbit/pull/237) & [carbon-data PR](https://github.com/wso2/carbon-data/pull/125)