### PR TITLE
Print a log the symbolic link defined in spark-defaults.conf file.

### DIFF
--- a/components/analytics-processors/org.wso2.carbon.analytics.spark.core/src/main/java/org/wso2/carbon/analytics/spark/core/internal/SparkAnalyticsExecutor.java
+++ b/components/analytics-processors/org.wso2.carbon.analytics.spark.core/src/main/java/org/wso2/carbon/analytics/spark/core/internal/SparkAnalyticsExecutor.java
@@ -75,6 +75,9 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -554,7 +557,12 @@ public class SparkAnalyticsExecutor implements GroupEventListener {
         String carbonHome = null, carbonConfDir, analyticsSparkConfDir;
         try {
             carbonHome = conf.get(AnalyticsConstants.CARBON_DAS_SYMBOLIC_LINK);
-            logDebug("CARBON HOME set with the symbolic link " + carbonHome);
+            log.info("CARBON HOME set with the symbolic link " + carbonHome);
+            Path CarbonHomePath = Paths.get(carbonHome);
+            if (!Files.exists(CarbonHomePath)) {
+                throw new AnalyticsExecutionException("Unable to create the extra spark classpath with CarbonHome "
+                        + "specified, does not exist : " + carbonHome);
+            }
         } catch (NoSuchElementException e) {
             try {
                 carbonHome = CarbonUtils.getCarbonHome();


### PR DESCRIPTION
- Print a log the symbolic link defined in spark-defaults.conf file.
- Verity whether specific path/symbolic link defined in the file exists. If not, print error logs.

## Purpose
> Fixing symbolic link not defined issue for Spark

## Approach
> Print a log the symbolic link defined in spark-defaults.conf file.
> Verity whether specific path/symbolic link defined in the file exists. If not, print error logs.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes