### PR TITLE
Passing appId to IdPClient and Bumping carbon-analytics-common to 6.0.45

### DIFF
--- a/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/impl/LoginApiServiceImpl.java
+++ b/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/impl/LoginApiServiceImpl.java
@@ -92,6 +92,7 @@ public class LoginApiServiceImpl extends LoginApiService {
                     idPClientProperties.put(IdPClientConstants.REFRESH_TOKEN, refToken);
                 }
             } else if (IdPClientConstants.PASSWORD_GRANT_TYPE.equals(grantType)) {
+                idPClientProperties.put(IdPClientConstants.APP_ID, appId);
                 idPClientProperties.put(IdPClientConstants.USERNAME, username);
                 idPClientProperties.put(IdPClientConstants.PASSWORD, password);
             } else {

--- a/pom.xml
+++ b/pom.xml
@@ -1486,7 +1486,7 @@
         <carbon.analytics.version>2.0.231-SNAPSHOT</carbon.analytics.version>
         <siddhi.version>4.0.0</siddhi.version>
         <siddhi.bundle.version>4.0.0</siddhi.bundle.version>
-        <carbon.analytics-common.version>6.0.44</carbon.analytics-common.version>
+        <carbon.analytics-common.version>6.0.45</carbon.analytics-common.version>
         <carbon.analytics-common.version.range>[6.0.44, 6.1.0)</carbon.analytics-common.version.range>
       
         <geronimo.jms.spec.version>1.1.1</geronimo.jms.spec.version>


### PR DESCRIPTION
## Purpose
Passing appId to IdPClient and Bumping carbon-analytics-common to 6.0.45

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes