### PR TITLE
Fix: Make clustering not mandatory for manager

### DIFF
--- a/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/CoordinatorChangeListener.java
+++ b/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/CoordinatorChangeListener.java
@@ -85,6 +85,8 @@ public class CoordinatorChangeListener extends MemberEventListener {
                     : new ResourcePool(groupId));
             ServiceDataHolder.getResourcePool().init();
             log.info(leader + " became the leader of the resource pool.");
+            // if clustering is disabled leader node and resource pool is set when worker heart beat is
+            // processed at updateHeartbeat in ResourceManagerApiServiceImpl
         } else {
             log.info(ServiceDataHolder.getLeaderNode() + " became the leader of the resource pool.");
         }

--- a/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/impl/ResourceManagerApiServiceImpl.java
+++ b/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/impl/ResourceManagerApiServiceImpl.java
@@ -53,7 +53,7 @@ public class ResourceManagerApiServiceImpl extends ResourceManagerApiService {
     @Override
     public Response updateHeartbeat(NodeConfig nodeConfig) throws NotFoundException {
         ManagerNode leaderNode = ServiceDataHolder.getLeaderNode();
-        if (leaderNode == null) {
+        if (leaderNode == null) { // this maybe null when clustering is disabled
             if (LOG.isDebugEnabled()) {
                 LOG.debug("No leader node is set because clustering is disabled. Setting current node as leader");
             }
@@ -65,6 +65,7 @@ public class ResourceManagerApiServiceImpl extends ResourceManagerApiService {
             ServiceDataHolder.setResourcePool((existingResourcePool != null) ? existingResourcePool
                     : new ResourcePool(groupId));
             ServiceDataHolder.getResourcePool().init();
+            LOG.info(ServiceDataHolder.getCurrentNode() + " is the leader of the resource pool.");
         }
         if (ServiceDataHolder.isLeader()) {
             ResourcePool resourcePool = ServiceDataHolder.getResourcePool();

--- a/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/internal/ServiceDataHolder.java
+++ b/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/internal/ServiceDataHolder.java
@@ -53,6 +53,10 @@ public class ServiceDataHolder {
         ServiceDataHolder.leader = leader;
     }
 
+    public static boolean isLeader() {
+        return leader;
+    }
+
     public static RDBMSServiceImpl getRdbmsService() {
         return rdbmsService;
     }
@@ -107,10 +111,6 @@ public class ServiceDataHolder {
 
     public static void setLeaderNode(ManagerNode leaderNode) {
         ServiceDataHolder.leaderNode = leaderNode;
-    }
-
-    public static boolean isLeader() {
-        return leader;
     }
 
     public static ClusterCoordinator getCoordinator() {


### PR DESCRIPTION
## Purpose
> Fixes #972 

## Goals
> When clustering is off and resource node sends heartbeat there will be no leader node. If so, current manager node is set as leader node and new resource pool created if not already present

## Approach
> If no leader node set current node as leader node and create new resource pool with default group Id

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes