### PR TITLE
RecordTableHandler return table ID instead of definition

### DIFF
--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/ha/HACoordinationRecordTableHandler.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/ha/HACoordinationRecordTableHandler.java
@@ -219,7 +219,7 @@ public class HACoordinationRecordTableHandler extends RecordTableHandler {
         return this.lastEventChunkTimestamp;
     }
 
-    public TableDefinition getTableDefinition() { // TODO: 10/25/17 Change to only return ID
-        return tableDefinition;
+    public String getTableId() {
+        return tableDefinition.getId();
     }
 }

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/ha/HAEventListener.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/ha/HAEventListener.java
@@ -82,7 +82,7 @@ public class HAEventListener extends MemberEventListener {
                 } catch (ConnectionUnavailableException e) {
                     backoffRetryCounter.reset();
                     log.error("HA Deployment: Error in connecting to table " + ((HACoordinationRecordTableHandler)
-                            recordTableHandler).getTableDefinition().getId() + " while changing from passive" +
+                            recordTableHandler).getTableId() + " while changing from passive" +
                             " state to active, will retry in " + backoffRetryCounter.getTimeInterval(), e);
                     ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
                     backoffRetryCounter.increment();

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/ha/RetryRecordTableConnection.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/ha/RetryRecordTableConnection.java
@@ -50,7 +50,7 @@ public class RetryRecordTableConnection implements Runnable {
                 ((HACoordinationRecordTableHandler) recordTableHandler).setAsActive();
             } catch (ConnectionUnavailableException e) {
                 log.error("HA Deployment: Error in connecting to table " + ((HACoordinationRecordTableHandler)
-                        recordTableHandler).getTableDefinition().getId() + " while changing from passive" +
+                        recordTableHandler).getTableId() + " while changing from passive" +
                         " state to active, will retry in " + backoffRetryCounter.getTimeInterval(), e);
                 backoffRetryCounter.increment();
                 scheduledExecutorService.schedule(new RetryRecordTableConnection(backoffRetryCounter,
@@ -59,7 +59,7 @@ public class RetryRecordTableConnection implements Runnable {
             }
         } else {
             log.error("Error reconnecting to " + ((HACoordinationRecordTableHandler) recordTableHandler).
-                    getTableDefinition().getId() + ". Passive node may not be in sync with active node");
+                    getTableId() + ". Passive node may not be in sync with active node");
         }
     }
 }

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/StreamProcessorService.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/StreamProcessorService.java
@@ -131,9 +131,9 @@ public class StreamProcessorService {
                             recordTableHandler.setAsActive();
                         } catch (ConnectionUnavailableException e) {
                             backoffRetryCounter.reset();
-                            log.error("HA Deployment: Error in connecting to table " + recordTableHandler.
-                                    getTableDefinition().getId() + " while changing from passive" +
-                                    " state to active, will retry in " + backoffRetryCounter.getTimeInterval(), e);
+                            log.error("HA Deployment: Error in connecting to table " + recordTableHandler.getTableId()
+                                    + " while changing from passive state to active, will retry in "
+                                    + backoffRetryCounter.getTimeInterval(), e);
                             ScheduledExecutorService scheduledExecutorService = Executors.
                                     newSingleThreadScheduledExecutor();
                             backoffRetryCounter.increment();


### PR DESCRIPTION
## Purpose
> Not give access to table definition but only the required table ID

## Approach
> Replace getter method of table definition with a method to return only table ID
