### PR TITLE
owasp encoding only used for html logging

### DIFF
--- a/components/distribution/carbon-home/conf/dashboard/deployment.yaml
+++ b/components/distribution/carbon-home/conf/dashboard/deployment.yaml
@@ -25,36 +25,6 @@ wso2.carbon:
       # port offset
     offset: 2
 
-wso2.transport.http:
-  transportProperties:
-    -
-      name: "server.bootstrap.socket.timeout"
-      value: 60
-    -
-      name: "client.bootstrap.socket.timeout"
-      value: 60
-    -
-      name: "latency.metrics.enabled"
-      value: true
-
-  listenerConfigurations:
-    -
-      id: "default"
-      host: "0.0.0.0"
-      port: 9090
-    -
-      id: "msf4j-https"
-      host: "0.0.0.0"
-      port: 9443
-      scheme: https
-      keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
-      keyStorePassword: wso2carbon
-      certPass: wso2carbon
-
-  senderConfigurations:
-    -
-      id: "http-sender"
-
   # Configuration used for the databridge communication
 databridge.config:
     # No of worker threads to consume events
@@ -345,3 +315,21 @@ wso2.business.rules.manager:
 
      type: default
      version: default
+
+wso2.transport.http:
+  transportProperties:
+    - name: "server.bootstrap.socket.timeout"
+      value: 60
+    - name: "client.bootstrap.socket.timeout"
+      value: 60
+    - name: "latency.metrics.enabled"
+      value: true
+
+  listenerConfigurations:
+    - id: "default-https"
+      host: "0.0.0.0"
+      port: 9643
+      scheme: https
+      keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
+      keyStorePassword: wso2carbon
+      certPass: wso2carbon

--- a/components/distribution/pom.xml
+++ b/components/distribution/pom.xml
@@ -297,12 +297,6 @@
             <artifactId>org.wso2.carbon.data.provider.feature</artifactId>
             <type>zip</type>
         </dependency>
-
-        <dependency>
-            <groupId>org.wso2.carbon.analytics-common</groupId>
-            <artifactId>org.wso2.orbit.org.owasp.encoder.feature</artifactId>
-            <type>zip</type>
-        </dependency>
     </dependencies>
 
     <build>
@@ -618,11 +612,6 @@
                                     <id>org.wso2.carbon.data.provider.feature</id>
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
-
-                                <feature>
-                                    <id>org.wso2.orbit.org.owasp.encoder.feature</id>
-                                    <version>${carbon.analytics-common.version}</version>
-                                </feature>
                             </features>
                         </configuration>
                     </execution>
@@ -863,11 +852,6 @@
                                     <id>org.wso2.carbon.sp.distributed.resource.core.feature.group</id>
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
-
-                                <feature>
-                                    <id>org.wso2.orbit.org.owasp.encoder.feature.group</id>
-                                    <version>${carbon.analytics-common.version}</version>
-                                </feature>
                             </features>
                         </configuration>
                     </execution>
@@ -1029,11 +1013,6 @@
                                 <feature>
                                     <id>org.wso2.carbon.cluster.coordinator.rdbms.feature.group</id>
                                     <version>${carbon.coordination.version}</version>
-                                </feature>
-
-                                <feature>
-                                    <id>org.wso2.orbit.org.owasp.encoder.feature.group</id>
-                                    <version>${carbon.analytics-common.version}</version>
                                 </feature>
                             </features>
                         </configuration>
@@ -1215,11 +1194,6 @@
                                     <id>org.wso2.carbon.sp.distributed.resource.core.feature.group</id>
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
-
-                                <feature>
-                                    <id>org.wso2.orbit.org.owasp.encoder.feature.group</id>
-                                    <version>${carbon.analytics-common.version}</version>
-                                </feature>
                             </features>
                         </configuration>
                     </execution>
@@ -1382,11 +1356,6 @@
                                 <feature>
                                     <id>org.wso2.carbon.data.provider.feature</id>
                                     <version>${carbon.analytics.version}</version>
-                                </feature>
-
-                                <feature>
-                                    <id>org.wso2.orbit.org.owasp.encoder.feature.group</id>
-                                    <version>${carbon.analytics-common.version}</version>
                                 </feature>
                             </features>
                         </configuration>

--- a/components/org.wso2.carbon.analytics.auth.rest.api/pom.xml
+++ b/components/org.wso2.carbon.analytics.auth.rest.api/pom.xml
@@ -71,10 +71,6 @@
             <groupId>org.wso2.carbon.analytics-common</groupId>
             <artifactId>org.wso2.carbon.analytics.idp.client</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.wso2.orbit.org.owasp.encoder</groupId>
-            <artifactId>encoder</artifactId>
-        </dependency>
     </dependencies>
 
     <build>
@@ -119,7 +115,6 @@
             org.wso2.msf4j.*;version="${msf4j.import.version.range}",
             javax.ws.rs.*,
             org.slf4j.*,
-            org.owasp.encoder.*;version="${owasp.encoder.version.range}",
             *;resolution:=optional
         </import.package>
         <private.package>

--- a/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/impl/LoginApiServiceImpl.java
+++ b/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/impl/LoginApiServiceImpl.java
@@ -17,7 +17,6 @@
  */
 package org.wso2.carbon.analytics.auth.rest.api.impl;
 
-import org.owasp.encoder.Encode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.analytics.auth.rest.api.LoginApiService;
@@ -80,7 +79,7 @@ public class LoginApiServiceImpl extends LoginApiService {
                         .extractTokenFromHeaders(request.getHeaders(), IdPClientConstants.WSO2_SP_REFRESH_TOKEN);
                 if (refToken == null) {
                     LOG.error("Unable to extract refresh token from the header for the request '"
-                            + getEncodedString(appName));
+                            + removeCRLFCharacters(appName));
                     ErrorDTO errorDTO = new ErrorDTO();
                     errorDTO.setError(IdPClientConstants.Error.INVALID_CREDENTIALS);
                     errorDTO.setDescription("Invalid Authorization header. Please provide the Authorization " +
@@ -93,7 +92,7 @@ public class LoginApiServiceImpl extends LoginApiService {
                 idPClientProperties.put(IdPClientConstants.USERNAME, username);
                 idPClientProperties.put(IdPClientConstants.PASSWORD, password);
             } else {
-                LOG.error("Grant type '" + getEncodedString(grantType) + "' is not supported.");
+                LOG.error("Grant type '" + removeCRLFCharacters(grantType) + "' is not supported.");
                 ErrorDTO errorDTO = new ErrorDTO();
                 errorDTO.setError(IdPClientConstants.Error.GRANT_TYPE_NOT_SUPPORTED);
                 errorDTO.setDescription("Grant type '" + grantType + "' is not supported.");
@@ -112,7 +111,7 @@ public class LoginApiServiceImpl extends LoginApiService {
                     try {
                         validityPeriod = Integer.parseInt(loginResponse.get(IdPClientConstants.VALIDITY_PERIOD));
                     } catch (NumberFormatException e) {
-                        LOG.error("Error in login to the uri '" + getEncodedString(appName) +
+                        LOG.error("Error in login to the uri '" + removeCRLFCharacters(appName) +
                                 "' in getting validity period of the session", e);
                         ErrorDTO errorDTO = new ErrorDTO();
                         errorDTO.setError(IdPClientConstants.Error.INTERNAL_SERVER_ERROR);
@@ -156,15 +155,15 @@ public class LoginApiServiceImpl extends LoginApiService {
                             .cookie(accessTokenhttpOnlyCookie, logoutContextAccessToken)
                             .build();
                 case IdPClientConstants.LoginStatus.LOGIN_FAILURE:
-                    LOG.error("Authentication failure for user '" + getEncodedString(username) +
-                            "' when accessing uri '" + getEncodedString(appName));
+                    LOG.error("Authentication failure for user '" + removeCRLFCharacters(username) +
+                            "' when accessing uri '" + removeCRLFCharacters(appName));
                     ErrorDTO errorDTO = new ErrorDTO();
                     errorDTO.setError(IdPClientConstants.Error.INVALID_CREDENTIALS);
                     errorDTO.setDescription("Username or Password is invalid. Please check again.");
                     return Response.status(Response.Status.UNAUTHORIZED).entity(errorDTO).build();
                 case IdPClientConstants.LoginStatus.LOGIN_REDIRECTION:
                     if (LOG.isDebugEnabled()) {
-                        LOG.debug("Authentication redirection for the uri '" + getEncodedString(appName));
+                        LOG.debug("Authentication redirection for the uri '" + removeCRLFCharacters(appName));
                     }
                     redirectionDTO = new RedirectionDTO();
                     redirectionDTO.setClientId(loginResponse.get(ExternalIdPClientConstants.CLIENT_ID));
@@ -172,7 +171,7 @@ public class LoginApiServiceImpl extends LoginApiService {
                     redirectionDTO.setRedirectUrl(loginResponse.get(ExternalIdPClientConstants.REDIRECT_URL));
                     return Response.status(Response.Status.FOUND).entity(redirectionDTO).build();
                 default:
-                    LOG.error("Error in login to the uri '" + getEncodedString(appName) + "'");
+                    LOG.error("Error in login to the uri '" + removeCRLFCharacters(appName) + "'");
                     ErrorDTO errorDTOServerError = new ErrorDTO();
                     errorDTOServerError.setError(IdPClientConstants.Error.INTERNAL_SERVER_ERROR);
                     errorDTOServerError.setDescription("Error in login to the uri '" + appName + "'. Error: " +
@@ -210,7 +209,7 @@ public class LoginApiServiceImpl extends LoginApiService {
                         validityPeriod = Integer.parseInt(
                                 authCodeloginResponse.get(IdPClientConstants.VALIDITY_PERIOD));
                     } catch (NumberFormatException e) {
-                        LOG.error("Error in login to the uri '" + getEncodedString(appName) +
+                        LOG.error("Error in login to the uri '" + removeCRLFCharacters(appName) +
                                 "' in getting validity period of the session from Identity Provider.", e);
                         ErrorDTO errorDTO = new ErrorDTO();
                         errorDTO.setError(IdPClientConstants.Error.INTERNAL_SERVER_ERROR);
@@ -221,8 +220,9 @@ public class LoginApiServiceImpl extends LoginApiService {
                     userDTO.validityPeriod(validityPeriod);
 
                     if (LOG.isDebugEnabled()) {
-                        LOG.debug("Login callback uri '" + getEncodedString(appName) + "' is redirected to '" +
-                                getEncodedString(authCodeloginResponse.get(ExternalIdPClientConstants.REDIRECT_URL)));
+                        LOG.debug("Login callback uri '" + removeCRLFCharacters(appName) + "' is redirected to '" +
+                                removeCRLFCharacters(authCodeloginResponse.get(
+                                        ExternalIdPClientConstants.REDIRECT_URL)));
                     }
 
                     URI targetURIForRedirection = new URI(authCodeloginResponse
@@ -267,8 +267,8 @@ public class LoginApiServiceImpl extends LoginApiService {
                             .cookie(accessTokenhttpOnlyCookie, logoutContextAccessToken)
                             .build();
                 } else {
-                    LOG.error("Unable to get the token from the returned code '" + getEncodedString(requestCode) +
-                            "', for callback uri '" + getEncodedString(appName) + "'");
+                    LOG.error("Unable to get the token from the returned code '" + removeCRLFCharacters(requestCode) +
+                            "', for callback uri '" + removeCRLFCharacters(appName) + "'");
                     ErrorDTO errorDTO = new ErrorDTO();
                     errorDTO.setError(IdPClientConstants.Error.INVALID_CREDENTIALS);
                     errorDTO.setDescription("Unable to get the token from the returned code '" + requestCode + "'");
@@ -276,7 +276,7 @@ public class LoginApiServiceImpl extends LoginApiService {
                 }
 
             } catch (URISyntaxException e) {
-                LOG.error("Error in redirecting uri '" + getEncodedString(appName) +
+                LOG.error("Error in redirecting uri '" + removeCRLFCharacters(appName) +
                         "' for auth code grant type login.", e);
                 ErrorDTO errorDTO = new ErrorDTO();
                 errorDTO.setError(IdPClientConstants.Error.INTERNAL_SERVER_ERROR);
@@ -284,8 +284,8 @@ public class LoginApiServiceImpl extends LoginApiService {
                         + e.getMessage() + "'.");
                 return Response.serverError().entity(errorDTO).build();
             } catch (IdPClientException e) {
-                LOG.error("Error in accessing token from the code '" + getEncodedString(requestCode) + "', for uri '" +
-                        getEncodedString(appName), e);
+                LOG.error("Error in accessing token from the code '" + removeCRLFCharacters(requestCode) +
+                        "', for uri '" + removeCRLFCharacters(appName), e);
                 ErrorDTO errorDTO = new ErrorDTO();
                 errorDTO.setError(IdPClientConstants.Error.INTERNAL_SERVER_ERROR);
                 errorDTO.setDescription("Error in accessing token from the code for uri '" + appName + "'. Error : '"
@@ -294,7 +294,7 @@ public class LoginApiServiceImpl extends LoginApiService {
             }
         } else {
             String errorMsg = "This API is only supported for External IS integration with OAuth2 support. " +
-                    "IdPClient found is '" + getEncodedString(idPClient.getClass().getName());
+                    "IdPClient found is '" + removeCRLFCharacters(idPClient.getClass().getName());
             LOG.error(errorMsg);
             ErrorDTO errorDTO = new ErrorDTO();
             errorDTO.setError(IdPClientConstants.Error.INTERNAL_SERVER_ERROR);
@@ -303,12 +303,7 @@ public class LoginApiServiceImpl extends LoginApiService {
         }
     }
 
-    private static String getEncodedString(String str) {
-        String cleanedString = str.replace('\n', '_').replace('\r', '_');
-        cleanedString = Encode.forHtml(cleanedString);
-        if (!cleanedString.equals(str)) {
-            cleanedString += " (Encoded)";
-        }
-        return cleanedString;
+    private static String removeCRLFCharacters(String str) {
+        return str.replace('\n', '_').replace('\r', '_');
     }
 }

--- a/components/org.wso2.carbon.business.rules.core/pom.xml
+++ b/components/org.wso2.carbon.business.rules.core/pom.xml
@@ -66,10 +66,6 @@
             <artifactId>json</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.orbit.org.owasp.encoder</groupId>
-            <artifactId>encoder</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.carbon.analytics-common</groupId>
             <artifactId>org.wso2.carbon.analytics.permissions</artifactId>
         </dependency>
@@ -161,7 +157,6 @@
             org.osgi.framework.*;version="${osgi.framework.import.version.range}",
             org.wso2.carbon.kernel;version="${carbon.kernel.package.import.version.range}",
             org.wso2.msf4j.*;version="${msf4j.import.version.range}",
-            org.owasp.encoder.*;version="${owasp.encoder.version.range}",
             *;resolution:=optional
         </import.package>
         <carbon.component>

--- a/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/api/impl/BusinessRulesApiServiceImpl.java
+++ b/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/api/impl/BusinessRulesApiServiceImpl.java
@@ -109,21 +109,21 @@ public class BusinessRulesApiServiceImpl extends BusinessRulesApiService {
             }
         } catch (TemplateManagerServiceException e) {
             log.error(String.format("Failed to create business rule %s ",
-                    LogEncoder.getEncodedString(businessRuleName)), e);
+                    LogEncoder.removeCRLFCharacters(businessRuleName)), e);
             responseData.add("Failure Occured");
             responseData.add("Failed to create business rule '" + businessRuleName + "'");
             responseData.add(TemplateManagerConstants.ERROR);
             return Response.serverError().entity(gson.toJson(responseData)).build();
         } catch (RuleTemplateScriptException e) {
             log.error(String.format("Failed to create business rule %s ",
-                    LogEncoder.getEncodedString(businessRuleName)), e);
+                    LogEncoder.removeCRLFCharacters(businessRuleName)), e);
             responseData.add("Error while processing the script");
             responseData.add("Please re-check the entered values, or the script provided by the administrator");
             responseData.add(TemplateManagerConstants.ERROR);
             return Response.serverError().entity(gson.toJson(responseData)).build();
         } catch (TemplateInstanceCountViolationException e) {
             log.error(String.format("Failed to create business rule %s ",
-                    LogEncoder.getEncodedString(businessRuleName)), e);
+                    LogEncoder.removeCRLFCharacters(businessRuleName)), e);
             responseData.add("Selected rule template can be instantiated only once.");
             responseData.add("Please delete the existing rule created from the selected rule template");
             responseData.add(TemplateManagerConstants.ERROR);
@@ -182,14 +182,14 @@ public class BusinessRulesApiServiceImpl extends BusinessRulesApiService {
             return Response.ok().entity(gson.toJson(responseData)).build();
         } catch (BusinessRuleNotFoundException e) {
             log.error(String.format("Failed to delete business rule %s ",
-                    LogEncoder.getEncodedString(businessRuleInstanceID)), e);
+                    LogEncoder.removeCRLFCharacters(businessRuleInstanceID)), e);
             responseData.add("Business Rule Not Found");
             responseData.add("Could not find business rule with uuid '" + businessRuleInstanceID + "'");
             responseData.add(TemplateManagerConstants.ERROR);
             return Response.status(Response.Status.NOT_FOUND).entity(gson.toJson(responseData)).build();
         } catch (TemplateManagerServiceException e) {
             log.error(String.format("Failed to create business rule %s ",
-                    LogEncoder.getEncodedString(businessRuleInstanceID)), e);
+                    LogEncoder.removeCRLFCharacters(businessRuleInstanceID)), e);
             responseData.add("Internal Server Error");
             responseData.add("There was an error connecting to the server");
             responseData.add(TemplateManagerConstants.ERROR);
@@ -247,8 +247,8 @@ public class BusinessRulesApiServiceImpl extends BusinessRulesApiService {
             return Response.ok().entity(gson.toJson(responseData)).build();
         } catch (TemplateManagerServiceException e) {
             log.error(String.format("Failed to load ruleTemplate with the uuid %s in " +
-                    "the templateGroup %s ", LogEncoder.getEncodedString(ruleTemplateID),
-                    LogEncoder.getEncodedString(templateGroupID)), e);
+                    "the templateGroup %s ", LogEncoder.removeCRLFCharacters(ruleTemplateID),
+                    LogEncoder.removeCRLFCharacters(templateGroupID)), e);
             responseData.add("Failed to load");
             responseData.add("Failed to load rule template with uuid '" + ruleTemplateID + "'");
             responseData.add(null);
@@ -276,7 +276,7 @@ public class BusinessRulesApiServiceImpl extends BusinessRulesApiService {
             return Response.ok().entity(gson.toJson(responseData)).build();
         } catch (TemplateManagerServiceException e) {
             log.error(String.format("Failed to load ruleTemplates of the templateGroup" +
-                    " %s ", LogEncoder.getEncodedString(templateGroupID)), e);
+                    " %s ", LogEncoder.removeCRLFCharacters(templateGroupID)), e);
             responseData.add("Failed to load");
             responseData.add("Failed to load rule templates of the template group with uuid '" + templateGroupID + "'");
             responseData.add(null);
@@ -300,7 +300,7 @@ public class BusinessRulesApiServiceImpl extends BusinessRulesApiService {
             return Response.ok().entity(gson.toJson(responseData)).build();
         } catch (TemplateManagerServiceException e) {
             log.error(String.format("Failed to load templateGroup with the uuid %s ",
-                    LogEncoder.getEncodedString(templateGroupID)), e);
+                    LogEncoder.removeCRLFCharacters(templateGroupID)), e);
             responseData.add("Failed to load");
             responseData.add("Failed to load template group with uuid '" + templateGroupID + "'");
             responseData.add(null);
@@ -353,7 +353,7 @@ public class BusinessRulesApiServiceImpl extends BusinessRulesApiService {
             return Response.ok().entity(gson.toJson(responseData)).build();
         } catch (TemplateManagerServiceException e) {
             log.error(String.format("Failed to load business rule with uuid %s ",
-                    LogEncoder.getEncodedString(businessRuleInstanceID)), e);
+                    LogEncoder.removeCRLFCharacters(businessRuleInstanceID)), e);
             responseData.add("Failed to load");
             responseData.add("Failed to load business rule with uuid '" + businessRuleInstanceID + "'");
             responseData.add(null);
@@ -393,7 +393,7 @@ public class BusinessRulesApiServiceImpl extends BusinessRulesApiService {
             return Response.ok().entity(gson.toJson(responseData)).build();
         } catch (TemplateManagerServiceException e) {
             log.error(String.format("Failed to re-deploy the business rule with uuid %s ",
-                    LogEncoder.getEncodedString(businessRuleInstanceID)), e);
+                    LogEncoder.removeCRLFCharacters(businessRuleInstanceID)), e);
             responseData.add("Re-deployment failure");
             responseData.add("Failed to re-deploy the business rule with uuid '" + businessRuleInstanceID + "'");
             responseData.add(null);
@@ -459,14 +459,14 @@ public class BusinessRulesApiServiceImpl extends BusinessRulesApiService {
             return Response.ok().entity(gson.toJson(responseData)).build();
         } catch (TemplateManagerServiceException e) {
             log.error(String.format("Failed to update the business rule with uuid %s ",
-                    LogEncoder.getEncodedString(businessRuleInstanceID)), e);
+                    LogEncoder.removeCRLFCharacters(businessRuleInstanceID)), e);
             responseData.add("Failed to update");
             responseData.add("Failed to update the business rule with uuid '" + businessRuleInstanceID + "'");
             responseData.add(null);
             return Response.serverError().entity(gson.toJson(responseData)).build();
         } catch (RuleTemplateScriptException e) {
             log.error(String.format("Failed to update the business rule with uuid %s ",
-                    LogEncoder.getEncodedString(businessRuleInstanceID)), e);
+                    LogEncoder.removeCRLFCharacters(businessRuleInstanceID)), e);
             responseData.add("Error while processing the script");
             responseData.add("Please re-check the entered values, or the script provided by the administrator");
             responseData.add(TemplateManagerConstants.ERROR);

--- a/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/services/TemplateManagerService.java
+++ b/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/services/TemplateManagerService.java
@@ -18,7 +18,6 @@
 
 package org.wso2.carbon.business.rules.core.services;
 
-import org.owasp.encoder.Encode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.business.rules.core.bean.Artifact;
@@ -110,8 +109,8 @@ public class TemplateManagerService implements BusinessRulesService {
         if (nodeList == null) {
             log.error(String.format("Failed to find configurations of nodes for " +
                     "ruleTemplate %s while deploying the business rule %s ",
-                    LogEncoder.getEncodedString(ruleTemplateUUID),
-                    LogEncoder.getEncodedString(businessRuleFromTemplate.getUuid())));
+                    LogEncoder.removeCRLFCharacters(ruleTemplateUUID),
+                    LogEncoder.removeCRLFCharacters(businessRuleFromTemplate.getUuid())));
             return TemplateManagerConstants.ERROR;
         }
 
@@ -190,8 +189,8 @@ public class TemplateManagerService implements BusinessRulesService {
                     deployedNodesCount += 1;
                 } catch (SiddhiAppsApiHelperException e) {
                     log.error(String.format("Deploying siddhi app %s for business rule" +
-                                    " %s is failed. ", LogEncoder.getEncodedString(deployableSiddhiApp.toString()),
-                            LogEncoder.getEncodedString(businessRuleFromScratch.getUuid())), e);
+                                    " %s is failed. ", LogEncoder.removeCRLFCharacters(deployableSiddhiApp.toString()),
+                            LogEncoder.removeCRLFCharacters(businessRuleFromScratch.getUuid())), e);
                 }
             }
 
@@ -246,7 +245,7 @@ public class TemplateManagerService implements BusinessRulesService {
                         deployedArtifactCount += 1;
                     } catch (SiddhiAppsApiHelperException e) {
                         log.error(String.format("Deploying artifact with uuid %s is" + " failed. ",
-                                LogEncoder.getEncodedString(artifact.getKey())), e);
+                                LogEncoder.removeCRLFCharacters(artifact.getKey())), e);
                     }
                 }
                 if (deployedArtifactCount == derivedArtifacts.keySet().size()) {
@@ -280,7 +279,7 @@ public class TemplateManagerService implements BusinessRulesService {
         try {
             overwriteBusinessRuleDefinition(uuid, businessRuleFromScratch, status);
             log.info(String.format("Business rule %s updated in the database.",
-                    getEncodedString(businessRuleFromScratch.getName())));
+                    removeCRLFCharacters(businessRuleFromScratch.getName())));
         } catch (UnsupportedEncodingException | BusinessRulesDatasourceException e) {
             throw new TemplateManagerServiceException("Saving business rule '" +
                     businessRuleFromScratch.getName() + "' to the database is failed. ", e);
@@ -291,13 +290,13 @@ public class TemplateManagerService implements BusinessRulesService {
             deployableSiddhiApp = buildSiddhiAppFromScratch(derivedArtifacts, businessRuleFromScratch);
         } catch (TemplateManagerHelperException e) {
             log.error(String.format("Deriving artifacts for business rule %s while editing, is failed. ",
-                    getEncodedString(businessRuleFromScratch.getUuid())), e);
+                    removeCRLFCharacters(businessRuleFromScratch.getUuid())), e);
             return TemplateManagerConstants.ERROR;
         }
 
         if (nodeList == null) {
             log.error(String.format("Failed to find configurations of nodes for deploying business rule %s .",
-                    getEncodedString(uuid)));
+                    removeCRLFCharacters(uuid)));
             return TemplateManagerConstants.ERROR;
         }
 
@@ -310,8 +309,8 @@ public class TemplateManagerService implements BusinessRulesService {
                 } catch (SiddhiAppsApiHelperException e) {
                     log.error(String.format("Deploying siddhi app for the business rule %s on node %s is failed." +
                             " Hence stopping deploying the business rule.",
-                            getEncodedString(businessRuleFromScratch.getUuid()),
-                            getEncodedString(nodeURL)), e);
+                            removeCRLFCharacters(businessRuleFromScratch.getUuid()),
+                            removeCRLFCharacters(nodeURL)), e);
                 }
             }
 
@@ -378,9 +377,9 @@ public class TemplateManagerService implements BusinessRulesService {
                             }
                         } catch (SiddhiAppsApiHelperException e) {
                             log.error(String.format("Failed to undeploy siddhi app of %s of the businessRule %s " +
-                                    "from node %s ", getEncodedString(siddhiAppName),
-                                                    getEncodedString(businessRule.getUuid()),
-                                                    getEncodedString(nodeURL)), e);
+                                    "from node %s ", removeCRLFCharacters(siddhiAppName),
+                                                    removeCRLFCharacters(businessRule.getUuid()),
+                                                    removeCRLFCharacters(nodeURL)), e);
                             status = TemplateManagerConstants.PARTIALLY_UNDEPLOYED;
                             break;
                         }
@@ -429,14 +428,14 @@ public class TemplateManagerService implements BusinessRulesService {
                 queryExecutor.executeUpdateDeploymentStatusQuery(uuid, status);
             } catch (BusinessRulesDatasourceException e) {
                 log.error(String.format("Failed to update the deployment status for the business rule with uuid %s " +
-                        "on the database after trying to undeploy.", getEncodedString(uuid)), e);
+                        "on the database after trying to undeploy.", removeCRLFCharacters(uuid)), e);
             }
         }
 
         try {
             removeBusinessRuleDefinition(uuid);
             log.info(String.format("Business rule %s deleted from the database.",
-                    getEncodedString(businessRule.getName())));
+                    removeCRLFCharacters(businessRule.getName())));
         } catch (BusinessRulesDatasourceException e) {
             throw new TemplateManagerServiceException("Failed to delete business rule with uuid '" +
                     uuid + "'. ", e);
@@ -460,7 +459,7 @@ public class TemplateManagerService implements BusinessRulesService {
             return nodeList;
         } else {
             log.error(String.format("Failed to find configurations of nodes for deploying business rule %s ",
-                    getEncodedString(businessRuleUUID)));
+                    removeCRLFCharacters(businessRuleUUID)));
             return null;
         }
     }
@@ -522,7 +521,7 @@ public class TemplateManagerService implements BusinessRulesService {
                     deployedNodesCount += 1;
                 } catch (SiddhiAppsApiHelperException e) {
                     log.error(String.format("Failed to update the deployed artifact for business rule %s ",
-                            getEncodedString(businessRuleUUID)), e);
+                            removeCRLFCharacters(businessRuleUUID)), e);
                 }
             }
 
@@ -558,7 +557,7 @@ public class TemplateManagerService implements BusinessRulesService {
                     deployedNodesCount += 1;
                 } catch (SiddhiAppsApiHelperException e) {
                     log.error(String.format("Failed to update the deployed artifact for business rule %s ",
-                            getEncodedString(businessRuleUUID)), e);
+                            removeCRLFCharacters(businessRuleUUID)), e);
                 }
             }
             // Set status with respect to deployed node count
@@ -754,7 +753,7 @@ public class TemplateManagerService implements BusinessRulesService {
                 } catch (SiddhiAppsApiHelperException e) {
                     if (log.isDebugEnabled()) {
                         log.error(String.format("Get status of the siddhi app %s failed.",
-                                getEncodedString(siddhiAppName)), e);
+                                removeCRLFCharacters(siddhiAppName)), e);
                     }
                     if (TemplateManagerConstants.SAVED == queryExecutor.executeRetrieveDeploymentStatus(
                             (businessRule.getUuid()))) {
@@ -1133,7 +1132,7 @@ public class TemplateManagerService implements BusinessRulesService {
             queryExecutor.executeUpdateDeploymentStatusQuery(businessRuleUUID, deploymentStatus);
         } catch (BusinessRulesDatasourceException e) {
             log.error(String.format("Failed to update the state of business rule %s ",
-                    getEncodedString(businessRuleUUID)), e);
+                    removeCRLFCharacters(businessRuleUUID)), e);
         }
     }
 
@@ -1336,13 +1335,8 @@ public class TemplateManagerService implements BusinessRulesService {
         return count;
     }
 
-    private String getEncodedString(String str) {
-        String cleanedString = str.replace('\n', '_').replace('\r', '_');
-        cleanedString = Encode.forHtml(cleanedString);
-        if (!cleanedString.equals(str)) {
-            cleanedString += " (Encoded)";
-        }
-        return cleanedString;
+    private String removeCRLFCharacters(String str) {
+        return str.replace('\n', '_').replace('\r', '_');
     }
 
 }

--- a/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/util/LogEncoder.java
+++ b/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/util/LogEncoder.java
@@ -16,21 +16,15 @@
 
 package org.wso2.carbon.business.rules.core.util;
 
-import org.owasp.encoder.Encode;
-
 /**
  * Class used to encode strings before logging.
  */
 public class LogEncoder {
 
-    private LogEncoder() {}
+    private LogEncoder() {
+    }
 
-    public static String getEncodedString(String str) {
-        String cleanedString = str.replace('\n', '_').replace('\r', '_');
-        cleanedString = Encode.forHtml(cleanedString);
-        if (!cleanedString.equals(str)) {
-            cleanedString += " (Encoded)";
-        }
-        return cleanedString;
+    public static String removeCRLFCharacters(String str) {
+        return str.replace('\n', '_').replace('\r', '_');
     }
 }

--- a/components/org.wso2.carbon.editor.log.appender/pom.xml
+++ b/components/org.wso2.carbon.editor.log.appender/pom.xml
@@ -65,9 +65,6 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Fragment-Host>org.ops4j.pax.logging.pax-logging-log4j2</Fragment-Host>
-                        <Private-Package>
-                            org.owasp.encoder.*;version="${owasp.encoder.version}"
-                        </Private-Package>
                         <Export-Package>
                             org.wso2.carbon.editor.log.appender.*
                         </Export-Package>

--- a/components/org.wso2.carbon.editor.log.appender/pom.xml
+++ b/components/org.wso2.carbon.editor.log.appender/pom.xml
@@ -43,6 +43,10 @@
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.org.owasp.encoder</groupId>
+            <artifactId>encoder</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -61,6 +65,9 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Fragment-Host>org.ops4j.pax.logging.pax-logging-log4j2</Fragment-Host>
+                        <Private-Package>
+                            org.owasp.encoder.*;version="${owasp.encoder.version}"
+                        </Private-Package>
                         <Export-Package>
                             org.wso2.carbon.editor.log.appender.*
                         </Export-Package>

--- a/components/org.wso2.carbon.editor.log.appender/src/main/java/org/wso2/carbon/editor/log/appender/DataHolder.java
+++ b/components/org.wso2.carbon.editor.log.appender/src/main/java/org/wso2/carbon/editor/log/appender/DataHolder.java
@@ -20,7 +20,7 @@ package org.wso2.carbon.editor.log.appender;
 import org.wso2.carbon.editor.log.appender.internal.CircularBuffer;
 import org.wso2.carbon.editor.log.appender.internal.ConsoleLogEvent;
 
-public class DataHodlder {
+public class DataHolder {
     private static CircularBuffer circularBuffer;
 
     public static CircularBuffer getBuffer(int bufferSize) {

--- a/components/org.wso2.carbon.editor.log.appender/src/main/java/org/wso2/carbon/editor/log/appender/EditorConsoleAppender.java
+++ b/components/org.wso2.carbon.editor.log.appender/src/main/java/org/wso2/carbon/editor/log/appender/EditorConsoleAppender.java
@@ -27,6 +27,7 @@ import org.apache.logging.log4j.core.config.plugins.PluginElement;
 import org.apache.logging.log4j.core.config.plugins.PluginFactory;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.apache.logging.log4j.core.util.Booleans;
+import org.owasp.encoder.Encode;
 import org.wso2.carbon.editor.log.appender.internal.CircularBuffer;
 import org.wso2.carbon.editor.log.appender.internal.ConsoleLogEvent;
 
@@ -67,7 +68,7 @@ public final class EditorConsoleAppender extends AbstractAppender {
      * Taken from the previous EditorConsoleAppender
      */
     public void activateOptions() {
-        this.circularBuffer = DataHodlder.getBuffer(BUFFER_SIZE);
+        this.circularBuffer = DataHolder.getBuffer(BUFFER_SIZE);
     }
 
     /**
@@ -117,7 +118,7 @@ public final class EditorConsoleAppender extends AbstractAppender {
         ConsoleLogEvent consoleLogEvent = new ConsoleLogEvent();
         consoleLogEvent.setFqcn(logEvent.getLoggerName());
         consoleLogEvent.setLevel(logEvent.getLevel().name());
-        consoleLogEvent.setMessage(logEvent.getMessage().getFormattedMessage());
+        consoleLogEvent.setMessage(getEncodedString(logEvent.getMessage().getFormattedMessage()));
         SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss_SSS");
         String dateString = formatter.format(logEvent.getTimeMillis());
         consoleLogEvent.setTimeStamp(dateString);
@@ -137,4 +138,13 @@ public final class EditorConsoleAppender extends AbstractAppender {
         e.printStackTrace(new PrintWriter(stringWriter));
         return stringWriter.toString().trim();
     }
+
+    private static String getEncodedString(String str) {
+        String cleanedString = Encode.forHtml(str);
+        if (!cleanedString.equals(str)) {
+            cleanedString += " (Encoded)";
+        }
+        return cleanedString;
+    }
+
 }

--- a/components/org.wso2.carbon.event.simulator.core/pom.xml
+++ b/components/org.wso2.carbon.event.simulator.core/pom.xml
@@ -139,10 +139,6 @@
             <groupId>org.wso2.carbon.analytics</groupId>
             <artifactId>org.wso2.carbon.analytics.msf4j.interceptor.common</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.wso2.orbit.org.owasp.encoder</groupId>
-            <artifactId>encoder</artifactId>
-        </dependency>
     </dependencies>
 
     <properties>
@@ -158,7 +154,6 @@
             javax.management.*,
             javax.ws.rs.*;version="0.0.0",
             org.wso2.siddhi.*;version="4.0.0",
-            org.owasp.encoder.*;version="${owasp.encoder.version.range}",
             *;resolution:=optional
         </import.package>
         <carbon.component>

--- a/components/org.wso2.carbon.event.simulator.core/src/main/java/org/wso2/carbon/event/simulator/core/internal/generator/csv/util/FileUploader.java
+++ b/components/org.wso2.carbon.event.simulator.core/src/main/java/org/wso2/carbon/event/simulator/core/internal/generator/csv/util/FileUploader.java
@@ -150,7 +150,7 @@ public class FileUploader {
             return Files.deleteIfExists(SecurityUtil.resolvePath(Paths.get(baseDirPath).toAbsolutePath(),
                     Paths.get(fileName)));
         } catch (IOException e) {
-            log.error("Error occurred while deleting the file '" + LogEncoder.getEncodedString(fileName) + "'", e);
+            log.error("Error occurred while deleting the file '" + LogEncoder.removeCRLFCharacters(fileName) + "'", e);
             throw new FileOperationsException("Error occurred while deleting the file '" + fileName + "'", e);
         }
     }

--- a/components/org.wso2.carbon.event.simulator.core/src/main/java/org/wso2/carbon/event/simulator/core/internal/generator/database/util/DatabaseConnector.java
+++ b/components/org.wso2.carbon.event.simulator.core/src/main/java/org/wso2/carbon/event/simulator/core/internal/generator/database/util/DatabaseConnector.java
@@ -294,7 +294,7 @@ public class DatabaseConnector {
             }
             if (log.isDebugEnabled()) {
                 log.debug("Successfully retrieved table names from datasource '" +
-                        LogEncoder.getEncodedString(connectionDetails.getDataSourceLocation()) + "'.");
+                        LogEncoder.removeCRLFCharacters(connectionDetails.getDataSourceLocation()) + "'.");
             }
             return tableNames;
         }
@@ -311,8 +311,8 @@ public class DatabaseConnector {
                 columnNames.add(rs.getString("COLUMN_NAME"));
             }
             if (log.isDebugEnabled()) {
-                log.debug("Successfully retrieved column names of table '" + LogEncoder.getEncodedString(tableName) +
-                        "' from datasource '" + LogEncoder.getEncodedString(connectionDetails.getDataSourceLocation())
+                log.debug("Successfully retrieved column names of table '" + LogEncoder.removeCRLFCharacters(tableName) +
+                        "' from datasource '" + LogEncoder.removeCRLFCharacters(connectionDetails.getDataSourceLocation())
                         + "'.");
             }
             return columnNames;

--- a/components/org.wso2.carbon.event.simulator.core/src/main/java/org/wso2/carbon/event/simulator/core/internal/generator/database/util/DatabaseConnector.java
+++ b/components/org.wso2.carbon.event.simulator.core/src/main/java/org/wso2/carbon/event/simulator/core/internal/generator/database/util/DatabaseConnector.java
@@ -312,8 +312,8 @@ public class DatabaseConnector {
             }
             if (log.isDebugEnabled()) {
                 log.debug("Successfully retrieved column names of table '" + LogEncoder.removeCRLFCharacters(tableName) +
-                        "' from datasource '" + LogEncoder.removeCRLFCharacters(connectionDetails.getDataSourceLocation())
-                        + "'.");
+                        "' from datasource '" + LogEncoder.removeCRLFCharacters(connectionDetails.
+                        getDataSourceLocation()) + "'.");
             }
             return columnNames;
         }

--- a/components/org.wso2.carbon.event.simulator.core/src/main/java/org/wso2/carbon/event/simulator/core/internal/util/SimulationConfigUploader.java
+++ b/components/org.wso2.carbon.event.simulator.core/src/main/java/org/wso2/carbon/event/simulator/core/internal/util/SimulationConfigUploader.java
@@ -100,13 +100,13 @@ public class SimulationConfigUploader {
     public boolean deleteSimulationConfig(String simulationName, String destination) throws FileOperationsException {
         try {
             if (log.isDebugEnabled()) {
-                log.debug("Delete simulation configuration '" + LogEncoder.getEncodedString(simulationName) + "'.");
+                log.debug("Delete simulation configuration '" + LogEncoder.removeCRLFCharacters(simulationName) + "'.");
             }
             return Files.deleteIfExists(Paths.get(destination, simulationName + "." +
                     EventSimulatorConstants.SIMULATION_FILE_EXTENSION));
         } catch (IOException e) {
             log.error("Error occurred while deleting the simulation configuration '" +
-                    LogEncoder.getEncodedString(simulationName) + "'.", e);
+                    LogEncoder.removeCRLFCharacters(simulationName) + "'.", e);
             throw new FileOperationsException("Error occurred while deleting the simulation configuration '" +
                     simulationName + "'.'", e);
         }
@@ -127,7 +127,7 @@ public class SimulationConfigUploader {
                     StandardCharsets.UTF_8);
         } catch (IOException e) {
             log.error("Error occurred while reading the simulation configuration '" +
-                    LogEncoder.getEncodedString(simulationName) + "'.", e);
+                    LogEncoder.removeCRLFCharacters(simulationName) + "'.", e);
             throw new FileOperationsException("Error occurred while reading the simulation configuration '" +
                     simulationName + "'.", e);
         }

--- a/components/org.wso2.carbon.event.simulator.core/src/main/java/org/wso2/carbon/event/simulator/core/service/EventSimulator.java
+++ b/components/org.wso2.carbon.event.simulator.core/src/main/java/org/wso2/carbon/event/simulator/core/service/EventSimulator.java
@@ -150,7 +150,7 @@ public class EventSimulator implements Runnable {
         } catch (JSONException e) {
             log.error("Error occurred when accessing simulation configuration of " +
                     "simulation. Invalid JSON simulation properties configuration provided : " +
-                    LogEncoder.getEncodedString(simulationConfiguration), e);
+                    LogEncoder.removeCRLFCharacters(simulationConfiguration), e);
             throw new InvalidConfigException("Error occurred when accessing simulation configuration. "
                                                      + "Invalid JSON simulation properties configuration provided : "
                                                      + simulationConfiguration, e);

--- a/components/org.wso2.carbon.event.simulator.core/src/main/java/org/wso2/carbon/event/simulator/core/util/LogEncoder.java
+++ b/components/org.wso2.carbon.event.simulator.core/src/main/java/org/wso2/carbon/event/simulator/core/util/LogEncoder.java
@@ -16,8 +16,6 @@
 
 package org.wso2.carbon.event.simulator.core.util;
 
-import org.owasp.encoder.Encode;
-
 /**
  * Class used to encode strings before logging.
  */
@@ -25,12 +23,7 @@ public class LogEncoder {
 
     private LogEncoder() {}
 
-    public static String getEncodedString(String str) {
-        String cleanedString = str.replace('\n', '_').replace('\r', '_');
-        cleanedString = Encode.forHtml(cleanedString);
-        if (!cleanedString.equals(str)) {
-            cleanedString += " (Encoded)";
-        }
-        return cleanedString;
+    public static String removeCRLFCharacters(String str) {
+        return str.replace('\n', '_').replace('\r', '_');
     }
 }

--- a/components/org.wso2.carbon.permissions.rest.api/pom.xml
+++ b/components/org.wso2.carbon.permissions.rest.api/pom.xml
@@ -97,10 +97,6 @@
             <artifactId>jackson-jaxrs-json-provider</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.orbit.org.owasp.encoder</groupId>
-            <artifactId>encoder</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.carbon.analytics-common</groupId>
             <artifactId>org.wso2.carbon.analytics.permissions</artifactId>
         </dependency>
@@ -167,7 +163,6 @@
             org.osgi.framework.*;version="[1.8.0, 2.0.0)",
             org.wso2.carbon.config.*;version="${carbon.config.version.range}",
             org.wso2.carbon.stream.processor.idp.*,
-            org.owasp.encoder.*;version="${owasp.encoder.version.range}",
             org.wso2.msf4j.*;version="${msf4j.import.version.range}",
             javax.management.*,
             javax.ws.rs.*;version="0.0.0",

--- a/components/org.wso2.carbon.permissions.rest.api/src/main/java/org/wso2/carbon/permissions/rest/api/impl/PermissionsApiServiceImpl.java
+++ b/components/org.wso2.carbon.permissions.rest.api/src/main/java/org/wso2/carbon/permissions/rest/api/impl/PermissionsApiServiceImpl.java
@@ -98,12 +98,12 @@ public class PermissionsApiServiceImpl extends PermissionsApiService {
             List<PermissionString> permissionStrings =
                     DataHolder.getInstance().getPermissionProvider().getPermissionStrings(appName);
             String successMsg = String.format("Getting permissions for app, %s successful",
-                    PermissionUtil.getEncodedString(appName));
+                    PermissionUtil.removeCRLFCharacters(appName));
             LOG.info(successMsg);
             return Response.ok().entity(gson.toJson(permissionStrings)).build();
         } catch (PermissionException e) {
             String errorMsg = String.format("Failed to retrieve permissions for app name: %s ",
-                    PermissionUtil.getEncodedString(appName));
+                    PermissionUtil.removeCRLFCharacters(appName));
             LOG.error(errorMsg, e);
             return Response.serverError().entity(new ApiResponseMessage(ApiResponseMessage.ERROR, errorMsg)).build();
         }
@@ -115,12 +115,12 @@ public class PermissionsApiServiceImpl extends PermissionsApiService {
             Boolean hasPermission =
                     DataHolder.getInstance().getPermissionProvider().hasPermission(roleName, permissionID);
             String successMsg = String.format("Checking permission for app:%s role: %s successful",
-                    permissionID, PermissionUtil.getEncodedString(roleName));
+                    permissionID, PermissionUtil.removeCRLFCharacters(roleName));
             LOG.info(successMsg);
             return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, successMsg)).build();
         } catch (PermissionException e) {
             String errorMsg = String.format("Checking permission for app:%s role: %s failed",
-                    permissionID, PermissionUtil.getEncodedString(roleName));
+                    permissionID, PermissionUtil.removeCRLFCharacters(roleName));
             LOG.error(errorMsg, e);
             return Response.serverError().entity(new ApiResponseMessage(ApiResponseMessage.ERROR, errorMsg)).build();
         }
@@ -143,20 +143,20 @@ public class PermissionsApiServiceImpl extends PermissionsApiService {
                     break;
                 default:
                     String errorMsg = String.format("Invalid input. Action should be "
-                            + "grant/revoke. But found %s", PermissionUtil.getEncodedString(action));
+                            + "grant/revoke. But found %s", PermissionUtil.removeCRLFCharacters(action));
                     LOG.error(errorMsg);
                     return Response.serverError().
                             entity(new ApiResponseMessage(ApiResponseMessage.ERROR, errorMsg)).build();
             }
             String successMsg = String.format("Action, %s for permission, %s successful.",
-                    PermissionUtil.getEncodedString(action),
-                    PermissionUtil.getEncodedString(permission.toString()));
+                    PermissionUtil.removeCRLFCharacters(action),
+                    PermissionUtil.removeCRLFCharacters(permission.toString()));
             LOG.info(successMsg);
             return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, successMsg)).build();
         } catch (PermissionException e) {
             String errorMsg = String.format("Failed to perform action, %s on permission %s",
-                    PermissionUtil.getEncodedString(action),
-                    PermissionUtil.getEncodedString(permission.toString()));
+                    PermissionUtil.removeCRLFCharacters(action),
+                    PermissionUtil.removeCRLFCharacters(permission.toString()));
             LOG.error(errorMsg, e);
             return Response.serverError().entity(new ApiResponseMessage(ApiResponseMessage.ERROR, errorMsg)).build();
         }

--- a/components/org.wso2.carbon.permissions.rest.api/src/main/java/org/wso2/carbon/permissions/rest/api/util/PermissionUtil.java
+++ b/components/org.wso2.carbon.permissions.rest.api/src/main/java/org/wso2/carbon/permissions/rest/api/util/PermissionUtil.java
@@ -18,7 +18,6 @@
  */
 package org.wso2.carbon.permissions.rest.api.util;
 
-import org.owasp.encoder.Encode;
 import org.wso2.carbon.analytics.permissions.bean.Permission;
 
 import java.nio.charset.Charset;
@@ -43,12 +42,7 @@ public class PermissionUtil {
         return new Permission(model.getAppName(), model.getPermissionString());
     }
 
-    public static String getEncodedString(String str) {
-        String cleanedString = str.replace('\n', '_').replace('\r', '_');
-        cleanedString = Encode.forHtml(cleanedString);
-        if (!cleanedString.equals(str)) {
-            cleanedString += " (Encoded)";
-        }
-        return cleanedString;
+    public static String removeCRLFCharacters(String str) {
+        return str.replace('\n', '_').replace('\r', '_');
     }
 }

--- a/components/org.wso2.carbon.siddhi.editor.core/pom.xml
+++ b/components/org.wso2.carbon.siddhi.editor.core/pom.xml
@@ -119,11 +119,6 @@
             <groupId>org.wso2.carbon.analytics</groupId>
             <artifactId>org.wso2.carbon.editor.log.appender</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.wso2.orbit.org.owasp.encoder</groupId>
-            <artifactId>encoder</artifactId>
-            <version>${owasp.encoder.version}</version>
-        </dependency>
     </dependencies>
 
     <properties>
@@ -144,7 +139,6 @@
             org.wso2.msf4j.*;version="${msf4j.import.version.range}",
             javax.management.*,
             javax.ws.rs.*;version="0.0.0",
-            org.owasp.encoder.*;version="${owasp.encoder.version.range}",
             *;resolution:=optional
         </import.package>
         <carbon.component>

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/EditorConsoleService.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/EditorConsoleService.java
@@ -23,7 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.editor.log.appender.internal.CircularBuffer;
 import org.wso2.carbon.editor.log.appender.internal.ConsoleLogEvent;
-import org.wso2.carbon.editor.log.appender.DataHodlder;
+import org.wso2.carbon.editor.log.appender.DataHolder;
 import org.wso2.msf4j.websocket.WebSocketEndpoint;
 
 import java.io.IOException;
@@ -51,7 +51,7 @@ public class EditorConsoleService implements WebSocketEndpoint {
     private static final int SCHEDULER_INITIAL_DELAY = 1000;
     private static final int SCHEDULER_TERMINATION_DELAY = 50;
     private Session session;
-    private CircularBuffer<ConsoleLogEvent> circularBuffer = DataHodlder.getBuffer();
+    private CircularBuffer<ConsoleLogEvent> circularBuffer = DataHolder.getBuffer();
     private ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
 
     @OnOpen

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/EditorMicroservice.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/EditorMicroservice.java
@@ -478,7 +478,7 @@ public class EditorMicroservice implements Microservice {
             String location = (Paths.get(workspaceLocationPath.toString(), siddhiAppName)).toString();
             File file = new File(location);
             if (file.delete()) {
-                log.info("Siddi App: " + LogEncoder.getEncodedString(siddhiAppName) + " is deleted");
+                log.info("Siddi App: " + LogEncoder.removeCRLFCharacters(siddhiAppName) + " is deleted");
                 JsonObject entity = new JsonObject();
                 entity.addProperty(STATUS, SUCCESS);
                 entity.addProperty("path", workspaceLocationPath.toString());
@@ -486,7 +486,7 @@ public class EditorMicroservice implements Microservice {
                 return Response.status(Response.Status.OK).entity(entity)
                         .type(MediaType.APPLICATION_JSON).build();
             } else {
-                log.error("Siddi App: " + LogEncoder.getEncodedString(siddhiAppName) + " could not deleted");
+                log.error("Siddi App: " + LogEncoder.removeCRLFCharacters(siddhiAppName) + " could not deleted");
                 return Response.serverError().entity("Siddi App: " + siddhiAppName + " could not deleted")
                         .build();
             }

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/local/LocalFSWorkspace.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/local/LocalFSWorkspace.java
@@ -193,7 +193,7 @@ public class LocalFSWorkspace implements Workspace {
                     rootObj.addProperty("children", Boolean.FALSE);
                 }
             } catch (IOException e) {
-                logger.debug("Error while fetching children of " + LogEncoder.getEncodedString(root.toString()), e);
+                logger.debug("Error while fetching children of " + LogEncoder.removeCRLFCharacters(root.toString()), e);
                 rootObj.addProperty("error", e.toString());
             }
         } else if (Files.isRegularFile(root) && checkChildren) {

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/LogEncoder.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/LogEncoder.java
@@ -16,8 +16,6 @@
 
 package org.wso2.carbon.siddhi.editor.core.util;
 
-import org.owasp.encoder.Encode;
-
 /**
  * Class used to encode strings before logging.
  */
@@ -25,12 +23,7 @@ public class LogEncoder {
 
     private LogEncoder() {}
 
-    public static String getEncodedString(String str) {
-        String cleanedString = str.replace('\n', '_').replace('\r', '_');
-        cleanedString = Encode.forHtml(cleanedString);
-        if (!cleanedString.equals(str)) {
-            cleanedString += " (Encoded)";
-        }
-        return cleanedString;
+    public static String removeCRLFCharacters(String str) {
+        return str.replace('\n', '_').replace('\r', '_');
     }
 }

--- a/components/org.wso2.carbon.siddhi.store.api.rest/pom.xml
+++ b/components/org.wso2.carbon.siddhi.store.api.rest/pom.xml
@@ -128,10 +128,6 @@
             <groupId>org.wso2.carbon.analytics</groupId>
             <artifactId>org.wso2.carbon.analytics.msf4j.interceptor.common</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.wso2.orbit.org.owasp.encoder</groupId>
-            <artifactId>encoder</artifactId>
-        </dependency>
     </dependencies>
 
     <build>
@@ -186,7 +182,6 @@
             org.wso2.carbon.kernel;version="${carbon.kernel.package.import.version.range}",
             org.wso2.msf4j.*;version="${msf4j.import.version.range}",
             org.wso2.siddhi.*;version="0.0.0",
-            org.owasp.encoder.*;version="${owasp.encoder.version.range}",
             *;resolution:=optional
         </import.package>
         <carbon.component>

--- a/components/org.wso2.carbon.siddhi.store.api.rest/src/main/java/org/wso2/carbon/siddhi/store/api/rest/impl/StoresApiServiceImpl.java
+++ b/components/org.wso2.carbon.siddhi.store.api.rest/src/main/java/org/wso2/carbon/siddhi/store/api/rest/impl/StoresApiServiceImpl.java
@@ -19,7 +19,6 @@
 
 package org.wso2.carbon.siddhi.store.api.rest.impl;
 
-import org.owasp.encoder.Encode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.siddhi.store.api.rest.NotFoundException;
@@ -70,9 +69,9 @@ public class StoresApiServiceImpl extends StoresApiService {
                 response.setRecords(records);
                 return Response.ok().entity(response).build();
             } catch (Exception e) {
-                log.error("Error while querying for siddhiApp: " + getEncodedString(body.getAppName()) +
-                        ", with query: " + getEncodedString(body.getQuery()) + " Error: " +
-                        getEncodedString(e.getMessage()), e);
+                log.error("Error while querying for siddhiApp: " + removeCRLFCharacters(body.getAppName()) +
+                        ", with query: " + removeCRLFCharacters(body.getQuery()) + " Error: " +
+                        removeCRLFCharacters(e.getMessage()), e);
                 return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
                         .entity(new ApiResponseMessage(ApiResponseMessage.ERROR,
                                                        "Cannot query: " + e.getMessage())).build();
@@ -92,12 +91,7 @@ public class StoresApiServiceImpl extends StoresApiService {
         return records;
     }
 
-    private static String getEncodedString(String str) {
-        String cleanedString = str.replace('\n', '_').replace('\r', '_');
-        cleanedString = Encode.forHtml(cleanedString);
-        if (!cleanedString.equals(str)) {
-            cleanedString += " (Encoded)";
-        }
-        return cleanedString;
+    private static String removeCRLFCharacters(String str) {
+        return str.replace('\n', '_').replace('\r', '_');
     }
 }

--- a/components/org.wso2.carbon.status.dashboard.core/pom.xml
+++ b/components/org.wso2.carbon.status.dashboard.core/pom.xml
@@ -125,10 +125,6 @@
             <artifactId>org.wso2.carbon.database.query.manager</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.orbit.org.owasp.encoder</groupId>
-            <artifactId>encoder</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito</artifactId>
             <scope>test</scope>
@@ -195,7 +191,6 @@
             javax.management.*,
             javax.ws.rs.*;version="0.0.0",org.wso2.carbon.analytics.permissions.*,
             org.wso2.carbon.analytics.idp.client.*,
-            org.owasp.encoder.*;version="${owasp.encoder.version.range}",
             *;resolution:=optional
         </import.package>
         <private.package>

--- a/components/org.wso2.carbon.status.dashboard.core/src/main/java/org/wso2/carbon/status/dashboard/core/dbhandler/StatusDashboardMetricsDBHandler.java
+++ b/components/org.wso2.carbon.status.dashboard.core/src/main/java/org/wso2/carbon/status/dashboard/core/dbhandler/StatusDashboardMetricsDBHandler.java
@@ -19,7 +19,6 @@
 package org.wso2.carbon.status.dashboard.core.dbhandler;
 
 import com.zaxxer.hikari.HikariDataSource;
-import org.owasp.encoder.Encode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.status.dashboard.core.bean.table.Attribute;
@@ -363,8 +362,8 @@ public class StatusDashboardMetricsDBHandler {
                 return select(resolvedQueryTable, columnsLabels, tableName);
             }
             default: {
-                logger.error("Invalid parameters type: " + getEncodedString(workerId) + ":"
-                        + getEncodedString(appName));
+                logger.error("Invalid parameters type: " + removeCRLFCharacters(workerId) + ":"
+                        + removeCRLFCharacters(appName));
                 return null;
             }
         }
@@ -619,12 +618,7 @@ public class StatusDashboardMetricsDBHandler {
         }
     }
 
-    private static String getEncodedString(String str) {
-        String cleanedString = str.replace('\n', '_').replace('\r', '_');
-        cleanedString = Encode.forHtml(cleanedString);
-        if (!cleanedString.equals(str)) {
-            cleanedString += " (Encoded)";
-        }
-        return cleanedString;
+    private static String removeCRLFCharacters(String str) {
+        return str.replace('\n', '_').replace('\r', '_');
     }
 }

--- a/components/org.wso2.carbon.status.dashboard.core/src/main/java/org/wso2/carbon/status/dashboard/core/impl/WorkersApiServiceImpl.java
+++ b/components/org.wso2.carbon.status.dashboard.core/src/main/java/org/wso2/carbon/status/dashboard/core/impl/WorkersApiServiceImpl.java
@@ -23,7 +23,6 @@ import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.owasp.encoder.Encode;
 import org.wso2.carbon.analytics.permissions.PermissionProvider;
 import org.wso2.carbon.analytics.permissions.bean.Permission;
 import org.wso2.carbon.status.dashboard.core.api.ApiResponseMessage;
@@ -123,7 +122,7 @@ public class WorkersApiServiceImpl extends WorkersApiService {
                     try {
                         workerDBHandler.insertWorkerGeneralDetails(workerGeneralDetails);
                     } catch (RDBMSTableException e) {
-                        logger.warn("Worker " + getEncodedString(workerID) +
+                        logger.warn("Worker " + removeCRLFCharacters(workerID) +
                                 " currently not active. Retry to reach " + "later");
                     }
                     workerIDCarbonIDMap.put(workerID, workerGeneralDetails.getCarbonId());
@@ -299,7 +298,7 @@ public class WorkersApiServiceImpl extends WorkersApiService {
                     }
 
                 } else {
-                    logger.error("Invalid format of worker id " + getEncodedString(id));
+                    logger.error("Invalid format of worker id " + removeCRLFCharacters(id));
                     return Response.status(Response.Status.BAD_REQUEST).build();
                 }
             } else {
@@ -863,9 +862,9 @@ public class WorkersApiServiceImpl extends WorkersApiService {
             return workerResponse.body().toString();
         } catch (feign.RetryableException e) {
             if (logger.isDebugEnabled()) {
-                logger.warn(getEncodedString(workerId) + " Unnable to reach worker.", e);
+                logger.warn(removeCRLFCharacters(workerId) + " Unnable to reach worker.", e);
             } else {
-                logger.warn(getEncodedString(workerId) + " Unnable to reach worker.");
+                logger.warn(removeCRLFCharacters(workerId) + " Unnable to reach worker.");
             }
             return workerId + " Unnable to reach worker. Caused by: " + e.getMessage();
         }
@@ -910,7 +909,7 @@ public class WorkersApiServiceImpl extends WorkersApiService {
                     workerInmemoryConfigs.put(workerId, new InmemoryAuthenticationConfig(hostPort[0], hostPort[1]));
                     return workerGeneralDetails.getCarbonId();
                 }
-                logger.warn("could not find carbon id hend use worker ID " + getEncodedString(workerId) +
+                logger.warn("could not find carbon id hend use worker ID " + removeCRLFCharacters(workerId) +
                         "as carbon id");
                 return workerId;
             }
@@ -1313,19 +1312,13 @@ public class WorkersApiServiceImpl extends WorkersApiService {
                 millisVal = Long.parseLong(interval);
             } catch (ClassCastException | NumberFormatException e) {
                 logger.error(String.format("Invalid parsing the value time period %s to milliseconds. Hence proceed " +
-                        "with default time", getEncodedString(interval)), e);
+                        "with default time", removeCRLFCharacters(interval)), e);
             }
         }
         return millisVal;
     }
 
-    private String getEncodedString(String str) {
-        String cleanedString = str.replace('\n', '_').replace('\r', '_');
-        cleanedString = Encode.forHtml(cleanedString);
-        if (!cleanedString.equals(str)) {
-            cleanedString += " (Encoded)";
-        }
-        return cleanedString;
+    private String removeCRLFCharacters(String str) {
+        return str.replace('\n', '_').replace('\r', '_');
     }
-
 }

--- a/features/org.wso2.carbon.siddhi.editor.core.feature/pom.xml
+++ b/features/org.wso2.carbon.siddhi.editor.core.feature/pom.xml
@@ -53,6 +53,10 @@
             <groupId>commons-io.wso2</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.org.owasp.encoder</groupId>
+            <artifactId>encoder</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -119,6 +123,10 @@
                                 <bundle>
                                     <symbolicName>org.wso2.carbon.editor.log.appender</symbolicName>
                                     <version>${project.version}</version>
+                                </bundle>
+                                <bundle>
+                                    <symbolicName>encoder</symbolicName>
+                                    <version>${owasp.encoder.version}</version>
                                 </bundle>
                             </bundles>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1649,7 +1649,7 @@
         <!--Event simulator-->
         <org.wso2.json.version>3.0.0.wso2v1</org.wso2.json.version>
         <orbit.axis2.client.version>1.6.1.wso2v5</orbit.axis2.client.version>
-        <owasp.encoder.version>1.2.0.wso2v1</owasp.encoder.version>
+        <owasp.encoder.version>1.2.0.wso2v2</owasp.encoder.version>
         <apache.httpcomponents.version>4.3.1.wso2v1</apache.httpcomponents.version>
         <apache.commons.csv.version>1.4</apache.commons.csv.version>
         <apache.commons.fileupload.version>1.3.2</apache.commons.fileupload.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1456,12 +1456,6 @@
                 <artifactId>encoder</artifactId>
                 <version>${owasp.encoder.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.wso2.carbon.analytics-common</groupId>
-                <artifactId>org.wso2.orbit.org.owasp.encoder.feature</artifactId>
-                <version>${carbon.analytics-common.version}</version>
-                <type>zip</type>
-            </dependency>
             <!--Permissions REST API related-->
             <dependency>
                 <groupId>org.wso2.carbon.analytics</groupId>
@@ -1485,9 +1479,9 @@
 
     <properties>
         <carbon.analytics.version>2.0.196-SNAPSHOT</carbon.analytics.version>
-        <siddhi.version>4.0.0-beta16</siddhi.version>
-        <siddhi.bundle.version>4.0.0-beta16</siddhi.bundle.version>
-        <carbon.analytics-common.version>6.0.36</carbon.analytics-common.version>
+        <siddhi.version>4.0.0-beta18</siddhi.version>
+        <siddhi.bundle.version>4.0.0-beta18</siddhi.bundle.version>
+        <carbon.analytics-common.version>6.0.38</carbon.analytics-common.version>
 
         <geronimo.jms.spec.version>1.1.1</geronimo.jms.spec.version>
         <apache.activemq.version>5.7.0</apache.activemq.version>
@@ -1594,7 +1588,7 @@
         <carbon.securevault.version>5.0.10</carbon.securevault.version>
 
         <!-- Clustering Dependencies -->
-        <carbon.coordination.version>2.0.9</carbon.coordination.version>
+        <carbon.coordination.version>2.0.11</carbon.coordination.version>
 
         <slf4j.version>1.7.12</slf4j.version>
         <slf4j.logging.package.import.version.range>[1.7.1, 2.0.0)
@@ -1657,7 +1651,6 @@
         <org.wso2.json.version>3.0.0.wso2v1</org.wso2.json.version>
         <orbit.axis2.client.version>1.6.1.wso2v5</orbit.axis2.client.version>
         <owasp.encoder.version>1.2.0.wso2v1</owasp.encoder.version>
-        <owasp.encoder.version.range>[1.2.0, 1.3.0)</owasp.encoder.version.range>
         <apache.httpcomponents.version>4.3.1.wso2v1</apache.httpcomponents.version>
         <apache.commons.csv.version>1.4</apache.commons.csv.version>
         <apache.commons.fileupload.version>1.3.2</apache.commons.fileupload.version>


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

## Approach
> owasp feature packing removed
> CRLF characters only removed when normal logging
> owasp packed as private package in editor.log.appender
> Bump carbon-analytics-common, Siddhi and carbon-coordination version