### PR TITLE
Fix_for_ANLYAPIM-165: Bug on Spark executor initialization__Forward_ported_fix

### DIFF
--- a/components/analytics-core/org.wso2.carbon.analytics.datasource.core/src/main/java/org/wso2/carbon/analytics/datasource/core/AnalyticsDataSourceConstants.java
+++ b/components/analytics-core/org.wso2.carbon.analytics.datasource.core/src/main/java/org/wso2/carbon/analytics/datasource/core/AnalyticsDataSourceConstants.java
@@ -27,4 +27,12 @@ public class AnalyticsDataSourceConstants {
     
     public static final String CARBON_HOME_VAR = "$CARBON_HOME";
 
+    public static final String SYS_PROPERTY_PROVIDERS = "ds.providers";
+    public static final String SYS_PROPERTY_BASE = "ds.definition.";
+    public static final String SYS_PROPERTY_IV = "ds.iv";
+    public static final String SYS_PROPERTY_KEY_ALIAS = "ds.key.alias";
+    public static final String SYS_PROPERTY_KEY_PASS = "ds.key.pass";
+    public static final String SYS_PROPERTY_KEY_STORE = "ds.key.store";
+    public static final String SYS_PROPERTY_KEY_STORE_PASSWORD = "ds.key.store.password";
+
 }

--- a/components/analytics-processors/org.wso2.carbon.analytics.spark.core/src/main/java/org/wso2/carbon/analytics/spark/core/internal/AnalyticsComponent.java
+++ b/components/analytics-processors/org.wso2.carbon.analytics.spark.core/src/main/java/org/wso2/carbon/analytics/spark/core/internal/AnalyticsComponent.java
@@ -35,6 +35,7 @@ import org.wso2.carbon.analytics.spark.core.udf.CarbonUDF;
 import org.wso2.carbon.analytics.spark.core.util.AnalyticsConstants;
 import org.wso2.carbon.analytics.spark.utils.ComputeClasspath;
 import org.wso2.carbon.application.deployer.handler.AppDeploymentHandler;
+import org.wso2.carbon.base.api.ServerConfigurationService;
 import org.wso2.carbon.ntask.common.TaskException;
 import org.wso2.carbon.ntask.core.service.TaskService;
 import org.wso2.carbon.registry.core.service.RegistryService;
@@ -55,6 +56,8 @@ import java.net.SocketException;
  * cardinality="1..1" policy="dynamic" bind="setTaskService" unbind="unsetTaskService"
  * @scr.reference name="analytics.dataservice" interface="AnalyticsDataService"
  * cardinality="1..1" policy="dynamic"  bind="setAnalyticsDataService" unbind="unsetAnalyticsDataService"
+ * @scr.reference name="server.config.service" interface="org.wso2.carbon.base.api.ServerConfigurationService"
+ * cardinality="1..1" policy="dynamic" bind="setServerConfigService" unbind="unsetServerConfigService"
  * @scr.reference name="registry.service" interface="org.wso2.carbon.registry.core.service.RegistryService"
  * cardinality="1..1" policy="dynamic" bind="setRegistryService" unbind="unsetRegistryService"
  * @scr.reference name="tenant.registryloader" interface="org.wso2.carbon.registry.core.service.TenantRegistryLoader"
@@ -162,6 +165,14 @@ public class AnalyticsComponent {
 
     protected void unsetRegistryService(RegistryService registryService) {
         ServiceHolder.setRegistryService(null);
+    }
+
+    protected void setServerConfigService(ServerConfigurationService serverConfigService) {
+        ServiceHolder.setServerConfigService(serverConfigService);
+    }
+
+    protected void unsetServerConfigService(ServerConfigurationService serverConfigService) {
+        ServiceHolder.setServerConfigService(null);
     }
 
     protected void setTenantRegistryLoader(TenantRegistryLoader tenantRegistryLoader) {

--- a/components/analytics-processors/org.wso2.carbon.analytics.spark.core/src/main/java/org/wso2/carbon/analytics/spark/core/internal/ServiceHolder.java
+++ b/components/analytics-processors/org.wso2.carbon.analytics.spark.core/src/main/java/org/wso2/carbon/analytics/spark/core/internal/ServiceHolder.java
@@ -35,6 +35,7 @@ import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.registry.core.service.TenantRegistryLoader;
 import org.wso2.carbon.registry.core.session.UserRegistry;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+import org.wso2.carbon.base.api.ServerConfigurationService;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -57,6 +58,8 @@ public class ServiceHolder {
     private static AnalyticsProcessorService analyticsProcessorService;
 
     private static RegistryService registryService;
+
+    private static ServerConfigurationService serverConfigService;
 
     private static TenantRegistryLoader tenantRegistryLoader;
 
@@ -112,6 +115,14 @@ public class ServiceHolder {
 
     public static void setRegistryService(RegistryService registryService) {
         ServiceHolder.registryService = registryService;
+    }
+
+    public static ServerConfigurationService getServerConfigService() {
+        return serverConfigService;
+    }
+
+    public static void setServerConfigService(ServerConfigurationService serverConfigService) {
+        ServiceHolder.serverConfigService = serverConfigService;
     }
 
     public static void setTenantRegistryLoader(TenantRegistryLoader tenantRegistryLoader) {


### PR DESCRIPTION
## Purpose
>   This fix enables capability of giving two different keystore in the data-bridg-config.xml and carbon.xml when the secure vault enabled and spark database encryption issue.