### PR TITLE
Removing interceptor module from coverage-report dependency

### DIFF
--- a/coverage-reports/pom.xml
+++ b/coverage-reports/pom.xml
@@ -47,10 +47,6 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.analytics</groupId>
-            <artifactId>org.wso2.carbon.msf4j.interceptor.common</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.analytics</groupId>
             <artifactId>org.wso2.carbon.siddhi.editor.core</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Purpose
Removing interceptor module from coverage-report dependency

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes