### PR TITLE
Fixing a conflicting shortcut key, when saving a file two modal are open

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/menu-bar/file-menu.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/menu-bar/file-menu.js
@@ -64,12 +64,12 @@ define(([],function (){
                     id: "open-sample-file-open-dialog",
                     shortcuts: {
                         mac: {
-                            key: "command+o+s",
-                            label: "\u2318OS"
+                            key: "command+shift+o",
+                            label: "\u2318\u21E7O"
                         },
                         other: {
-                            key: "ctrl+o+s",
-                            label: "Ctrl+O+S"
+                            key: "ctrl+shift+o",
+                            label: "Ctrl+Shift+O"
                         }
                     }
                 },


### PR DESCRIPTION
## Purpose
Fixing a conflicting shortcut key, when saving a file two modal are open.
