### PR TITLE
Adding precise error to be displayed when script execution fails

### DIFF
--- a/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/api/impl/BusinessRulesApiServiceImpl.java
+++ b/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/api/impl/BusinessRulesApiServiceImpl.java
@@ -115,8 +115,8 @@ public class BusinessRulesApiServiceImpl extends BusinessRulesApiService {
             log.error(String.format("Failed to create business rule %s ",
                     LogEncoder.removeCRLFCharacters(businessRuleName)), e);
             responseData.add("Error while processing the script");
-            responseData.add("Please re-check the entered values, or the script provided by the administrator");
-            responseData.add(TemplateManagerConstants.ERROR);
+            responseData.add(e.getLocalizedMessage());
+            responseData.add(TemplateManagerConstants.SCRIPT_ERROR);
             return Response.serverError().entity(gson.toJson(responseData)).build();
         } catch (TemplateInstanceCountViolationException e) {
             log.error(String.format("Failed to deploy business rule %s ",
@@ -396,8 +396,8 @@ public class BusinessRulesApiServiceImpl extends BusinessRulesApiService {
             return Response.ok().entity(gson.toJson(responseData)).build();
         } catch (RuleTemplateScriptException e) {
             responseData.add("Error while processing the script");
-            responseData.add("Please re-check the entered values, or the script provided by the administrator");
-            responseData.add(TemplateManagerConstants.ERROR);
+            responseData.add(e.getLocalizedMessage());
+            responseData.add(TemplateManagerConstants.SCRIPT_ERROR);
             return Response.serverError().entity(gson.toJson(responseData)).build();
         } catch (TemplateInstanceCountViolationException e) {
             log.error(String.format("Failed to deploy business rule %s ",
@@ -472,8 +472,8 @@ public class BusinessRulesApiServiceImpl extends BusinessRulesApiService {
             log.error(String.format("Failed to update the business rule with uuid %s ",
                     LogEncoder.removeCRLFCharacters(businessRuleInstanceID)), e);
             responseData.add("Error while processing the script");
-            responseData.add("Please re-check the entered values, or the script provided by the administrator");
-            responseData.add(TemplateManagerConstants.ERROR);
+            responseData.add(e.getLocalizedMessage());
+            responseData.add(TemplateManagerConstants.SCRIPT_ERROR);
             return Response.serverError().entity(gson.toJson(responseData)).build();
         }
     }

--- a/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/api/impl/BusinessRulesApiServiceImpl.java
+++ b/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/api/impl/BusinessRulesApiServiceImpl.java
@@ -19,7 +19,6 @@ package org.wso2.carbon.business.rules.core.api.impl;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wso2.carbon.analytics.msf4j.interceptor.common.util.InterceptorConstants;
 import org.wso2.carbon.analytics.permissions.PermissionProvider;
 import org.wso2.carbon.analytics.permissions.bean.Permission;
 import org.wso2.carbon.business.rules.core.api.BusinessRulesApiService;
@@ -32,7 +31,6 @@ import org.wso2.carbon.business.rules.core.bean.scratch.BusinessRuleFromScratch;
 import org.wso2.carbon.business.rules.core.bean.template.BusinessRuleFromTemplate;
 import org.wso2.carbon.business.rules.core.datasource.configreader.DataHolder;
 import org.wso2.carbon.business.rules.core.exceptions.BusinessRuleNotFoundException;
-import org.wso2.carbon.business.rules.core.exceptions.BusinessRulesDatasourceException;
 import org.wso2.carbon.business.rules.core.exceptions.RuleTemplateScriptException;
 import org.wso2.carbon.business.rules.core.exceptions.TemplateInstanceCountViolationException;
 import org.wso2.carbon.business.rules.core.exceptions.TemplateManagerServiceException;
@@ -47,7 +45,6 @@ import java.util.List;
 import java.util.Map;
 
 import javax.ws.rs.core.Response;
-import javax.xml.crypto.Data;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -114,9 +111,9 @@ public class BusinessRulesApiServiceImpl extends BusinessRulesApiService {
         } catch (RuleTemplateScriptException e) {
             log.error(String.format("Failed to create business rule %s ",
                     LogEncoder.removeCRLFCharacters(businessRuleName)), e);
-            responseData.add("Error while processing the script");
-            responseData.add(e.getLocalizedMessage());
-            responseData.add(TemplateManagerConstants.SCRIPT_ERROR);
+            responseData.add("Error while executing the script");
+            responseData.add(e.getMessage());
+            responseData.add(TemplateManagerConstants.SCRIPT_EXECUTION_ERROR);
             return Response.serverError().entity(gson.toJson(responseData)).build();
         } catch (TemplateInstanceCountViolationException e) {
             log.error(String.format("Failed to deploy business rule %s ",
@@ -395,9 +392,9 @@ public class BusinessRulesApiServiceImpl extends BusinessRulesApiService {
             responseData.add(new String[]{});
             return Response.ok().entity(gson.toJson(responseData)).build();
         } catch (RuleTemplateScriptException e) {
-            responseData.add("Error while processing the script");
-            responseData.add(e.getLocalizedMessage());
-            responseData.add(TemplateManagerConstants.SCRIPT_ERROR);
+            responseData.add("Error while executing the script");
+            responseData.add(e.getMessage());
+            responseData.add(TemplateManagerConstants.SCRIPT_EXECUTION_ERROR);
             return Response.serverError().entity(gson.toJson(responseData)).build();
         } catch (TemplateInstanceCountViolationException e) {
             log.error(String.format("Failed to deploy business rule %s ",
@@ -420,7 +417,6 @@ public class BusinessRulesApiServiceImpl extends BusinessRulesApiService {
         Gson gson = new GsonBuilder().disableHtmlEscaping().setPrettyPrinting().create();
         String businessRuleDefinition = gson.toJson(businessRule);
         JsonObject businessRuleJson = gson.fromJson(businessRuleDefinition, JsonObject.class);
-//        String businessRuleName;
         int status;
         try {
             if (businessRuleJson.get("type").toString().equals("\"" +
@@ -429,11 +425,9 @@ public class BusinessRulesApiServiceImpl extends BusinessRulesApiService {
                         .jsonToBusinessRuleFromTemplate(businessRuleDefinition);
                 status = templateManagerService.editBusinessRuleFromTemplate(businessRuleInstanceID,
                         businessRuleFromTemplate, deploy);
-//                businessRuleName = businessRuleFromTemplate.getName();
             } else {
                 BusinessRuleFromScratch businessRuleFromScratch = TemplateManagerHelper.jsonToBusinessRuleFromScratch
                         (businessRuleDefinition);
-//                businessRuleName = businessRuleFromScratch.getName();
 
                 status = templateManagerService.editBusinessRuleFromScratch(businessRuleInstanceID,
                         businessRuleFromScratch, deploy);
@@ -471,9 +465,9 @@ public class BusinessRulesApiServiceImpl extends BusinessRulesApiService {
         } catch (RuleTemplateScriptException e) {
             log.error(String.format("Failed to update the business rule with uuid %s ",
                     LogEncoder.removeCRLFCharacters(businessRuleInstanceID)), e);
-            responseData.add("Error while processing the script");
-            responseData.add(e.getLocalizedMessage());
-            responseData.add(TemplateManagerConstants.SCRIPT_ERROR);
+            responseData.add("Error while executing the script");
+            responseData.add(e.getMessage());
+            responseData.add(TemplateManagerConstants.SCRIPT_EXECUTION_ERROR);
             return Response.serverError().entity(gson.toJson(responseData)).build();
         }
     }

--- a/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/util/TemplateManagerConstants.java
+++ b/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/util/TemplateManagerConstants.java
@@ -61,9 +61,9 @@ public class TemplateManagerConstants {
     public static final int PARTIALLY_UNDEPLOYED = 3;
     public static final int DEPLOYMENT_FAILURE = 4;
     public static final int ERROR = 5;
-    public static final int SCRIPT_ERROR = 6;
 
     public static final int SUCCESSFULLY_DELETED = 6;
+    public static final int SCRIPT_EXECUTION_ERROR = 7;
 
     // Directory locations
     private static final String CARBON_RUNTIME = Utils.getRuntimePath().toString();

--- a/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/util/TemplateManagerConstants.java
+++ b/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/util/TemplateManagerConstants.java
@@ -61,6 +61,7 @@ public class TemplateManagerConstants {
     public static final int PARTIALLY_UNDEPLOYED = 3;
     public static final int DEPLOYMENT_FAILURE = 4;
     public static final int ERROR = 5;
+    public static final int SCRIPT_ERROR = 6;
 
     public static final int SUCCESSFULLY_DELETED = 6;
 

--- a/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/util/TemplateManagerHelper.java
+++ b/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/util/TemplateManagerHelper.java
@@ -506,16 +506,16 @@ public class TemplateManagerHelper {
             engine.eval(script);
             Map<String, Object> returnedScriptContextBindings = engine.getBindings(ScriptContext.ENGINE_SCOPE);
 
-            // Variable values from the script context binding as strings
-            Map<String, String> variableValues = new HashMap<>();
-            for (Map.Entry variable : returnedScriptContextBindings.entrySet()) {
-                if (variable.getValue() == null) {
-                    variableValues.put(variable.getKey().toString(), null);
+            // Variable names and their values as strings, from the script context binding
+            Map<String, String> scriptVariables = new HashMap<>();
+            for (Map.Entry scriptVariable : returnedScriptContextBindings.entrySet()) {
+                if (scriptVariable.getValue() == null) {
+                    scriptVariables.put(scriptVariable.getKey().toString(), null);
                 } else {
-                    variableValues.put(variable.getKey().toString(), variable.getValue().toString());
+                    scriptVariables.put(scriptVariable.getKey().toString(), scriptVariable.getValue().toString());
                 }
             }
-            return variableValues;
+            return scriptVariables;
         } catch (ScriptException e) {
             throw new RuleTemplateScriptException(e.getCause().getMessage(), e);
         }

--- a/components/org.wso2.carbon.business.rules.web/src/components/BusinessRuleFromScratchForm.jsx
+++ b/components/org.wso2.carbon.business.rules.web/src/components/BusinessRuleFromScratchForm.jsx
@@ -593,10 +593,13 @@ class BusinessRuleFromScratchForm extends React.Component {
                             window.location.href = appContext + '/businessRulesManager';
                         }, 3000);
                     }).catch(function (error) {
-                    // Check for script error
-                    if (error.data) {
-                        if (error.data[2] === 6) {
-                            that.setSnackbar(error.data[1]);
+                    // Check for script execution error
+                    if (error.response) {
+                        if (error.response.data[2] === BusinessRulesConstants.SCRIPT_EXECUTION_ERROR) {
+                            this.setState({
+                                isFormFillable: true
+                            });
+                            that.setSnackbar(error.response.data[1]);
                         } else {
                             that.setSnackbar('Failed to create the Business Rule');
                             setTimeout(function () {
@@ -666,10 +669,13 @@ class BusinessRuleFromScratchForm extends React.Component {
                             window.location.href = appContext + '/businessRulesManager';
                         }, 3000);
                     }).catch(function (error) {
-                    // Check for script error
-                    if (error.data) {
-                        if (error.data[2] === 6) {
-                            that.setSnackbar(error.data[1]);
+                    // Check for script execution error
+                    if (error.response) {
+                        if (error.response.data[2] === BusinessRulesConstants.SCRIPT_EXECUTION_ERROR) {
+                            this.setState({
+                                isFormFillable: true
+                            });
+                            that.setSnackbar(error.response.data[1]);
                         } else {
                             that.setSnackbar('Failed to create the Business Rule');
                             setTimeout(function () {

--- a/components/org.wso2.carbon.business.rules.web/src/components/BusinessRuleFromScratchForm.jsx
+++ b/components/org.wso2.carbon.business.rules.web/src/components/BusinessRuleFromScratchForm.jsx
@@ -593,11 +593,23 @@ class BusinessRuleFromScratchForm extends React.Component {
                             window.location.href = appContext + '/businessRulesManager';
                         }, 3000);
                     }).catch(function (error) {
-                    that.setSnackbar('Failed to create the Business Rule');
-                    setTimeout(function () {
-                        window.location.href = appContext + '/businessRulesManager';
-                    }, 3000);
-                });
+                    // Check for script error
+                    if (error.data) {
+                        if (error.data[2] === 6) {
+                            that.setSnackbar(error.data[1]);
+                        } else {
+                            that.setSnackbar('Failed to create the Business Rule');
+                            setTimeout(function () {
+                                window.location.href = appContext + '/businessRulesManager';
+                            }, 3000);
+                        }
+                    } else {
+                        that.setSnackbar('Failed to create the Business Rule');
+                        setTimeout(function () {
+                            window.location.href = appContext + '/businessRulesManager';
+                        }, 3000);
+                    }
+                })
             } else {
                 // Display error
                 this.setState({
@@ -654,11 +666,23 @@ class BusinessRuleFromScratchForm extends React.Component {
                             window.location.href = appContext + '/businessRulesManager';
                         }, 3000);
                     }).catch(function (error) {
-                    that.setSnackbar('Failed to create the Business Rule');
-                    setTimeout(function () {
-                        window.location.href = appContext + '/businessRulesManager';
-                    }, 3000);
-                });
+                    // Check for script error
+                    if (error.data) {
+                        if (error.data[2] === 6) {
+                            that.setSnackbar(error.data[1]);
+                        } else {
+                            that.setSnackbar('Failed to create the Business Rule');
+                            setTimeout(function () {
+                                window.location.href = appContext + '/businessRulesManager';
+                            }, 3000);
+                        }
+                    } else {
+                        that.setSnackbar('Failed to create the Business Rule');
+                        setTimeout(function () {
+                            window.location.href = appContext + '/businessRulesManager';
+                        }, 3000);
+                    }
+                })
             } else {
                 // Display error
                 this.setState({

--- a/components/org.wso2.carbon.business.rules.web/src/components/BusinessRuleFromScratchForm.jsx
+++ b/components/org.wso2.carbon.business.rules.web/src/components/BusinessRuleFromScratchForm.jsx
@@ -596,7 +596,7 @@ class BusinessRuleFromScratchForm extends React.Component {
                     // Check for script execution error
                     if (error.response) {
                         if (error.response.data[2] === BusinessRulesConstants.SCRIPT_EXECUTION_ERROR) {
-                            this.setState({
+                            that.setState({
                                 isFormFillable: true
                             });
                             that.setSnackbar(error.response.data[1]);
@@ -672,7 +672,7 @@ class BusinessRuleFromScratchForm extends React.Component {
                     // Check for script execution error
                     if (error.response) {
                         if (error.response.data[2] === BusinessRulesConstants.SCRIPT_EXECUTION_ERROR) {
-                            this.setState({
+                            that.setState({
                                 isFormFillable: true
                             });
                             that.setSnackbar(error.response.data[1]);

--- a/components/org.wso2.carbon.business.rules.web/src/components/BusinessRuleFromScratchForm.jsx
+++ b/components/org.wso2.carbon.business.rules.web/src/components/BusinessRuleFromScratchForm.jsx
@@ -869,6 +869,14 @@ class BusinessRuleFromScratchForm extends React.Component {
                                 onClick={(e) => this.createBusinessRule(true)}>
                             Save & Deploy
                         </Button>
+                        <Button
+                            color="default" style={{marginRight: 10}}
+                            onClick={() => {
+                                window.location.href = appContext + '/businessRulesManager';
+                            }}
+                        >
+                            Cancel
+                        </Button>
                     </div>
             } else if (this.state.formMode === BusinessRulesConstants.BUSINESS_RULE_FORM_MODE_EDIT) {
                 submitButtons =
@@ -880,6 +888,14 @@ class BusinessRuleFromScratchForm extends React.Component {
                         <Button raised color="primary" style={styles.button}
                                 onClick={(e) => this.updateBusinessRule(true)}>
                             Save & Deploy
+                        </Button>
+                        <Button
+                            color="default" style={{marginRight: 10}}
+                            onClick={() => {
+                                window.location.href = appContext + '/businessRulesManager';
+                            }}
+                        >
+                            Cancel
                         </Button>
                     </div>
             }

--- a/components/org.wso2.carbon.business.rules.web/src/components/BusinessRuleFromTemplateForm.jsx
+++ b/components/org.wso2.carbon.business.rules.web/src/components/BusinessRuleFromTemplateForm.jsx
@@ -254,10 +254,13 @@ class BusinessRuleFromTemplateForm extends React.Component {
                             window.location.href = appContext + '/businessRulesManager';
                         }, 3000);
                     }).catch(function (error) {
-                        // Check for script error
-                        if (error.data) {
-                            if (error.data[2] === 6) {
-                                that.setSnackbar(error.data[1]);
+                        // Check for script execution error
+                        if (error.response) {
+                            if (error.response.data[2] === BusinessRulesConstants.SCRIPT_EXECUTION_ERROR) {
+                                this.setState({
+                                    isFormFillable: true
+                                });
+                                that.setSnackbar(error.response.data[1]);
                             } else {
                                 that.setSnackbar('Failed to create the Business Rule');
                                 setTimeout(function () {
@@ -326,10 +329,13 @@ class BusinessRuleFromTemplateForm extends React.Component {
                             window.location.href = appContext + '/businessRulesManager';
                         }, 3000);
                     }).catch(function (error) {
-                    // Check for script error
-                    if (error.data) {
-                        if (error.data[2] === 6) {
-                            that.setSnackbar(error.data[1]);
+                    // Check for script execution error
+                    if (error.response) {
+                        if (error.response.data[2] === BusinessRulesConstants.SCRIPT_EXECUTION_ERROR) {
+                            this.setState({
+                                isFormFillable: true
+                            });
+                            that.setSnackbar(error.response.data[1]);
                         } else {
                             that.setSnackbar('Failed to create the Business Rule');
                             setTimeout(function () {

--- a/components/org.wso2.carbon.business.rules.web/src/components/BusinessRuleFromTemplateForm.jsx
+++ b/components/org.wso2.carbon.business.rules.web/src/components/BusinessRuleFromTemplateForm.jsx
@@ -257,7 +257,7 @@ class BusinessRuleFromTemplateForm extends React.Component {
                         // Check for script execution error
                         if (error.response) {
                             if (error.response.data[2] === BusinessRulesConstants.SCRIPT_EXECUTION_ERROR) {
-                                this.setState({
+                                that.setState({
                                     isFormFillable: true
                                 });
                                 that.setSnackbar(error.response.data[1]);
@@ -332,7 +332,7 @@ class BusinessRuleFromTemplateForm extends React.Component {
                     // Check for script execution error
                     if (error.response) {
                         if (error.response.data[2] === BusinessRulesConstants.SCRIPT_EXECUTION_ERROR) {
-                            this.setState({
+                            that.setState({
                                 isFormFillable: true
                             });
                             that.setSnackbar(error.response.data[1]);

--- a/components/org.wso2.carbon.business.rules.web/src/components/BusinessRuleFromTemplateForm.jsx
+++ b/components/org.wso2.carbon.business.rules.web/src/components/BusinessRuleFromTemplateForm.jsx
@@ -254,10 +254,22 @@ class BusinessRuleFromTemplateForm extends React.Component {
                             window.location.href = appContext + '/businessRulesManager';
                         }, 3000);
                     }).catch(function (error) {
-                    that.setSnackbar('Failed to create the Business Rule');
-                    setTimeout(function () {
-                        window.location.href = appContext + '/businessRulesManager';
-                    }, 3000);
+                        // Check for script error
+                        if (error.data) {
+                            if (error.data[2] === 6) {
+                                that.setSnackbar(error.data[1]);
+                            } else {
+                                that.setSnackbar('Failed to create the Business Rule');
+                                setTimeout(function () {
+                                    window.location.href = appContext + '/businessRulesManager';
+                                }, 3000);
+                            }
+                        } else {
+                            that.setSnackbar('Failed to create the Business Rule');
+                            setTimeout(function () {
+                                window.location.href = appContext + '/businessRulesManager';
+                            }, 3000);
+                        }
                 })
             } else {
                 // Display error
@@ -314,10 +326,22 @@ class BusinessRuleFromTemplateForm extends React.Component {
                             window.location.href = appContext + '/businessRulesManager';
                         }, 3000);
                     }).catch(function (error) {
-                    that.setSnackbar('Failed to update the Business Rule');
-                    setTimeout(function () {
-                        window.location.href = appContext + '/businessRulesManager';
-                    }, 3000);
+                    // Check for script error
+                    if (error.data) {
+                        if (error.data[2] === 6) {
+                            that.setSnackbar(error.data[1]);
+                        } else {
+                            that.setSnackbar('Failed to create the Business Rule');
+                            setTimeout(function () {
+                                window.location.href = appContext + '/businessRulesManager';
+                            }, 3000);
+                        }
+                    } else {
+                        that.setSnackbar('Failed to create the Business Rule');
+                        setTimeout(function () {
+                            window.location.href = appContext + '/businessRulesManager';
+                        }, 3000);
+                    }
                 })
             } else {
                 // Display error

--- a/components/org.wso2.carbon.business.rules.web/src/components/BusinessRuleFromTemplateForm.jsx
+++ b/components/org.wso2.carbon.business.rules.web/src/components/BusinessRuleFromTemplateForm.jsx
@@ -588,6 +588,14 @@ class BusinessRuleFromTemplateForm extends React.Component {
                                     onClick={(e) => this.createBusinessRule(true)}>
                                 Save & Deploy
                             </Button>
+                            <Button
+                                color="default" style={{marginRight: 10}}
+                                onClick={() => {
+                                    window.location.href = appContext + '/businessRulesManager';
+                                }}
+                            >
+                                Cancel
+                            </Button>
                         </div>
                 }
             } else if (this.state.formMode === BusinessRulesConstants.BUSINESS_RULE_FORM_MODE_EDIT) {
@@ -600,6 +608,14 @@ class BusinessRuleFromTemplateForm extends React.Component {
                         <Button raised color="primary" style={{marginRight: 10}}
                                 onClick={(e) => this.updateBusinessRule(true)}>
                             Save & Deploy
+                        </Button>
+                        <Button
+                            color="default" style={{marginRight: 10}}
+                            onClick={() => {
+                                window.location.href = appContext + '/businessRulesManager';
+                            }}
+                        >
+                            Cancel
                         </Button>
                     </div>
             }

--- a/components/org.wso2.carbon.business.rules.web/src/components/BusinessRulesManager.jsx
+++ b/components/org.wso2.carbon.business.rules.web/src/components/BusinessRulesManager.jsx
@@ -300,7 +300,7 @@ class BusinessRulesManager extends React.Component {
 
         return (
             <MuiThemeProvider theme={theme}>
-                <Header />
+                <Header hideHomeButton />
                 <br />
                 <div>
                     {snackbar}

--- a/components/org.wso2.carbon.business.rules.web/src/components/common/Header.jsx
+++ b/components/org.wso2.carbon.business.rules.web/src/components/common/Header.jsx
@@ -26,6 +26,7 @@ import Toolbar from 'material-ui/Toolbar';
 import IconButton from 'material-ui/IconButton';
 import Button from 'material-ui/Button';
 import AccountCircle from 'material-ui-icons/AccountCircle';
+import HomeIcon from 'material-ui-icons/Home';
 import Menu, { MenuItem } from 'material-ui/Menu';
 import Logo from '../../images/wso2-logo.svg';
 // App Utilities
@@ -62,6 +63,22 @@ class Header extends React.Component {
      * @returns {XML} HTML content
      */
     renderRightLinks() {
+        const homeButton = (
+            <Link
+                style={{textDecoration: 'none'}}
+                to={`${appContext}/login?referrer=${window.location.pathname}`}
+            >
+                <IconButton
+                    onClick={event => {
+                        this.setState({ anchorEl: event.currentTarget });
+                    }}
+                    color="contrast"
+                >
+                    <HomeIcon />
+                </IconButton>
+            </Link>
+        );
+
         if (this.props.hideUserSettings) {
             return (<div />);
         }
@@ -84,6 +101,7 @@ class Header extends React.Component {
         return (
             <div>
                 <Toolbar>
+                    {!this.props.hideHomeButton ? (homeButton) : (null)}
                     <Typography type="body1" style={{ color: 'inherit' }}>
                         {user.username}
                     </Typography>

--- a/components/org.wso2.carbon.business.rules.web/src/constants/BusinessRulesConstants.js
+++ b/components/org.wso2.carbon.business.rules.web/src/constants/BusinessRulesConstants.js
@@ -57,6 +57,7 @@ const BusinessRulesConstants = {
     BUSINESS_RULE_STATUS_DEPLOYED: 3,
     BUSINESS_RULE_STATUS_DEPLOYMENT_FAILED: 1, // Tried to save & deploy, but only save was successful
     BUSINESS_RULE_STATUS_NOT_DEPLOYED: 0, // Tried only to save, and was successful
+    SCRIPT_EXECUTION_ERROR: 7, // Script execution has been failed in the backend, due to the provided value(s)
 
     // Business Rule deployment statuses
     BUSINESS_RULE_STATUSES: [
@@ -82,7 +83,6 @@ const BusinessRulesConstants = {
         'After deletion' // 5
         // Else, normal mode
     ],
-
 
     // URL for APIs
     BASE_URL: window.location.origin

--- a/components/org.wso2.carbon.business.rules.web/src/constants/BusinessRulesConstants.js
+++ b/components/org.wso2.carbon.business.rules.web/src/constants/BusinessRulesConstants.js
@@ -65,7 +65,7 @@ const BusinessRulesConstants = {
         'Partially Deployed', // 2
         'Partially Undeployed', // 3
         'Deployment Failure', // 4
-        'Error' // 5
+        'Error', // 5
     ],
 
     BUSINESS_RULE_STATUS_DEPLOYED_STRING: 'Deployed',

--- a/features/org.wso2.carbon.business.rules.core.feature/src/main/resources/templates/Sweet_Factory.json
+++ b/features/org.wso2.carbon.business.rules.core.feature/src/main/resources/templates/Sweet_Factory.json
@@ -16,7 +16,7 @@
         if (!isNaN(number) && (number > 0)) {
         return number;
       } else {
-        throw 'Positive number expected for time range';
+        throw 'A positive number expected for time range';
       }
     }
 

--- a/features/org.wso2.carbon.business.rules.core.feature/src/main/resources/templates/Sweet_Factory.json
+++ b/features/org.wso2.carbon.business.rules.core.feature/src/main/resources/templates/Sweet_Factory.json
@@ -16,7 +16,7 @@
         if (!isNaN(number) && (number > 0)) {
         return number;
       } else {
-        throw 'Number expected for time range';
+        throw 'Positive number expected for time range';
       }
     }
 


### PR DESCRIPTION
## Purpose
> When a Javascript is used in a rule template for functionalities like validation, providing invalid inputs in Business Rule creation form would throw an error.
> 
> Script generation related fixes:
> - Displaying the precise error produced after script execution
> - Holds the Business Rule without saving, whenever script executions are failed
> Other fixes:
> - Adding Cancel & Home buttons 

## Goals
> Improving usability

## Approach
![image](https://user-images.githubusercontent.com/24828296/34210849-4249f31c-e5bd-11e7-9250-e9c932c2ddfc.png)

![image](https://user-images.githubusercontent.com/24828296/34210882-5f1d493a-e5bd-11e7-8996-2d3c2a2d06ca.png)

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes