### PR TITLE
Fixing the table listing in data explorer in ascending order

### DIFF
--- a/components/analytics-views/org.wso2.carbon.analytics.messageconsole.ui/src/main/java/org/wso2/carbon/messageconsole/ui/MessageConsoleConnector.java
+++ b/components/analytics-views/org.wso2.carbon.analytics.messageconsole.ui/src/main/java/org/wso2/carbon/messageconsole/ui/MessageConsoleConnector.java
@@ -153,6 +153,8 @@ public class MessageConsoleConnector {
                 log.debug("Received an empty table name list!");
             }
             tableList = new String[0];
+        } else {
+            Arrays.sort(tableList);
         }
         return new Gson().toJson(tableList);
     }


### PR DESCRIPTION
## Purpose
> Display Table names in ascending order in data explorer page.