### PR TITLE
Implemented check for invalid stream names.

### DIFF
--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/CarbonEventStreamService.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/CarbonEventStreamService.java
@@ -64,9 +64,12 @@ public class CarbonEventStreamService implements EventStreamService {
         ExecutionPlanRuntime executionPlanRuntime = executionPlanRunTimeMap.get(executionPlanName);
         if (executionPlanRuntime != null) {
             if (executionPlanRuntime.getStreamDefinitionMap().size() != 0) {
-                AbstractDefinition streamDefinition = executionPlanRuntime.getStreamDefinitionMap().get(streamName);
-                return streamDefinition.getAttributeList();
-
+                if (executionPlanRuntime.getStreamDefinitionMap().containsKey(streamName)) {
+                    AbstractDefinition streamDefinition = executionPlanRuntime.getStreamDefinitionMap().get(streamName);
+                    return streamDefinition.getAttributeList();
+                } else {
+                    return null;
+                }
             }
         }
         return null;


### PR DESCRIPTION
When retrieving stream attributes list, if the stream is not available in the execution plan `streamDefinition.getAttributeList()` will result in a null pointer exception. Implemented a fix by checking whether the `executionPlanRuntime` contains the stream. Please review and merge.