### PR TITLE
Changed periodic persistence testcases to use yaml datasource config

### DIFF
--- a/build-scripts/JenkinsFile
+++ b/build-scripts/JenkinsFile
@@ -45,31 +45,37 @@ node("${nodeLabel}") {
         stage('Running Test on File System') {
             withEnv(["PATH+MAVEN=${mvnHome}/bin:${env.JAVA_HOME}/bin",
                      "DOCKER_HOST=${dockerHost}"]) {
-                sh "mvn clean install -f carbon-analytics/components/osgi-tests/pom.xml -e"
+                sh "mvn clean install -f carbon-analytics/components/osgi-tests/pom.xml"
             }
         }
         stage('Running Test on H2 database') {
             withEnv(["PATH+MAVEN=${mvnHome}/bin:${env.JAVA_HOME}/bin",
                      "DOCKER_HOST=${dockerHost}"]) {
-                sh "mvn verify -P local-h2 -f carbon-analytics/components/osgi-tests/pom.xml -Dmaven.test.failure.ignore -Dskip.surefire.test=true -e"
+                sh "mvn verify -P local-h2 -f carbon-analytics/components/osgi-tests/pom.xml"
             }
         }
         stage('Running Test on MySQL database') {
             withEnv(["PATH+MAVEN=${mvnHome}/bin:${env.JAVA_HOME}/bin",
                      "DOCKER_HOST=${dockerHost}"]) {
-                sh "mvn verify -P local-mysql -f carbon-analytics/components/osgi-tests/pom.xml -Dmaven.test.failure.ignore -Dskip.surefire.test=true -Ddocker.removeVolumes=true -e"
+                sh "mvn verify -P local-mysql -f carbon-analytics/components/osgi-tests/pom.xml"
             }
         }
         stage('Running Test on PostgreSQL database') {
             withEnv(["PATH+MAVEN=${mvnHome}/bin:${env.JAVA_HOME}/bin",
                      "DOCKER_HOST=${dockerHost}"]) {
-                sh "mvn verify -P local-postgres -f carbon-analytics/components/osgi-tests/pom.xml -Dmaven.test.failure.ignore -Dskip.surefire.test=true -Ddocker.removeVolumes=true -e"
+                sh "mvn verify -P local-postgres -f carbon-analytics/components/osgi-tests/pom.xml"
             }
         }
         stage('Running Test on MicrosoftSQL database') {
             withEnv(["PATH+MAVEN=${mvnHome}/bin:${env.JAVA_HOME}/bin",
                      "DOCKER_HOST=${dockerHost}"]) {
-                sh "mvn verify -P local-mssql -f carbon-analytics/components/osgi-tests/pom.xml -Dmaven.test.failure.ignore -Dskip.surefire.test=true -e"
+                sh "mvn verify -P local-mssql -f carbon-analytics/components/osgi-tests/pom.xml"
+            }
+        }
+        stage('Running Test on Oracle database') {
+            withEnv(["PATH+MAVEN=${mvnHome}/bin:${env.JAVA_HOME}/bin",
+                     "DOCKER_HOST=${dockerHost}"]) {
+                sh "mvn verify -P local-oracle -f carbon-analytics/components/osgi-tests/pom.xml"
             }
         }
         currentBuild.result = 'SUCCESS'

--- a/components/distribution/carbon-home/conf/default/deployment.yaml
+++ b/components/distribution/carbon-home/conf/default/deployment.yaml
@@ -182,7 +182,7 @@ wso2.artifact.deployment:
     # Scheduler update interval
   updateInterval: 5
 
-  # HA Configuration
+  # Persistence Configuration
 state.persistence:
   enabled: true
   intervalInMin: 1

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/persistence/DBPersistenceStore.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/persistence/DBPersistenceStore.java
@@ -250,6 +250,7 @@ public class DBPersistenceStore implements PersistenceStore {
             try {
                 try {
                     con = datasource.getConnection();
+                    con.setAutoCommit(false);
                     stmt = con.createStatement();
                 } catch (SQLException e) {
                     log.error("Cannot establish connection to datasource " + datasourceName +
@@ -264,7 +265,10 @@ public class DBPersistenceStore implements PersistenceStore {
                     if (log.isDebugEnabled()) {
                         log.debug("Table " + tableName + " does not Exist. Table Will be created. ");
                     }
+                    cleanupConnections(stmt, con);
                     try {
+                        con = datasource.getConnection();
+                        stmt = con.createStatement();
                         con.setAutoCommit(false);
                         stmt.executeUpdate(executionInfo.getPreparedCreateTableStatement());
                         con.commit();

--- a/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/DBPersistenceStoreTestIT.java
+++ b/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/DBPersistenceStoreTestIT.java
@@ -71,7 +71,7 @@ public class DBPersistenceStoreTestIT {
     private final String selectLastQuery = "SELECT siddhiAppName FROM " + TABLE_NAME + " WHERE siddhiAppName = ?";
 
     /**
-     * Replace the existing deployment-structure.yaml file with populated deployment-structure.yaml file.
+     * Replace the existing deployment.yaml file with populated deployment.yaml file.
      */
     private Option copyCarbonYAMLOption() {
         Path carbonYmlFilePath;

--- a/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/FileSystemPersistenceStoreTestIT.java
+++ b/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/FileSystemPersistenceStoreTestIT.java
@@ -53,7 +53,7 @@ public class FileSystemPersistenceStoreTestIT {
     protected BundleContext bundleContext;
 
     /**
-     * Replace the existing deployment.yaml file with populated deployment.yaml file.
+     * Replace the existing deployment-structure.yaml file with populated deployment-structure.yaml file.
      */
     private Option copyCarbonYAMLOption() {
         Path carbonYmlFilePath;
@@ -87,6 +87,7 @@ public class FileSystemPersistenceStoreTestIT {
 
         File file = new File(PERSISTENCE_FOLDER + File.separator + SIDDHIAPP_NAME);
         Assert.assertEquals(file.exists() && file.isDirectory(), false, "No Folder Created");
+        log.info("Waiting for first time interval for state persistence");
         Thread.sleep(60000);
         Assert.assertEquals(file.exists() && file.isDirectory(), true);
         Assert.assertEquals(file.list().length, 1, "There should be one revision persisted");

--- a/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/FileSystemPersistenceStoreTestIT.java
+++ b/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/FileSystemPersistenceStoreTestIT.java
@@ -53,7 +53,7 @@ public class FileSystemPersistenceStoreTestIT {
     protected BundleContext bundleContext;
 
     /**
-     * Replace the existing deployment-structure.yaml file with populated deployment-structure.yaml file.
+     * Replace the existing deployment.yaml file with populated deployment.yaml file.
      */
     private Option copyCarbonYAMLOption() {
         Path carbonYmlFilePath;

--- a/components/osgi-tests/src/test/resources/conf/db/persistence/deployment-structure.yaml
+++ b/components/osgi-tests/src/test/resources/conf/db/persistence/deployment-structure.yaml
@@ -1,5 +1,5 @@
 ################################################################################
-#   Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved
+#   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved
 #
 #   Licensed under the Apache License, Version 2.0 (the \"License\");
 #   you may not use this file except in compliance with the License.
@@ -182,16 +182,6 @@ wso2.artifact.deployment:
     # Scheduler update interval
   updateInterval: 5
 
-  # HA Configuration
-state.persistence:
-  enabled: true
-  intervalInMin: 1
-  revisionsToKeep: 2
-  class: org.wso2.carbon.stream.processor.core.persistence.DBPersistenceStore
-  config:
-    datasource: WSO2_ANALYTICS_DB
-    table: PERSISTENCE_TABLE
-
   # Secure Vault Configuration
 wso2.securevault:
   secretRepository:
@@ -205,6 +195,16 @@ wso2.securevault:
     parameters:
       masterKeyReaderFile: ${sys:carbon.home}/conf/${sys:wso2.runtime}/master-keys.yaml
 
+  # Persistence Configuration
+state.persistence:
+  enabled: true
+  intervalInMin: 1
+  revisionsToKeep: 2
+  class: org.wso2.carbon.stream.processor.core.persistence.DBPersistenceStore
+  config:
+    datasource: WSO2_ANALYTICS_DB
+    table: PERSISTENCE_TABLE
+
 # Data Sources Configuration
 wso2.datasources:
   dataSources:
@@ -214,11 +214,11 @@ wso2.datasources:
         name: jdbc/WSO2_ANALYTICS_DB
       definition:
         type: RDBMS
-        configuration:
-          jdbcUrl: 'jdbc:h2:./target/database/WSO2_ANALYTICS_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000'
-          username: wso2carbon
-          password: wso2carbon
-          driverClassName: org.h2.Driver
+        configuration: # Empty parameters will be populated at runtime
+          jdbcUrl:
+          username:
+          password:
+          driverClassName:
           maxPoolSize: 50
           idleTimeout: 60000
           connectionTestQuery: SELECT 1


### PR DESCRIPTION
## Purpose
> Periodic persistence testcases should run by using datasources configured in deployment.yaml

## Approach
> Update test cases to use deployment.yaml instead of master-datasources.xml

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes