### PR TITLE
Added error log when clustering is disabled for manager runtime

### DIFF
--- a/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/internal/ServiceComponent.java
+++ b/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/internal/ServiceComponent.java
@@ -124,6 +124,11 @@ public class ServiceComponent {
                 clusterConfig = configProvider.getConfigurationObject(ClusterConfig.class);
                 if (clusterConfig != null) {
                     ServiceDataHolder.setClusterConfig(clusterConfig);
+                    if (!clusterConfig.isEnabled()) {
+                        log.error("Clustering of manager node is disabled which is not recommended to be used " +
+                                "in production environment. Please configure clustering with a minimum of 2 manager " +
+                                "nodes before using distributed deployment in production environment.");
+                    }
                 } else {
                     log.error("Couldn't read " + ResourceManagerConstants.CLUSTER_CONFIG_NS +
                             " from deployment.yaml");


### PR DESCRIPTION
## Purpose
> Related to PR #973. Error log prints when using manager runtime with clustering disabled.