### PR TITLE
 Msf4j is migrated to v2.4.1 version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1101,19 +1101,19 @@
         <carbon.kernel.package.import.version.range>[5.0.0, 6.0.0)</carbon.kernel.package.import.version.range>
         <carbon.kernel.pax.version>5.2.0-alpha</carbon.kernel.pax.version>
 
-        <org.wso2.carbon.transport.http.netty.version>5.0.0-m1</org.wso2.carbon.transport.http.netty.version>
+        <org.wso2.carbon.transport.http.netty.version>5.0.1</org.wso2.carbon.transport.http.netty.version>
         <carbon.transport.package.import.version.range>[4.0.0, 6.0.0)</carbon.transport.package.import.version.range>
-        <org.wso2.carbon.transport.version>5.0.0-m1</org.wso2.carbon.transport.version>
+        <org.wso2.carbon.transport.version>5.0.1</org.wso2.carbon.transport.version>
 
-        <carbon.messaging.version>3.0.0</carbon.messaging.version>
+        <carbon.messaging.version>3.0.1</carbon.messaging.version>
         <carbon.messaging.package.import.version.range>[0.0.0, 4.0.0)</carbon.messaging.package.import.version.range>
 
-        <carbon.deployment.version>5.1.4</carbon.deployment.version>
+        <carbon.deployment.version>5.1.5</carbon.deployment.version>
         <carbon.deployment.export.version>5.1.4</carbon.deployment.export.version>
 
-        <carbon.datasources.version>1.1.2</carbon.datasources.version>
-        <carbon.metrics.version>2.3.1</carbon.metrics.version>
-        <carbon.jndi.version>1.0.3</carbon.jndi.version>
+        <carbon.datasources.version>1.1.3</carbon.datasources.version>
+        <carbon.metrics.version>2.3.2</carbon.metrics.version>
+        <carbon.jndi.version>1.0.4</carbon.jndi.version>
 
         <carbon.cache.version>1.1.3</carbon.cache.version>
         <carbon.touchpoint.version>1.1.0</carbon.touchpoint.version>
@@ -1171,7 +1171,7 @@
         <common.collections4.version>4.0</common.collections4.version>
 
         <!--MSF4J related-->
-        <msf4j.version>2.4.0-m1</msf4j.version>
+        <msf4j.version>2.4.1</msf4j.version>
         <msf4j.import.version.range>[2.0.0, 3.0.0)</msf4j.import.version.range>
         <com.fasterxml.jackson.core.version>2.7.4</com.fasterxml.jackson.core.version>
         <io.swagger.version>1.5.10</io.swagger.version>


### PR DESCRIPTION
msf4j is migrated to v2.4.1 version.
Change the other feature dependency according to msf4j version.