### PR TITLE
Refactoring of cookie storage

### DIFF
--- a/components/org.wso2.carbon.analytics.auth.rest.api/src/gen/java/org/wso2/carbon/analytics/auth/rest/api/LoginApi.java
+++ b/components/org.wso2.carbon.analytics.auth.rest.api/src/gen/java/org/wso2/carbon/analytics/auth/rest/api/LoginApi.java
@@ -75,9 +75,10 @@ public class LoginApi implements Microservice {
             , @ApiParam(value = "") @FormDataParam("password") String password
             , @ApiParam(value = "") @FormDataParam("grantType") String grantType
             , @ApiParam(value = "", defaultValue = "false") @FormDataParam("rememberMe") Boolean rememberMe
+            , @ApiParam(value = "") @FormDataParam("appId") String appId
             , @Context Request request)
             throws NotFoundException {
-        return delegate.loginAppNamePost(appName, username, password, grantType, rememberMe, request);
+        return delegate.loginAppNamePost(appName, username, password, grantType, rememberMe, appId, request);
     }
 
     @GET

--- a/components/org.wso2.carbon.analytics.auth.rest.api/src/gen/java/org/wso2/carbon/analytics/auth/rest/api/LoginApiService.java
+++ b/components/org.wso2.carbon.analytics.auth.rest.api/src/gen/java/org/wso2/carbon/analytics/auth/rest/api/LoginApiService.java
@@ -30,6 +30,7 @@ public abstract class LoginApiService {
             , String password
             , String grantType
             , Boolean rememberMe
+            , String appId
             , Request request) throws NotFoundException;
 
     public abstract Response loginCallbackAppNameGet(String appName

--- a/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/impl/LoginApiServiceImpl.java
+++ b/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/impl/LoginApiServiceImpl.java
@@ -57,6 +57,7 @@ public class LoginApiServiceImpl extends LoginApiService {
             , String password
             , String grantType
             , Boolean rememberMe
+            , String appId
             , Request request) throws NotFoundException {
         try {
             if (rememberMe == null) {

--- a/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/impl/LoginApiServiceImpl.java
+++ b/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/impl/LoginApiServiceImpl.java
@@ -137,8 +137,11 @@ public class LoginApiServiceImpl extends LoginApiService {
                             .cookieBuilder(AuthRESTAPIConstants.WSO2_SP_TOKEN, part2,
                                     AuthRESTAPIConstants.LOGOUT_CONTEXT + appContext, true, true,
                                     -1);
-
-                    if (refreshToken != null && rememberMe) {
+                    if (refreshToken != null) {
+                        int refTokenValidityPeriod = -1;
+                        if (rememberMe) {
+                            refTokenValidityPeriod = AuthRESTAPIConstants.REFRESH_TOKEN_VALIDITY_PERIOD;
+                        }
                         NewCookie loginContextRefreshTokenCookie;
                         String refTokenPart1 = refreshToken.substring(0, refreshToken.length() / 2);
                         String refTokenPart2 = refreshToken.substring(refreshToken.length() / 2);
@@ -146,7 +149,7 @@ public class LoginApiServiceImpl extends LoginApiService {
                         loginContextRefreshTokenCookie = AuthUtil
                                 .cookieBuilder(AuthRESTAPIConstants.WSO2_SP_REFRESH_TOKEN, refTokenPart2,
                                         AuthRESTAPIConstants.LOGIN_CONTEXT + appContext, true, true,
-                                        AuthRESTAPIConstants.REFRESH_TOKEN_VALIDITY_PERIOD);
+                                        refTokenValidityPeriod);
                         return Response.ok(userDTO, MediaType.APPLICATION_JSON)
                                 .cookie(accessTokenhttpOnlyCookie, logoutContextAccessToken,
                                         loginContextRefreshTokenCookie)

--- a/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/impl/LoginApiServiceImpl.java
+++ b/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/impl/LoginApiServiceImpl.java
@@ -132,11 +132,11 @@ public class LoginApiServiceImpl extends LoginApiService {
                     userDTO.setpID(part1);
                     NewCookie accessTokenhttpOnlyCookie = AuthUtil
                             .cookieBuilder(SPConstants.WSO2_SP_TOKEN_2, part2, appContext, true, true,
-                                    validityPeriod);
+                                    -1);
                     NewCookie logoutContextAccessToken = AuthUtil
                             .cookieBuilder(AuthRESTAPIConstants.WSO2_SP_TOKEN, part2,
                                     AuthRESTAPIConstants.LOGOUT_CONTEXT + appContext, true, true,
-                                    validityPeriod);
+                                    -1);
 
                     if (refreshToken != null && rememberMe) {
                         NewCookie loginContextRefreshTokenCookie;
@@ -239,10 +239,10 @@ public class LoginApiServiceImpl extends LoginApiService {
                     userDTO.setpID(part1);
                     NewCookie accessTokenhttpOnlyCookie = AuthUtil
                             .cookieBuilder(SPConstants.WSO2_SP_TOKEN_2, part2, appContext, true, true,
-                                    validityPeriod);
+                                    -1);
                     NewCookie logoutContextAccessToken = AuthUtil
                             .cookieBuilder(AuthRESTAPIConstants.WSO2_SP_TOKEN, part2,
-                                    AuthRESTAPIConstants.LOGOUT_CONTEXT + appContext, true, true, validityPeriod);
+                                    AuthRESTAPIConstants.LOGOUT_CONTEXT + appContext, true, true, -1);
 
                     if (refreshToken != null) {
                         NewCookie loginContextRefreshTokenCookie;

--- a/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/util/AuthRESTAPIConstants.java
+++ b/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/util/AuthRESTAPIConstants.java
@@ -28,6 +28,7 @@ public class AuthRESTAPIConstants {
     public static final String HTTP_ONLY_COOKIE = "HttpOnly";
     public static final String SECURE_COOKIE = "Secure";
     public static final String EXPIRES_COOKIE = "Expires=";
+    public static final String DEFAULT_EXPIRES_COOKIE = "Thu, 01 Jan 1970 00:00:01 GMT";
 
     public static final String LOGIN_CONTEXT = "/login";
     public static final String LOGOUT_CONTEXT = "/logout";

--- a/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/util/AuthUtil.java
+++ b/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/util/AuthUtil.java
@@ -75,6 +75,9 @@ public class AuthUtil {
             stringBuilder.append(COOKIE_VALUE_SEPERATOR).append(AuthRESTAPIConstants.EXPIRES_COOKIE)
                     .append(ZonedDateTime.now().plusSeconds(expiresIn).format(DateTimeFormatter.RFC_1123_DATE_TIME))
                     .append(COOKIE_VALUE_SEPERATOR);
+        } else if (expiresIn == 0) {
+            stringBuilder.append(COOKIE_VALUE_SEPERATOR).append(AuthRESTAPIConstants.EXPIRES_COOKIE)
+                    .append(AuthRESTAPIConstants.DEFAULT_EXPIRES_COOKIE).append(COOKIE_VALUE_SEPERATOR);
         }
         return new NewCookie(name, stringBuilder.toString());
     }


### PR DESCRIPTION
## Purpose
1. Using default 1970 date for cookie invalidation
2. Always set refresh token cookie.
3. All cookies are set as session cookie
4. Add appId parameter to Auth API
 
## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes