### PR TITLE
Added 2 Node Minimum HA Feature

### DIFF
--- a/components/distribution/carbon-home/conf/default/deployment.yaml
+++ b/components/distribution/carbon-home/conf/default/deployment.yaml
@@ -191,7 +191,7 @@ state.persistence:
   # config:
     # location: siddhi-app-persistence
   config:
-    datasource: WSO2_ANALYTICS_DB
+    datasource: WSO2_CLUSTER_DB
     table: PERSISTENCE_TABLE
 
   # Secure Vault Configuration
@@ -210,14 +210,14 @@ wso2.securevault:
 # Data Sources Configuration
 wso2.datasources:
   dataSources:
-    - name: WSO2_ANALYTICS_DB
+    - name: WSO2_CLUSTER_DB
       description: The datasource used for Siddhi App state persistence
       jndiConfig:
-        name: jdbc/WSO2_ANALYTICS_DB
+        name: jdbc/WSO2_CLUSTER_DB
       definition:
         type: RDBMS
         configuration:
-          jdbcUrl: 'jdbc:h2:./target/database/WSO2_ANALYTICS_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000'
+          jdbcUrl: 'jdbc:h2:./target/database/WSO2_CLUSTER_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000'
           username: wso2carbon
           password: wso2carbon
           driverClassName: org.h2.Driver
@@ -226,3 +226,24 @@ wso2.datasources:
           connectionTestQuery: SELECT 1
           validationTimeout: 30000
           isAutoCommit: false
+
+cluster.config:
+  enabled: true
+  groupId: group-1
+  coordinationStrategyClass: org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy
+  strategyConfig:
+    datasource: WSO2_CLUSTER_DB
+    heartbeatInterval: 1000
+    heartbeatMaxAge: 2
+    eventPollingInterval: 1000
+  modeConfig:
+    type: distributed
+    liveStateSync: enabled
+    publisherSyncInterval: 60000
+    advertisedHost: localhost
+    advertisedPort: 9090
+  resourceManagers:
+    - host: manager.host.1
+      port: 9090
+    - host: manager.host.2
+      port: 9090

--- a/components/distribution/pom.xml
+++ b/components/distribution/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.analytics</groupId>
         <artifactId>org.wso2.carbon.analytics.parent</artifactId>
-        <version>2.0.89</version>
+        <version>2.0.90-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/distribution/pom.xml
+++ b/components/distribution/pom.xml
@@ -515,6 +515,11 @@
                                     <id>org.wso2.carbon.pax.exam.feature.group</id>
                                     <version>${carbon.kernel.version}</version>
                                 </feature>
+
+                                <feature>
+                                    <id>org.wso2.carbon.das.jobmanager.core.feature.group</id>
+                                    <version>${carbon.analytics.version}</version>
+                                </feature>
                             </features>
                         </configuration>
                     </execution>

--- a/components/org.wso2.carbon.das.jobmanager.core/pom.xml
+++ b/components/org.wso2.carbon.das.jobmanager.core/pom.xml
@@ -17,7 +17,8 @@
 ~ under the License.
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.wso2.carbon.analytics</groupId>
         <artifactId>org.wso2.carbon.analytics.parent</artifactId>
@@ -77,6 +78,23 @@
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wso2.carbon.utils</groupId>
+            <artifactId>org.wso2.carbon.utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.datasources</groupId>
+            <artifactId>org.wso2.carbon.datasource.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.coordination</groupId>
+            <artifactId>org.wso2.carbon.cluster.coordinator.service</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.coordination</groupId>
+            <artifactId>org.wso2.carbon.cluster.coordinator.commons</artifactId>
         </dependency>
     </dependencies>
     <build>
@@ -170,7 +188,7 @@
             *;resolution:=optional
         </import.package>
         <export.package>
-            !org.wso2.carbon.das.jobmanager.core.internal,
+            <!--!org.wso2.carbon.das.jobmanager.core.internal,-->
             org.wso2.carbon.das.jobmanager.core.*
         </export.package>
         <carbon.component>

--- a/components/org.wso2.carbon.das.jobmanager.core/pom.xml
+++ b/components/org.wso2.carbon.das.jobmanager.core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.analytics</groupId>
         <artifactId>org.wso2.carbon.analytics.parent</artifactId>
-        <version>2.0.89</version>
+        <version>2.0.90-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.das.jobmanager.core/src/main/java/org/wso2/carbon/das/jobmanager/core/beans/ClusterConfig.java
+++ b/components/org.wso2.carbon.das.jobmanager.core/src/main/java/org/wso2/carbon/das/jobmanager/core/beans/ClusterConfig.java
@@ -1,0 +1,113 @@
+/*
+ *  Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.wso2.carbon.das.jobmanager.core.beans;
+
+
+import org.wso2.carbon.config.annotation.Configuration;
+import org.wso2.carbon.das.jobmanager.core.util.Utils;
+
+import java.util.List;
+
+/**
+ * This class represents the cluster configuration.
+ */
+@Configuration(namespace = "cluster.config", description = "Cluster Configuration")
+public class ClusterConfig {
+    private Boolean enabled;
+    private String groupId;
+    private String coordinationStrategyClass;
+    private CoordinationModeConfig modeConfig;
+    private CoordinationStrategyConfig strategyConfig;
+    private List<ResourceManagerConfig> resourceManagers;
+
+    public Boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
+    }
+
+    public String getCoordinationStrategyClass() {
+        return coordinationStrategyClass;
+    }
+
+    public void setCoordinationStrategyClass(String coordinationStrategy) {
+        this.coordinationStrategyClass = coordinationStrategy;
+    }
+
+    public CoordinationModeConfig getModeConfig() {
+        return modeConfig;
+    }
+
+    public void setModeConfig(CoordinationModeConfig modeConfig) {
+        this.modeConfig = modeConfig;
+    }
+
+    public CoordinationStrategyConfig getStrategyConfig() {
+        return strategyConfig;
+    }
+
+    public void setStrategyConfig(CoordinationStrategyConfig strategyConfig) {
+        this.strategyConfig = strategyConfig;
+    }
+
+    public List<ResourceManagerConfig> getResourceManagers() {
+        return resourceManagers;
+    }
+
+    public void setResourceManagers(List<ResourceManagerConfig> resourceManagers) {
+        this.resourceManagers = resourceManagers;
+    }
+
+    @Override
+    public boolean equals(Object rhs) {
+        if (!(rhs instanceof ClusterConfig)) {
+            return false;
+        }
+        ClusterConfig dsmInfo = (ClusterConfig) rhs;
+        if (!Utils.nullAllowEquals(dsmInfo.isEnabled(), this.isEnabled())) {
+            return false;
+        }
+        if (!Utils.nullAllowEquals(dsmInfo.getGroupId(), this.getGroupId())) {
+            return false;
+        }
+        if (!Utils.nullAllowEquals(dsmInfo.getCoordinationStrategyClass(), this.getCoordinationStrategyClass())) {
+            return false;
+        }
+        if (!Utils.nullAllowEquals(dsmInfo.getModeConfig(), this.getModeConfig())) {
+            return false;
+        }
+        if (!Utils.nullAllowEquals(dsmInfo.getStrategyConfig(), this.getStrategyConfig())) {
+            return false;
+        }
+        return Utils.nullAllowEquals(dsmInfo.getResourceManagers(), this.getResourceManagers());
+    }
+
+    @Override
+    public int hashCode() {
+        assert false : "hashCode() not implemented";
+        return -1;
+    }
+}

--- a/components/org.wso2.carbon.das.jobmanager.core/src/main/java/org/wso2/carbon/das/jobmanager/core/beans/CoordinationModeConfig.java
+++ b/components/org.wso2.carbon.das.jobmanager.core/src/main/java/org/wso2/carbon/das/jobmanager/core/beans/CoordinationModeConfig.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.wso2.carbon.das.jobmanager.core.beans;
+
+
+import org.wso2.carbon.config.annotation.Configuration;
+
+/**
+ * This class represents the cluster coordination mode configuration.
+ */
+@Configuration(description = "Cluster Coordination Mode Configuration")
+public class CoordinationModeConfig {
+    private String type;
+    private String liveStateSync;
+    private int publisherSyncInterval;
+    private String advertisedHost;
+    private int advertisedPort;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getLiveStateSync() {
+        return liveStateSync;
+    }
+
+    public void setLiveStateSync(String liveStateSync) {
+        this.liveStateSync = liveStateSync;
+    }
+
+    public int getPublisherSyncInterval() {
+        return publisherSyncInterval;
+    }
+
+    public void setPublisherSyncInterval(int publisherSyncInterval) {
+        this.publisherSyncInterval = publisherSyncInterval;
+    }
+
+    public String getAdvertisedHost() {
+        return advertisedHost;
+    }
+
+    public void setAdvertisedHost(String advertisedHost) {
+        this.advertisedHost = advertisedHost;
+    }
+
+    public int getAdvertisedPort() {
+        return advertisedPort;
+    }
+
+    public void setAdvertisedPort(int advertisedPort) {
+        this.advertisedPort = advertisedPort;
+    }
+
+    @Override
+    public int hashCode() {
+        assert false : "hashCode() not implemented";
+        return -1;
+    }
+}

--- a/components/org.wso2.carbon.das.jobmanager.core/src/main/java/org/wso2/carbon/das/jobmanager/core/beans/CoordinationStrategyConfig.java
+++ b/components/org.wso2.carbon.das.jobmanager.core/src/main/java/org/wso2/carbon/das/jobmanager/core/beans/CoordinationStrategyConfig.java
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.wso2.carbon.das.jobmanager.core.beans;
+
+
+import org.wso2.carbon.config.annotation.Configuration;
+
+/**
+ * This class represents the cluster Coordination Strategy configuration.
+ */
+@Configuration(description = "Cluster Coordination Strategy Configuration")
+public class CoordinationStrategyConfig {
+    private String datasource;
+    private int heartbeatInterval;
+    private int heartbeatMaxAge;
+    private int eventPollingInterval;
+
+    public String getDatasource() {
+        return datasource;
+    }
+
+    public void setDatasource(String datasource) {
+        this.datasource = datasource;
+    }
+
+    public int getHeartbeatInterval() {
+        return heartbeatInterval;
+    }
+
+    public void setHeartbeatInterval(int heartbeatInterval) {
+        this.heartbeatInterval = heartbeatInterval;
+    }
+
+    public int getHeartbeatMaxAge() {
+        return heartbeatMaxAge;
+    }
+
+    public void setHeartbeatMaxAge(int heartbeatMaxAge) {
+        this.heartbeatMaxAge = heartbeatMaxAge;
+    }
+
+    public int getEventPollingInterval() {
+        return eventPollingInterval;
+    }
+
+    public void setEventPollingInterval(int eventPollingInterval) {
+        this.eventPollingInterval = eventPollingInterval;
+    }
+
+    @Override
+    public int hashCode() {
+        assert false : "hashCode() not implemented";
+        return -1;
+    }
+}

--- a/components/org.wso2.carbon.das.jobmanager.core/src/main/java/org/wso2/carbon/das/jobmanager/core/beans/ResourceManagerConfig.java
+++ b/components/org.wso2.carbon.das.jobmanager.core/src/main/java/org/wso2/carbon/das/jobmanager/core/beans/ResourceManagerConfig.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.wso2.carbon.das.jobmanager.core.beans;
+
+
+import org.wso2.carbon.config.annotation.Configuration;
+
+/**
+ * This class represents a Resource Manager configuration.
+ */
+@Configuration(description = "Resource Manager Configuration")
+public class ResourceManagerConfig {
+    private String host;
+    private int port;
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    @Override
+    public int hashCode() {
+        assert false : "hashCode() not implemented";
+        return -1;
+    }
+
+}

--- a/components/org.wso2.carbon.das.jobmanager.core/src/main/java/org/wso2/carbon/das/jobmanager/core/exception/JobManagerException.java
+++ b/components/org.wso2.carbon.das.jobmanager.core/src/main/java/org/wso2/carbon/das/jobmanager/core/exception/JobManagerException.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.wso2.carbon.das.jobmanager.core.exception;
+
+/**
+ * This class represents exceptions which are related to data sources.
+ */
+public class JobManagerException extends Exception {
+
+    private static final long serialVersionUID = -3151279311929070293L;
+
+    public JobManagerException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public JobManagerException(String msg) {
+        super(msg);
+    }
+}

--- a/components/org.wso2.carbon.das.jobmanager.core/src/main/java/org/wso2/carbon/das/jobmanager/core/internal/ServiceComponent.java
+++ b/components/org.wso2.carbon.das.jobmanager.core/src/main/java/org/wso2/carbon/das/jobmanager/core/internal/ServiceComponent.java
@@ -1,0 +1,179 @@
+package org.wso2.carbon.das.jobmanager.core.internal;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.carbon.cluster.coordinator.commons.MemberEventListener;
+import org.wso2.carbon.cluster.coordinator.commons.node.NodeDetail;
+import org.wso2.carbon.cluster.coordinator.service.ClusterCoordinator;
+import org.wso2.carbon.config.ConfigurationException;
+import org.wso2.carbon.config.provider.ConfigProvider;
+import org.wso2.carbon.das.jobmanager.core.beans.ClusterConfig;
+import org.wso2.carbon.das.jobmanager.core.exception.JobManagerException;
+import org.wso2.carbon.das.jobmanager.core.util.DeploymentMode;
+import org.wso2.carbon.das.jobmanager.core.util.DistributedConstants;
+import org.wso2.carbon.das.jobmanager.core.util.RuntimeMode;
+import org.wso2.carbon.datasource.core.api.DataSourceService;
+import org.wso2.carbon.utils.Utils;
+
+import java.util.HashMap;
+
+/**
+ * ServiceComponent for the Distributed Manager.
+ */
+@Component(
+        name = "DistributedManagerServiceComponent",
+        service = ServiceComponent.class,
+        immediate = true
+)
+public class ServiceComponent {
+    private static final Logger log = LoggerFactory.getLogger(ServiceComponent.class);
+    private ServiceRegistration serviceRegistration;
+
+    /**
+     * This is the activation method of ServiceComponent.
+     * This will be called when its references are satisfied.
+     *
+     * @param bundleContext the bundle context instance of this bundle.
+     * @throws Exception will be thrown if an issue occurs while executing the activate method
+     */
+    @Activate
+    protected void start(BundleContext bundleContext) throws Exception {
+        log.info("ServiceComponent bundle activated.");
+    }
+
+    /**
+     * This is the deactivation method of ServiceComponent.
+     * This will be called when this component is being stopped.
+     *
+     * @throws Exception will be thrown if an issue occurs while executing the de-activate method
+     */
+    @Deactivate
+    protected void stop() throws Exception {
+        log.info("ServiceComponent is deactivated");
+        if (serviceRegistration != null) {
+            serviceRegistration.unregister();
+        }
+    }
+
+    /**
+     * Register carbon {@link ConfigProvider} to be used with config reading.
+     * @param configProvider {@link ConfigProvider} reference.
+     * @throws JobManagerException Will be thrown upon failure to read deployment.yaml
+     */
+    @Reference(
+            name = "carbon.config.provider",
+            service = ConfigProvider.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unregisterConfigProvider"
+    )
+    protected void registerConfigProvider(ConfigProvider configProvider) throws JobManagerException {
+        ServiceDataHolder.setConfigProvider(configProvider);
+        if (DistributedConstants.RUNTIME_NAME_MANAGER.equalsIgnoreCase(Utils.getRuntimeName())) {
+            ServiceDataHolder.setRuntimeMode(RuntimeMode.MANAGER);
+            ClusterConfig clusterConfig;
+            try {
+                if (ServiceDataHolder.getConfigProvider()
+                        .getConfigurationObject(DistributedConstants.CLUSTER_CONFIG_NS) != null) {
+                    clusterConfig = ServiceDataHolder.getConfigProvider().getConfigurationObject(ClusterConfig.class);
+                    if (clusterConfig != null) {
+                        ServiceDataHolder.setClusterConfig(clusterConfig);
+                        if (DistributedConstants.MODE_DISTRIBUTED.equalsIgnoreCase(
+                                clusterConfig.getModeConfig().getType())) {
+                            ServiceDataHolder.setDeploymentMode(DeploymentMode.DISTRIBUTED);
+                        }
+                    } else {
+                        throw new JobManagerException("Configuration doesn't specify any cluster configurations");
+                    }
+                }
+            } catch (ConfigurationException e) {
+                throw new JobManagerException("Error while reading cluster configuration from deployment.yaml", e);
+            }
+        }
+    }
+
+    /**
+     * Unregister ConfigProvider
+     * @param configProvider
+     */
+    protected void unregisterConfigProvider(ConfigProvider configProvider) {
+        ServiceDataHolder.setConfigProvider(null);
+    }
+
+    @Reference(
+            name = "org.wso2.carbon.datasource.DataSourceService",
+            service = DataSourceService.class,
+            cardinality = ReferenceCardinality.OPTIONAL,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unregisterDataSourceService"
+    )
+    protected void registerDataSourceService(DataSourceService dataSourceService) {
+        ServiceDataHolder.setDataSourceService(dataSourceService);
+    }
+
+    protected void unregisterDataSourceService(DataSourceService dataSourceService) {
+        ServiceDataHolder.setDataSourceService(null);
+    }
+
+    @Reference(
+            name = "org.wso2.carbon.cluster.coordinator.service.ClusterCoordinator",
+            service = ClusterCoordinator.class,
+            cardinality = ReferenceCardinality.OPTIONAL,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unregisterClusterCoordinator"
+    )
+    protected void registerClusterCoordinator(ClusterCoordinator clusterCoordinator) {
+        ServiceDataHolder.setClusterCoordinator(clusterCoordinator);
+        configureCluster(clusterCoordinator);
+    }
+
+    protected void unregisterClusterCoordinator(ClusterCoordinator coordinationStrategy) {
+        ServiceDataHolder.setClusterCoordinator(null);
+    }
+
+    private void configureCluster(ClusterCoordinator clusterCoordinator) {
+        // Only have to join the cluster if this node is a Manager and it's running on Distributed mode.
+        ClusterConfig clusterConfig = ServiceDataHolder.getClusterConfig();
+        if (ServiceDataHolder.getClusterCoordinator() != null && clusterConfig != null &&
+                ServiceDataHolder.getDeploymentMode() == DeploymentMode.DISTRIBUTED &&
+                ServiceDataHolder.getRuntimeMode() == RuntimeMode.MANAGER) {
+            if (clusterConfig.isEnabled()) {
+                if (DistributedConstants.MODE_DISTRIBUTED.equalsIgnoreCase(clusterConfig.getModeConfig().getType())) {
+                    clusterCoordinator.setPropertiesMap(new HashMap<String, Object>() {{
+                        put("host", ServiceDataHolder.getClusterConfig().getModeConfig().getAdvertisedHost());
+                        put("port", ServiceDataHolder.getClusterConfig().getModeConfig().getAdvertisedHost());
+                    }});
+                    clusterCoordinator.registerEventListener(new MemberEventListener() {
+                        @Override
+                        public void memberAdded(NodeDetail nodeDetail) {
+                            // do nothing
+                        }
+
+                        @Override
+                        public void memberRemoved(NodeDetail nodeDetail) {
+                            // do nothing
+                        }
+
+                        @Override
+                        public void coordinatorChanged(NodeDetail nodeDetail) {
+                            ServiceDataHolder.setIsLeader(clusterCoordinator.isLeaderNode());
+                            ServiceDataHolder.setLeaderNodeDetail(clusterCoordinator.getLeaderNode());
+                        }
+                    });
+                    ServiceDataHolder.setIsLeader(clusterCoordinator.isLeaderNode());
+                    log.info("Stream Processor started as a Manager node in Distributed mode.");
+                }
+            } else {
+                log.warn("Clustering disabled in configuration. Hence, Manager runtime activated without clustering.");
+            }
+        }
+    }
+}

--- a/components/org.wso2.carbon.das.jobmanager.core/src/main/java/org/wso2/carbon/das/jobmanager/core/internal/ServiceDataHolder.java
+++ b/components/org.wso2.carbon.das.jobmanager.core/src/main/java/org/wso2/carbon/das/jobmanager/core/internal/ServiceDataHolder.java
@@ -1,0 +1,84 @@
+package org.wso2.carbon.das.jobmanager.core.internal;
+
+import org.wso2.carbon.cluster.coordinator.commons.node.NodeDetail;
+import org.wso2.carbon.cluster.coordinator.service.ClusterCoordinator;
+import org.wso2.carbon.config.provider.ConfigProvider;
+import org.wso2.carbon.das.jobmanager.core.beans.ClusterConfig;
+import org.wso2.carbon.das.jobmanager.core.util.DeploymentMode;
+import org.wso2.carbon.das.jobmanager.core.util.RuntimeMode;
+import org.wso2.carbon.datasource.core.api.DataSourceService;
+
+public class ServiceDataHolder {
+    private static ConfigProvider configProvider;
+    private static DataSourceService dataSourceService;
+    private static ClusterCoordinator clusterCoordinator;
+    private static DeploymentMode deploymentMode;
+    private static RuntimeMode runtimeMode;
+    private static ClusterConfig clusterConfig;
+    private static NodeDetail leaderNodeDetail;
+    private static boolean isLeader;
+
+    public static ConfigProvider getConfigProvider() {
+        return configProvider;
+    }
+
+    public static void setConfigProvider(ConfigProvider configProvider) {
+        ServiceDataHolder.configProvider = configProvider;
+    }
+
+    public static DataSourceService getDataSourceService() {
+        return dataSourceService;
+    }
+
+    public static void setDataSourceService(DataSourceService dataSourceService) {
+        ServiceDataHolder.dataSourceService = dataSourceService;
+    }
+
+    public static ClusterCoordinator getClusterCoordinator() {
+        return clusterCoordinator;
+    }
+
+    public static void setClusterCoordinator(ClusterCoordinator clusterCoordinator) {
+        ServiceDataHolder.clusterCoordinator = clusterCoordinator;
+    }
+
+    public static DeploymentMode getDeploymentMode() {
+        return deploymentMode;
+    }
+
+    public static void setDeploymentMode(DeploymentMode deploymentMode) {
+        ServiceDataHolder.deploymentMode = deploymentMode;
+    }
+
+    public static ClusterConfig getClusterConfig() {
+        return clusterConfig;
+    }
+
+    public static void setClusterConfig(ClusterConfig clusterConfig) {
+        ServiceDataHolder.clusterConfig = clusterConfig;
+    }
+
+    public static RuntimeMode getRuntimeMode() {
+        return runtimeMode;
+    }
+
+    public static void setRuntimeMode(RuntimeMode runtimeMode) {
+        ServiceDataHolder.runtimeMode = runtimeMode;
+    }
+
+    public static boolean isLeader() {
+        return isLeader;
+    }
+
+    public static void setIsLeader(boolean isLeader) {
+        ServiceDataHolder.isLeader = isLeader;
+    }
+
+    public static NodeDetail getLeaderNodeDetail() {
+        return leaderNodeDetail;
+    }
+
+    public static void setLeaderNodeDetail(NodeDetail leaderNodeDetail) {
+        ServiceDataHolder.leaderNodeDetail = leaderNodeDetail;
+    }
+}

--- a/components/org.wso2.carbon.das.jobmanager.core/src/main/java/org/wso2/carbon/das/jobmanager/core/util/DeploymentMode.java
+++ b/components/org.wso2.carbon.das.jobmanager.core/src/main/java/org/wso2/carbon/das/jobmanager/core/util/DeploymentMode.java
@@ -1,0 +1,5 @@
+package org.wso2.carbon.das.jobmanager.core.util;
+
+public enum DeploymentMode {
+    DISTRIBUTED, HA
+}

--- a/components/org.wso2.carbon.das.jobmanager.core/src/main/java/org/wso2/carbon/das/jobmanager/core/util/DistributedConstants.java
+++ b/components/org.wso2.carbon.das.jobmanager.core/src/main/java/org/wso2/carbon/das/jobmanager/core/util/DistributedConstants.java
@@ -1,0 +1,17 @@
+package org.wso2.carbon.das.jobmanager.core.util;
+
+/**
+ * This class contains the constants needed for the distributed deployment.
+ */
+public class DistributedConstants {
+    public static final String RUNTIME_NAME_WORKER = "worker";
+
+    public static final String RUNTIME_NAME_MANAGER = "default"; // TODO: 10/15/17 For testing, change to manager
+
+    public static final String CLUSTER_CONFIG_NS = "cluster.config";
+
+    public static final String MODE_DISTRIBUTED = "distributed";
+
+    public static final String MODE_HA = "ha";
+
+}

--- a/components/org.wso2.carbon.das.jobmanager.core/src/main/java/org/wso2/carbon/das/jobmanager/core/util/RuntimeMode.java
+++ b/components/org.wso2.carbon.das.jobmanager.core/src/main/java/org/wso2/carbon/das/jobmanager/core/util/RuntimeMode.java
@@ -1,0 +1,5 @@
+package org.wso2.carbon.das.jobmanager.core.util;
+
+public enum RuntimeMode {
+    MANAGER, RESOURCE
+}

--- a/components/org.wso2.carbon.das.jobmanager.core/src/main/java/org/wso2/carbon/das/jobmanager/core/util/Utils.java
+++ b/components/org.wso2.carbon.das.jobmanager.core/src/main/java/org/wso2/carbon/das/jobmanager/core/util/Utils.java
@@ -1,0 +1,10 @@
+package org.wso2.carbon.das.jobmanager.core.util;
+
+public class Utils {
+
+
+    public static boolean nullAllowEquals(Object lhs, Object rhs) {
+        return lhs == null && rhs == null || !((lhs == null && rhs != null) || (lhs != null && rhs == null))
+                && (lhs != null && lhs.equals(rhs));
+    }
+}

--- a/components/org.wso2.carbon.database.query.manager/pom.xml
+++ b/components/org.wso2.carbon.database.query.manager/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.analytics</groupId>
         <artifactId>org.wso2.carbon.analytics.parent</artifactId>
-        <version>2.0.89</version>
+        <version>2.0.90-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.event.simulator.core/pom.xml
+++ b/components/org.wso2.carbon.event.simulator.core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.analytics</groupId>
         <artifactId>org.wso2.carbon.analytics.parent</artifactId>
-        <version>2.0.89</version>
+        <version>2.0.90-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.msf4j.interceptor.common/pom.xml
+++ b/components/org.wso2.carbon.msf4j.interceptor.common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.analytics</groupId>
         <artifactId>org.wso2.carbon.analytics.parent</artifactId>
-        <version>2.0.89</version>
+        <version>2.0.90-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.siddhi.editor.core/pom.xml
+++ b/components/org.wso2.carbon.siddhi.editor.core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.analytics</groupId>
         <artifactId>org.wso2.carbon.analytics.parent</artifactId>
-        <version>2.0.89</version>
+        <version>2.0.90-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.stream.processor.common/pom.xml
+++ b/components/org.wso2.carbon.stream.processor.common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.analytics</groupId>
         <artifactId>org.wso2.carbon.analytics.parent</artifactId>
-        <version>2.0.89</version>
+        <version>2.0.90-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.stream.processor.core/pom.xml
+++ b/components/org.wso2.carbon.stream.processor.core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.analytics</groupId>
         <artifactId>org.wso2.carbon.analytics.parent</artifactId>
-        <version>2.0.89</version>
+        <version>2.0.90-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/osgi-tests/pom.xml
+++ b/components/osgi-tests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.analytics</groupId>
         <artifactId>org.wso2.carbon.analytics.parent</artifactId>
-        <version>2.0.89</version>
+        <version>2.0.90-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.das.jobmanager.core.feature/pom.xml
+++ b/features/org.wso2.carbon.das.jobmanager.core.feature/pom.xml
@@ -17,7 +17,8 @@
   ~ under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.wso2.carbon.analytics</groupId>
         <artifactId>org.wso2.carbon.analytics.parent</artifactId>
@@ -36,6 +37,18 @@
         <dependency>
             <groupId>org.wso2.carbon.analytics</groupId>
             <artifactId>org.wso2.carbon.das.jobmanager.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.coordination</groupId>
+            <artifactId>org.wso2.carbon.cluster.coordinator.commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.coordination</groupId>
+            <artifactId>org.wso2.carbon.cluster.coordinator.service</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.coordination</groupId>
+            <artifactId>org.wso2.carbon.cluster.coordinator.rdbms</artifactId>
         </dependency>
     </dependencies>
 
@@ -68,6 +81,18 @@
                                 <bundle>
                                     <symbolicName>org.wso2.carbon.das.jobmanager.core</symbolicName>
                                     <version>${project.version}</version>
+                                </bundle>
+                                <bundle>
+                                    <symbolicName>org.wso2.carbon.cluster.coordinator.commons</symbolicName>
+                                    <version>${carbon.coordination.version}</version>
+                                </bundle>
+                                <bundle>
+                                    <symbolicName>org.wso2.carbon.cluster.coordinator.service</symbolicName>
+                                    <version>${carbon.coordination.version}</version>
+                                </bundle>
+                                <bundle>
+                                    <symbolicName>org.wso2.carbon.cluster.coordinator.rdbms</symbolicName>
+                                    <version>${carbon.coordination.version}</version>
                                 </bundle>
                             </bundles>
                         </configuration>

--- a/features/org.wso2.carbon.das.jobmanager.core.feature/pom.xml
+++ b/features/org.wso2.carbon.das.jobmanager.core.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.analytics</groupId>
         <artifactId>org.wso2.carbon.analytics.parent</artifactId>
-        <version>2.0.89</version>
+        <version>2.0.90-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.event.simulator.core.feature/pom.xml
+++ b/features/org.wso2.carbon.event.simulator.core.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.analytics</groupId>
         <artifactId>org.wso2.carbon.analytics.parent</artifactId>
-        <version>2.0.89</version>
+        <version>2.0.90-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.msf4j.interceptor.common.feature/pom.xml
+++ b/features/org.wso2.carbon.msf4j.interceptor.common.feature/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.analytics</groupId>
         <artifactId>org.wso2.carbon.analytics.parent</artifactId>
-        <version>2.0.89</version>
+        <version>2.0.90-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.siddhi.editor.core.feature/pom.xml
+++ b/features/org.wso2.carbon.siddhi.editor.core.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.analytics</groupId>
         <artifactId>org.wso2.carbon.analytics.parent</artifactId>
-        <version>2.0.89</version>
+        <version>2.0.90-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.stream.processor.common.feature/pom.xml
+++ b/features/org.wso2.carbon.stream.processor.common.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.analytics</groupId>
         <artifactId>org.wso2.carbon.analytics.parent</artifactId>
-        <version>2.0.89</version>
+        <version>2.0.90-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.stream.processor.core.feature/pom.xml
+++ b/features/org.wso2.carbon.stream.processor.core.feature/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.analytics</groupId>
         <artifactId>org.wso2.carbon.analytics.parent</artifactId>
-        <version>2.0.89</version>
+        <version>2.0.90-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.siddhi.feature/pom.xml
+++ b/features/org.wso2.siddhi.feature/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.analytics</groupId>
         <artifactId>org.wso2.carbon.analytics.parent</artifactId>
-        <version>2.0.89</version>
+        <version>2.0.90-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -469,6 +469,21 @@
                 <artifactId>org.wso2.carbon.datasource.core</artifactId>
                 <version>${carbon.datasources.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.coordination</groupId>
+                <artifactId>org.wso2.carbon.cluster.coordinator.service</artifactId>
+                <version>${carbon.coordination.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.coordination</groupId>
+                <artifactId>org.wso2.carbon.cluster.coordinator.commons</artifactId>
+                <version>${carbon.coordination.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.coordination</groupId>
+                <artifactId>org.wso2.carbon.cluster.coordinator.rdbms</artifactId>
+                <version>${carbon.coordination.version}</version>
+            </dependency>
 
             <!--###moved from carbon-analytics repo#### -->
             <dependency>
@@ -1112,6 +1127,7 @@
         <carbon.deployment.export.version>5.1.4</carbon.deployment.export.version>
 
         <carbon.datasources.version>1.1.3</carbon.datasources.version>
+        <carbon.coordination.version>2.0.1-SNAPSHOT</carbon.coordination.version>
         <carbon.metrics.version>2.3.2</carbon.metrics.version>
         <carbon.jndi.version>1.0.4</carbon.jndi.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <groupId>org.wso2.carbon.analytics</groupId>
     <artifactId>org.wso2.carbon.analytics.parent</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.89</version>
+    <version>2.0.90-SNAPSHOT</version>
     <name>WSO2 Carbon Analytics - Parent</name>
     <modules>
         <module>components/org.wso2.carbon.msf4j.interceptor.common</module>
@@ -261,7 +261,7 @@
         <url>https://github.com/wso2/carbon-analytics.git</url>
         <developerConnection>scm:git:https://github.com/wso2/carbon-analytics.git</developerConnection>
         <connection>scm:git:https://github.com/wso2/carbon-analytics.git</connection>
-        <tag>v2.0.89</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <dependencyManagement>
@@ -1023,7 +1023,7 @@
     </dependencyManagement>
 
     <properties>
-        <carbon.analytics.version>2.0.89</carbon.analytics.version>
+        <carbon.analytics.version>2.0.90-SNAPSHOT</carbon.analytics.version>
         <siddhi.version>4.0.0-M92</siddhi.version>
         <siddhi.bundle.version>4.0.0-M92</siddhi.bundle.version>
         <carbon.analytics-common.pkg.export.version>2.0.0</carbon.analytics-common.pkg.export.version>


### PR DESCRIPTION
## Purpose
> Requirement of a 2 Node Minimum HA deployment setup to run WSO2 SP

## Goals
> This feature enables a deployment setup to run WSO2 SP in 2 Node minimum HA

## Approach
> https://docs.google.com/a/wso2.com/document/d/1wH4gK-UZPK2TjS1GVucbEoeYqjfuE-PgkZFz8YSylRM/edit?usp=sharing

## User stories
> https://redmine.wso2.com/issues/6724

## Release note
> 2 Node Minimum HA Deployment

## Documentation
> WIP

## Test environment
> JDK 8
> Ubuntu 16.04