### PR TITLE
improved simulator user experience

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/event-simulator/simulator.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/event-simulator/simulator.js
@@ -624,7 +624,7 @@ define(['jquery', 'log', './simulator-rest-client', 'lodash', /* void libs */'bo
             result += dataOption.replaceAll('{{dataName}}', dataArray[i]);
         }
         if(dataArray.length == 0){
-            result += dataOption.replaceAll('{{dataName}}', "   No saved Siddhi Apps available.");
+            result += dataOption.replaceAll('{{dataName}}', "No saved Siddhi Apps available.");
         }
         return result;
     };

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/event-simulator/simulator.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/event-simulator/simulator.js
@@ -558,6 +558,11 @@ define(['jquery', 'log', './simulator-rest-client', 'lodash', /* void libs */'bo
     self.refreshSiddhiAppList = function ($siddhiAppSelect, siddhiAppNames) {
         var newSiddhiApps = self.generateOptions(siddhiAppNames);
         $siddhiAppSelect.html(newSiddhiApps);
+        if(siddhiAppNames.length == 0){
+            $siddhiAppSelect.find('option:eq(0)').attr("selected", "selected");
+        } else{
+            $siddhiAppSelect.prop('selectedIndex', -1);
+        }
     };
 
 // select an option from the siddhi app name drop down
@@ -572,8 +577,6 @@ define(['jquery', 'log', './simulator-rest-client', 'lodash', /* void libs */'bo
             $siddhiAppSelect
                 .val(siddhiAppName);
         } else {
-            $siddhiAppSelect
-                .prop('selectedIndex', -1);
             if (siddhiAppName !== null) {
                 var $form = $siddhiAppSelect.closest('form[data-form-type="single"]');
                 $form
@@ -603,6 +606,11 @@ define(['jquery', 'log', './simulator-rest-client', 'lodash', /* void libs */'bo
         var newStreamOptions = self.generateOptions(streamNames);
         $streamNameSelect
             .html(newStreamOptions);
+        if(streamNames.length == 0){
+            $streamNameSelect.find('option:eq(0)').attr("selected", "selected");
+        } else{
+            $siddhiAppSelect.prop('selectedIndex', -1);
+        }
     };
 
 //    used to create options for available siddhi apps and streams
@@ -616,7 +624,7 @@ define(['jquery', 'log', './simulator-rest-client', 'lodash', /* void libs */'bo
             result += dataOption.replaceAll('{{dataName}}', dataArray[i]);
         }
         if(dataArray.length == 0){
-            result += dataOption.replaceAll('{{dataName}}', "No saved Siddhi Apps available.");
+            result += dataOption.replaceAll('{{dataName}}', "   No saved Siddhi Apps available.");
         }
         return result;
     };


### PR DESCRIPTION
## Purpose
Resolves the user experience issue where in event simulation, when there is no siddhi app saved then user does not know that he needs to save them before hand to do a simulation. 

## Goals
Corresponding selecting area will now show a relevant message to the user

## Approach
![fixnosiddhiappavailable](https://user-images.githubusercontent.com/9207770/31175204-0d5ce1be-a92c-11e7-9c2c-20d0d5ef8a02.png)


## User stories
N/A

## Release note
Event simulator improvements on user experience

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
N/A
## Certification
N/A

## Marketing
N/A

## Automation tests
N/A
   > Code coverage information
 - Integration tests
  N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
JDK 1.8 , Linux , chrome Version 58.0.3029.81
 
## Learning
Jquery