### PR TITLE
Reduce INFO log noise

### DIFF
--- a/components/org.wso2.carbon.siddhi.store.api.rest/src/gen/java/org/wso2/carbon/siddhi/store/api/rest/StoresApi.java
+++ b/components/org.wso2.carbon.siddhi.store.api.rest/src/gen/java/org/wso2/carbon/siddhi/store/api/rest/StoresApi.java
@@ -82,7 +82,7 @@ public class StoresApi implements Microservice {
      */
     @Activate
     protected void start(BundleContext bundleContext) throws Exception {
-        log.info("Siddhi Store REST API Started...");
+        log.debug("Siddhi Store REST API activated.");
     }
 
     /**
@@ -93,7 +93,7 @@ public class StoresApi implements Microservice {
      */
     @Deactivate
     protected void stop() throws Exception {
-
+        log.debug("Siddhi Store REST API deactivated.");
     }
 
     @Reference(

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/ServiceComponent.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/ServiceComponent.java
@@ -90,7 +90,7 @@ public class ServiceComponent {
      */
     @Activate
     protected void start(BundleContext bundleContext) throws Exception {
-        log.info("Service Component is activated");
+        log.debug("Service Component is activated");
 
         String runningFileName = System.getProperty(SiddhiAppProcessorConstants.SYSTEM_PROP_RUN_FILE);
         ConfigProvider configProvider = StreamProcessorDataHolder.getInstance().getConfigProvider();
@@ -210,7 +210,7 @@ public class ServiceComponent {
      */
     @Deactivate
     protected void stop() throws Exception {
-        log.info("Service Component is deactivated");
+        log.debug("Service Component is deactivated");
 
         Map<String, SiddhiAppData> siddhiAppMap = StreamProcessorDataHolder.
                 getStreamProcessorService().getSiddhiAppMap();

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/StreamProcessorDeployer.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/StreamProcessorDeployer.java
@@ -154,7 +154,7 @@ public class StreamProcessorDeployer implements Deployer {
     public void init() {
         try {
             directoryLocation = new URL("file:" + SiddhiAppProcessorConstants.SIDDHI_APP_FILES_DIRECTORY);
-            log.info("Stream Processor Deployer Initiated");
+            log.debug("Stream Processor Deployer initiated.");
         } catch (MalformedURLException e) {
             log.error("Error while initializing directoryLocation" + SiddhiAppProcessorConstants.
                     SIDDHI_APP_FILES_DIRECTORY, e);

--- a/components/org.wso2.carbon.stream.processor.statistics/src/gen/java/org/wso2/carbon/stream/processor/statistics/api/SystemDetailsApi.java
+++ b/components/org.wso2.carbon.stream.processor.statistics/src/gen/java/org/wso2/carbon/stream/processor/statistics/api/SystemDetailsApi.java
@@ -53,7 +53,7 @@ public class SystemDetailsApi implements Microservice {
      */
     @Activate
     protected void start() throws Exception {
-        log.info("SystemDetailsApi has been activated.");
+        log.debug("SystemDetailsApi has been activated.");
     }
 
     /**
@@ -64,7 +64,7 @@ public class SystemDetailsApi implements Microservice {
      */
     @Deactivate
     protected void stop() throws Exception {
-        log.info("SystemDetailsApi has been stop.");
+        log.debug("SystemDetailsApi has been stop.");
     }
 
     @GET


### PR DESCRIPTION
## Purpose
Due to unnecessary INFO level logs, the terminal gets cluttered at the server startup.

## Goals
- Reduce INFO logs at server startup.

## Approach
- Change log level to DEBUG

## Automation tests
 - Unit tests 
   N/A
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
