### PR TITLE
Reverting renaming of cookies until MSF4J issue is solved

### DIFF
--- a/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/util/AuthRESTAPIConstants.java
+++ b/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/util/AuthRESTAPIConstants.java
@@ -22,8 +22,8 @@ package org.wso2.carbon.analytics.auth.rest.api.util;
  */
 public class AuthRESTAPIConstants {
 
-    public static final String WSO2_SP_TOKEN = "JID";
-    public static final String WSO2_SP_REFRESH_TOKEN = "ASID";
+    public static final String WSO2_SP_TOKEN = "WSO2_SP_TOKEN";
+    public static final String WSO2_SP_REFRESH_TOKEN = "WSO2_SP_REFRESH_TOKEN";
 
     public static final String HTTP_ONLY_COOKIE = "HttpOnly";
     public static final String SECURE_COOKIE = "Secure";

--- a/components/org.wso2.carbon.stream.processor.common/src/main/java/org/wso2/carbon/stream/processor/common/utils/SPConstants.java
+++ b/components/org.wso2.carbon.stream.processor.common/src/main/java/org/wso2/carbon/stream/processor/common/utils/SPConstants.java
@@ -21,7 +21,7 @@ package org.wso2.carbon.stream.processor.common.utils;
  * Stream Processor Constants.
  */
 public class SPConstants {
-    public static final String WSO2_SP_TOKEN_2 = "HID";
+    public static final String WSO2_SP_TOKEN_2 = "WSO2_SP_TOKEN_2";
     public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final String COOKIE_HEADER = "Cookie";
 


### PR DESCRIPTION
## Purpose
A workaround until MSF4J multiple cookie not being set is resolved

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes