### PR TITLE
Added front end validation for adding random simulation source

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/event-simulator/feed_simulator.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/event-simulator/feed_simulator.js
@@ -254,7 +254,7 @@ Simulator, _, OpenSiddhiApps) {
                     source.simulationType = "RANDOM_DATA_SIMULATION";
                     source.timestampInterval = $sourceConfigForm.find('input[name="timestamp-interval"]').val();
                     source.attributeConfiguration = [];
-                    var $attributesDivs = $sourceConfigForm.find('div.attributes-section label[for^="attributes_"]').closest('div');
+                    var $attributesDivs = $sourceConfigForm.find('div.attributes-section label[for^="attributes_"]').closest('div.form-group');
                     $attributesDivs.each(function () {
                         var attributeConfig = {};
                         var $attributesDiv = $(this);
@@ -924,6 +924,9 @@ Simulator, _, OpenSiddhiApps) {
             $sourceConfigForm.find('[class^="feed-attribute-random-' + dynamicId + '-property"]').each(function () {
                 $(this).prop('selectedIndex', -1);
             });
+            // Get all input elements of new attribute and add validation rule
+            var inputs = this.closest('div.form-group').getElementsByTagName('input');
+            self.addSourceValuesValidation(inputs);
             // addRandomConfigTypeValidation(id);
         });
     };
@@ -1407,6 +1410,7 @@ Simulator, _, OpenSiddhiApps) {
                                             i++;
                                         });
                                     }
+                                self.addAllSourceValuesValidation();
                                 },
                                 function (data) {
                                     log.info(data);
@@ -1601,6 +1605,28 @@ Simulator, _, OpenSiddhiApps) {
             }
         });
     };
+
+    self.addAllSourceValuesValidation = function() {
+        $("#source-accordion div.attributes-section input[type=text]").each(function () {
+            $(this).rules('add', {
+                required: true,
+                messages: {
+                    required: "This field can not be empty"
+                }
+            });
+        });
+    }
+
+    self.addSourceValuesValidation = function(inputs) {
+        $(inputs).each(function () {
+            $(this).rules('add', {
+                required: true,
+                messages: {
+                    required: "This field can not be empty"
+                }
+            });
+        });
+    }
 
     self.refreshAttributesList = function (uuid, streamAttributes) {
         var $attributesDiv = $('div.sourceConfigForm[data-uuid="' + uuid + '"] div.attributes-section');


### PR DESCRIPTION
## Purpose
> Add front end validation for random simulation form in editor for dynamically generated attributes

## Goals
> Ensure that values are entered when adding a new random feed simulation source

## Approach
> For each dynamic attribute being generated, a jquery validation rule is added
> When editing an existing simulation source all attributes are given the validation rule

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A