### PR TITLE
added support for showing stack trace in the console

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/css/console.css
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/css/console.css
@@ -130,3 +130,10 @@
     display: block;
 }
 
+.output-console-content pre {
+    border: 0;
+    background-color: #131313;
+    color: #f44336;
+    white-space: pre-wrap;
+}
+

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/output-console/service-console-list-manager.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/output-console/service-console-list-manager.js
@@ -167,8 +167,12 @@ define(['log', 'jquery', 'lodash', 'output_console_list', 'workspace', 'service_
                             type = "ERROR";
                             colorDIffType = "ERROR";
                         }
+                        var stacktrace = "";
+                        if(loggerObj.stacktrace != null){
+                            stacktrace = "<pre>" + loggerObj.stacktrace + "</pre>";
+                        }
                         var logMessage = "[" + loggerObj.timeStamp + "] " + type + " " + "{" + loggerObj.fqcn + "} - " +
-                            loggerObj.message
+                            loggerObj.message + " " + stacktrace ;
                         var message = {
                             "type" : colorDIffType,
                             "message": logMessage


### PR DESCRIPTION
## Purpose
added support for showing stack trace in the console

## Goals
Provide better debugging experience

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

