### PR TITLE
Migrate to kernel 5.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1146,9 +1146,9 @@
         <osgi.service.tracker.import.version.range>[1.5.1, 2.0.0)</osgi.service.tracker.import.version.range>
 
         <!-- Dependencies -->
-        <carbon.kernel.version>5.2.0-alpha</carbon.kernel.version>
-        <carbon.kernel.package.import.version.range>[5.0.0, 6.0.0)</carbon.kernel.package.import.version.range>
-        <carbon.kernel.pax.version>5.2.0-alpha</carbon.kernel.pax.version>
+        <carbon.kernel.version>5.2.0</carbon.kernel.version>
+        <carbon.kernel.package.import.version.range>[5.2.0, 6.0.0)</carbon.kernel.package.import.version.range>
+        <carbon.kernel.pax.version>5.2.0</carbon.kernel.pax.version>
 
         <org.wso2.carbon.transport.http.netty.version>5.0.1</org.wso2.carbon.transport.http.netty.version>
         <carbon.transport.package.import.version.range>[4.0.0, 6.0.0)</carbon.transport.package.import.version.range>
@@ -1160,16 +1160,16 @@
         <carbon.deployment.version>5.1.5</carbon.deployment.version>
         <carbon.deployment.export.version>5.1.4</carbon.deployment.export.version>
 
-        <carbon.datasources.version>1.1.3</carbon.datasources.version>
-        <carbon.metrics.version>2.3.2</carbon.metrics.version>
-        <carbon.jndi.version>1.0.4</carbon.jndi.version>
+        <carbon.datasources.version>1.1.4</carbon.datasources.version>
+        <carbon.metrics.version>2.3.3</carbon.metrics.version>
+        <carbon.jndi.version>1.0.5</carbon.jndi.version>
 
         <carbon.cache.version>1.1.3</carbon.cache.version>
-        <carbon.touchpoint.version>1.1.0</carbon.touchpoint.version>
-        <carbon.utils.version>2.0.2</carbon.utils.version>
-        <carbon.config.version>2.0.5</carbon.config.version>
-        <carbon.config.version.range>[2.0.0, 3.0.0)</carbon.config.version.range>
-        <carbon.securevault.version>5.0.8</carbon.securevault.version>
+        <carbon.touchpoint.version>1.1.1</carbon.touchpoint.version>
+        <carbon.utils.version>2.0.4</carbon.utils.version>
+        <carbon.config.version>2.1.4</carbon.config.version>
+        <carbon.config.version.range>[2.1.0, 3.0.0)</carbon.config.version.range>
+        <carbon.securevault.version>5.0.10</carbon.securevault.version>
  
 	    <!-- Clustering Dependencies -->
         <carbon.coordination.version>2.0.5</carbon.coordination.version>


### PR DESCRIPTION
## Purpose
> Update the kernel dependencies to the version 5.2.0

## Goals
> Having the latest kernel dependencies.

## Related PRs
> https://github.com/wso2/carbon-metrics/pull/65