### PR TITLE
Remove msf4j-core bundle from org.wso2.carbon.status.dashboard.core.feature

### DIFF
--- a/features/org.wso2.carbon.status.dashboard.core.feature/pom.xml
+++ b/features/org.wso2.carbon.status.dashboard.core.feature/pom.xml
@@ -55,10 +55,6 @@
             <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.msf4j</groupId>
-            <artifactId>msf4j-core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.carbon.config</groupId>
             <artifactId>org.wso2.carbon.config</artifactId>
         </dependency>
@@ -128,10 +124,6 @@
                                 <bundle>
                                     <symbolicName>com.google.gson</symbolicName>
                                     <version>${gson.version}</version>
-                                </bundle>
-                                <bundle>
-                                    <symbolicName>msf4j-core</symbolicName>
-                                    <version>${msf4j.version}</version>
                                 </bundle>
                                 <bundle>
                                     <symbolicName>jaxen</symbolicName>


### PR DESCRIPTION
## Purpose
Remove `msf4j-core` bundle from being packed in `org.wso2.carbon.status.dashboard.core.feature` Carbon feature.
Fixes #926 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
