### PR TITLE
Removing a sample rule template that could cause ambiguity

### DIFF
--- a/features/org.wso2.carbon.business.rules.core.feature/src/main/resources/templates/stock-exchange.json
+++ b/features/org.wso2.carbon.business.rules.core.feature/src/main/resources/templates/stock-exchange.json
@@ -5,66 +5,6 @@
     "description" : "Domain for stock exchange analytics",
     "ruleTemplates" : [
       {
-        "name" : "Stock Data Analysis" ,
-        "uuid" : "stock-data-analysis",
-        "type" : "template",
-        "instanceCount" : "one",
-        "script" :
-          "
-          /*
-          Derives share volume margin deviation, between the user given min and max share volume margins
-          */
-          function deriveVolumeMarginDeviation(minShareVolumesMargin, maxShareVolumesMargin){
-            return (maxShareVolumesMargin - minShareVolumesMargin);
-          }
-          // To test whether this unwanted variable causes any issues
-          var marginDeviation = deriveVolumeMarginDeviation(${minShareVolumesMargin}, ${maxShareVolumesMargin});
-          var mediumShareVolumesMargin = marginDeviation/2;
-          ",
-        "description" : "Analyzes data of company stocks, related to share volumes",
-        "templates" : [
-          { "type" : "siddhiApp",
-            "content" :
-            "@App:name('lowShareVolumesAnalysis')
-            @Source(type = 'http', receiver.url='http://localhost:5005/inputStream',  basic.auth.enabled='false',
-            @map(type='text'))
-            define stream StockInputStream(symbol string, price float, volume long, company string);
-
-            define stream LowShareVolumesStream(symbol string, price float, totalVolume long, company string);
-
-            from StockInputStream[volume < ${minShareVolumesMargin}]
-            select symbol, price, volume as totalVolume, company
-            insert into LowShareVolumesStream;
-
-            from LowShareVolumesStream#log('Low share volume : ')
-            insert into ShareVolumesStream;"
-          },
-          { "type" : "siddhiApp",
-            "content" :
-            "@App:name('mediumShareVolumesAnalysis')
-            @Source(type = 'http', receiver.url='${httpReceiverURL}',  basic.auth.enabled='false',
-            @map(type='${sourceMapType}'))
-            define stream StockInputStream(symbol string, price float, volume long, company string);
-
-            define stream MediumShareVolumesStream(symbol string, price float, totalVolume long, company string);
-
-            from StockInputStream[volume == ${mediumShareVolumesMargin}]
-            select symbol, price, volume as totalVolume, company
-            insert into MediumShareVolumesStream;
-
-            from MediumShareVolumesStream#log('Medium share volume : ')
-            insert into ShareVolumesStream;"
-          }
-        ],
-        "properties" : {
-          "httpReceiverURL" : {"fieldName":"Receiver URL","description" : "Enter the URL for the http receiver.This url should not be used in another business rule.", "defaultValue" : "https://localhost:8005/stockInputStream"},
-          "sourceMapType" : {"fieldName":"Mapping type for data source","description" : "Enter the format to which, data from the source are mapped", "defaultValue" : "xml", "options" : ["xml", "json"]},
-          "sinkMapType" : {"fieldName":"Mapping type for data sink","description" : "Enter the format to which, data to the sink are mapped", "defaultValue" : "xml", "options" : ["xml", "json"]},
-          "minShareVolumesMargin" : {"fieldName":"Minimum margin for volume shares", "description" : "Enter the threshold value below which, share volumes are considered as low volume shares", "defaultValue" : "10"},
-          "maxShareVolumesMargin" : {"fieldName":"Maximum margin for volume shares", "description" : "Enter the threshold value above which, share volumes are considered as high volume shares", "defaultValue" : "10000"}
-        }
-      },
-      {
         "name" : "Stock Exchange Input",
         "uuid" : "stock-exchange-input",
         "type" : "input",


### PR DESCRIPTION
## Purpose
> The removed rule template produces two SiddhiApps, that use the same HTTP source configuration by default. This causes unnecessary errors while trying to run one of the SiddhiApps. Resolves #974 (ambiguity)

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
