### PR TITLE
Fix permission issue in Status Dashboard

### DIFF
--- a/components/org.wso2.carbon.status.dashboard.web/src/utils/apis/StatusDashboardAPIs.jsx
+++ b/components/org.wso2.carbon.status.dashboard.web/src/utils/apis/StatusDashboardAPIs.jsx
@@ -32,10 +32,7 @@ export default class StatusDashboardAPIS {
         let httpClient = Axios.create({
             baseURL: window.location.origin + '/monitoring/apis/workers',
             timeout: 10000,
-            headers: {
-                'Content-Type': MediaType.APPLICATION_JSON,
-                Authorization: `Bearer ${AuthManager.getUser().token}`
-            }
+            headers: {"Authorization": "Bearer " + AuthManager.getUser().token}
         });
         httpClient.defaults.headers.post['Content-Type'] = MediaType.APPLICATION_JSON;
         return httpClient;


### PR DESCRIPTION
## Purpose
Status Dashboard gives a 401 unauthorized error for the admin login and this fix will solve that issue.

## Approach
Access token required for the api call was not sent properly and the fix solves that.
