### PR TITLE
Disabling SiddhiMetricsAPITestCase and StatusDashboardWorkerTestCase

### DIFF
--- a/components/osgi-tests/src/test/resources/testng.xml
+++ b/components/osgi-tests/src/test/resources/testng.xml
@@ -17,8 +17,11 @@ limitations under the License.
 <suite name="Carbon-Analytics-Test-Suite">
     <test name="carbon-analytics-tests" preserve-order="true" parallel="false" thread-count="1">
         <classes>
+<!--
+            todo: To be enabled after OSGi test cases failing is resolved
             <class name="org.wso2.carbon.analytics.test.osgi.SiddhiMetricsAPITestcase"/>
             <class name="org.wso2.carbon.analytics.test.osgi.StatusDashboardWorkerTestCase"/>
+-->
             <class name="org.wso2.carbon.analytics.test.osgi.FileSystemPersistenceStoreTestcase"/>
             <class name="org.wso2.carbon.analytics.test.osgi.SiddhiAsAPITestcase"/>
             <class name="org.wso2.carbon.analytics.test.osgi.SiddhiMetricsTestcase"/>


### PR DESCRIPTION
## Purpose
Disabling SiddhiMetricsAPITestCase and StatusDashboardWorkerTestCase until test case failing due to timeout is resolved.