### PR TITLE
Normalize the final path constructed in editor CSV file simulator delete API call.

### DIFF
--- a/components/org.wso2.carbon.event.simulator.core/src/main/java/org/wso2/carbon/event/simulator/core/impl/FilesApiServiceImpl.java
+++ b/components/org.wso2.carbon.event.simulator.core/src/main/java/org/wso2/carbon/event/simulator/core/impl/FilesApiServiceImpl.java
@@ -1,45 +1,34 @@
 package org.wso2.carbon.event.simulator.core.impl;
 
 import org.apache.commons.io.FilenameUtils;
-import org.wso2.carbon.event.simulator.core.api.*;
+import org.wso2.carbon.event.simulator.core.api.FilesApiService;
+import org.wso2.carbon.event.simulator.core.api.NotFoundException;
 import org.wso2.carbon.event.simulator.core.exception.FileAlreadyExistsException;
 import org.wso2.carbon.event.simulator.core.exception.FileOperationsException;
 import org.wso2.carbon.event.simulator.core.exception.InvalidFileException;
 import org.wso2.carbon.event.simulator.core.internal.generator.csv.util.FileUploader;
 import org.wso2.carbon.event.simulator.core.internal.util.EventSimulatorConstants;
-import org.wso2.carbon.event.simulator.core.model.*;
-
-import java.io.File;
-
-import org.wso2.carbon.event.simulator.core.model.InlineResponse2001;
-
-import java.nio.file.Paths;
-import java.util.List;
-
-import org.wso2.carbon.event.simulator.core.api.NotFoundException;
-
-import java.io.InputStream;
-
 import org.wso2.carbon.stream.processor.common.exception.ResponseMapper;
 import org.wso2.carbon.utils.Utils;
-import org.wso2.msf4j.formparam.FormDataParam;
 import org.wso2.msf4j.formparam.FileInfo;
 
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.SecurityContext;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaMSF4JServerCodegen",
                             date = "2017-07-20T09:30:14.336Z")
 public class FilesApiServiceImpl extends FilesApiService {
+    private final Path CSV_BASE_PATH = Paths.get(Utils.getRuntimePath().toString(),
+            EventSimulatorConstants.DIRECTORY_DEPLOYMENT, EventSimulatorConstants.DIRECTORY_CSV_FILES);
     @Override
     public Response deleteFile(String fileName) throws NotFoundException {
         FileUploader fileUploader = FileUploader.getFileUploaderInstance();
         if (FilenameUtils.isExtension(fileName, EventSimulatorConstants.CSV_FILE_EXTENSION)) {
             boolean deleted = false;
             try {
-                deleted = fileUploader.deleteFile(fileName, (Paths.get(Utils.getRuntimePath().toString(),
-                                                                       EventSimulatorConstants.DIRECTORY_DEPLOYMENT,
-                                                                       EventSimulatorConstants.DIRECTORY_CSV_FILES)).toString());
+                deleted = fileUploader.deleteFile(fileName, CSV_BASE_PATH.toString());
             } catch (FileOperationsException e) {
                 return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
                         .header("Access-Control-Allow-Origin", "*")
@@ -75,10 +64,7 @@ public class FilesApiServiceImpl extends FilesApiService {
                     .header("Access-Control-Allow-Origin", "*")
                     .entity(
                             FileUploader.getFileUploaderInstance()
-                                    .retrieveFileNameList(EventSimulatorConstants.CSV_FILE_EXTENSION,
-                                                          (Paths.get(Utils.getRuntimePath().toString(),
-                                                                     EventSimulatorConstants.DIRECTORY_DEPLOYMENT,
-                                                                     EventSimulatorConstants.DIRECTORY_CSV_FILES)))
+                                    .retrieveFileNameList(EventSimulatorConstants.CSV_FILE_EXTENSION, CSV_BASE_PATH)
                            )
                     .build();
         } catch (FileOperationsException e) {
@@ -98,11 +84,7 @@ public class FilesApiServiceImpl extends FilesApiService {
                 if (fileUploader.validateFileExists(fileName)) {
                     boolean deleted = false;
                     try {
-                        deleted = fileUploader.deleteFile(fileName, (Paths.get(Utils.getRuntimePath().toString(),
-                                                                               EventSimulatorConstants.DIRECTORY_DEPLOYMENT,
-                                                                               EventSimulatorConstants
-                                                                                           .DIRECTORY_CSV_FILES))
-                                    .toString());
+                        deleted = fileUploader.deleteFile(fileName, CSV_BASE_PATH.toString());
                     } catch (FileOperationsException e) {
                         return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
                                 .header("Access-Control-Allow-Origin", "*")
@@ -111,10 +93,7 @@ public class FilesApiServiceImpl extends FilesApiService {
                     }
                     if (deleted) {
                         try {
-                            fileUploader.uploadFile(fileInfo, fileInputStream,
-                                                    (Paths.get(Utils.getRuntimePath().toString(),
-                                                               EventSimulatorConstants.DIRECTORY_DEPLOYMENT,
-                                                               EventSimulatorConstants.DIRECTORY_CSV_FILES)).toString());
+                            fileUploader.uploadFile(fileInfo, fileInputStream, CSV_BASE_PATH.toString());
                         } catch (FileAlreadyExistsException | FileOperationsException | InvalidFileException e) {
                             return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
                                     .header("Access-Control-Allow-Origin", "*")
@@ -159,9 +138,7 @@ public class FilesApiServiceImpl extends FilesApiService {
     @Override
     public Response uploadFile(InputStream fileInputStream, FileInfo fileInfo) throws NotFoundException {
         try {
-            FileUploader.getFileUploaderInstance().uploadFile(fileInfo, fileInputStream,
-                                                              (Paths.get(Utils.getRuntimePath().toString(), EventSimulatorConstants.DIRECTORY_DEPLOYMENT,
-                                                                         EventSimulatorConstants.DIRECTORY_CSV_FILES)).toString());
+            FileUploader.getFileUploaderInstance().uploadFile(fileInfo, fileInputStream, CSV_BASE_PATH.toString());
         } catch (FileAlreadyExistsException | FileOperationsException | InvalidFileException e) {
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
                     .header("Access-Control-Allow-Origin", "*")

--- a/components/org.wso2.carbon.event.simulator.core/src/main/java/org/wso2/carbon/event/simulator/core/internal/generator/csv/util/FileUploader.java
+++ b/components/org.wso2.carbon.event.simulator.core/src/main/java/org/wso2/carbon/event/simulator/core/internal/generator/csv/util/FileUploader.java
@@ -128,7 +128,15 @@ public class FileUploader {
      * @param fileName name of CSV file to be deleted
      * @throws FileOperationsException if an IOException occurs while deleting file
      */
-    public boolean deleteFile(String fileName, String destination) throws FileOperationsException {
+
+    /**
+     * Method to delete an uploaded file.
+     * @param fileName name of CSV file to be deleted
+     * @param baseDirPath base path directory
+     * @return
+     * @throws FileOperationsException if an IOException occurs while deleting file
+     */
+    public boolean deleteFile(String fileName, String baseDirPath) throws FileOperationsException {
         try {
             if (fileStore.checkExists(fileName)) {
                 /*
@@ -139,7 +147,8 @@ public class FileUploader {
                  * */
                 fileStore.deleteFile(fileName);
             }
-            return Files.deleteIfExists(Paths.get(destination, fileName));
+            return Files.deleteIfExists(SecurityUtil.resolvePath(Paths.get(baseDirPath).toAbsolutePath(),
+                    Paths.get(fileName)));
         } catch (IOException e) {
             log.error("Error occurred while deleting the file '" + LogEncoder.getEncodedString(fileName) + "'", e);
             throw new FileOperationsException("Error occurred while deleting the file '" + fileName + "'", e);

--- a/components/org.wso2.carbon.event.simulator.core/src/main/java/org/wso2/carbon/event/simulator/core/internal/generator/csv/util/SecurityUtil.java
+++ b/components/org.wso2.carbon.event.simulator.core/src/main/java/org/wso2/carbon/event/simulator/core/internal/generator/csv/util/SecurityUtil.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.event.simulator.core.internal.generator.csv.util;
+
+import java.nio.file.Path;
+
+/**
+ * Resolves an untrusted user-specified path against the API's base directory.
+ */
+public class SecurityUtil {
+    /**
+     * Resolves an untrusted user-specified path against the API's base directory.
+     * Paths that try to escape the base directory are rejected.
+     *
+     * @param baseDirPath the absolute path of the base directory that all user-specified paths should be within.
+     * @param userPath    the untrusted path provided by the API user, expected to be relative to {@code baseDirPath}
+     */
+    public static Path resolvePath(final Path baseDirPath, final Path userPath) {
+        final Path resolvedPath = baseDirPath.resolve(userPath).normalize();
+        if (!baseDirPath.isAbsolute()) {
+            throw new IllegalArgumentException("Base path must be absolute");
+        }
+        if (userPath.isAbsolute()) {
+            throw new IllegalArgumentException("User path must be relative");
+        }
+        if (!resolvedPath.startsWith(baseDirPath)) {
+            throw new IllegalArgumentException("User path escapes the base path");
+        }
+        return resolvedPath;
+    }
+}

--- a/components/org.wso2.carbon.event.simulator.core/src/test/java/org/wso2/carbon/event/simulator/core/internal/generator/csv/util/FileUploaderTest.java
+++ b/components/org.wso2.carbon.event.simulator.core/src/test/java/org/wso2/carbon/event/simulator/core/internal/generator/csv/util/FileUploaderTest.java
@@ -41,7 +41,7 @@ import java.nio.file.Paths;
 public class FileUploaderTest {
     private static File testDir = Paths.get("target", "FileUploaderTest").toFile();
     private static String sampleOrderedCSVFile = Paths.get("src", "test", "resources", "files",
-            "sample(ordered).csv").toString();
+            "sample(ordered).csv").toAbsolutePath().toString();
     private static String sampleORDEREDcsv = Paths.get("src", "test", "resources", "files",
             "SAMPLE(ORDERED).csv").toString();
     private static String sampleTextFile = Paths.get("src", "test", "resources", "files",


### PR DESCRIPTION
## Purpose
> The purpose of this validation is to check if any malicious user has used ".." or other traversal techniques to move out of the expected base directory the action should be performed on. 
