### PR TITLE
Disabling 'Create BR' option for unauthorized user, when no BRs are available

### DIFF
--- a/components/org.wso2.carbon.business.rules.web/src/components/BusinessRulesManager.jsx
+++ b/components/org.wso2.carbon.business.rules.web/src/components/BusinessRulesManager.jsx
@@ -190,13 +190,6 @@ class BusinessRulesManager extends React.Component {
     }
 
     /**
-     * Redirects to the Business Rules creator page
-     */
-    loadBusinessRulesCreator() {
-        window.location.href = `${appContext}/businessRuleCreator`;
-    }
-
-    /**
      * Displays list of Business Rules when available, or message for creation when not
      */
     displayAvailableBusinessRules() {
@@ -215,6 +208,7 @@ class BusinessRulesManager extends React.Component {
         }
 
         if (!isNoneAvailable) {
+            // Business rules are available
             // Show available business rules
             let businessRules = this.state.businessRules.map((businessRule) =>
                 <BusinessRule
@@ -253,30 +247,43 @@ class BusinessRulesManager extends React.Component {
                 </div>
             )
         } else {
-            // Show message for creation
-            return (
-                <div>
-                    <Paper style={styles.paper}>
-                        <Typography type="title">
-                            {(this.state.permissions === 1) ? ('Access Denied') : ('No business rules found')}
-                        </Typography>
-                        <Typography type="subheading">
-                            {(this.state.permissions === 1) ?
-                                ('Please login with valid permissions') :
-                                ('Get started by creating one')}
-                        </Typography>
-                        <br/>
-                        <Button
-                            raised
-                            disabled={this.state.permissions === 1}
-                            color="primary"
-                            onClick={() => this.loadBusinessRulesCreator()}
-                        >
-                            Create
-                        </Button>
-                    </Paper>
-                </div>
-            )
+            if (this.state.permissions === 0) {
+                // Manager
+                // Show message for creation
+                return (
+                    <div>
+                        <Paper style={styles.paper}>
+                            <Typography type="title">
+                                No business rules found
+                            </Typography>
+                            <Typography type="subheading">
+                                Get started by creating one
+                            </Typography>
+                            <br/>
+                            <Link to={`${appContext}/businessRuleCreator`} style={{textDecoration: 'none'}}>
+                                <Button raised color="primary">
+                                    Create
+                                </Button>
+                            </Link>
+                        </Paper>
+                    </div>
+                );
+            } else {
+                // Viewer
+                // Deny creation
+                return (
+                    <div>
+                        <Paper style={styles.paper}>
+                            <Typography type="title">
+                                Access Denied
+                            </Typography>
+                            <Typography type="subheading">
+                                Please login with valid permissions
+                            </Typography>
+                        </Paper>
+                    </div>
+                );
+            }
         }
     }
 

--- a/components/org.wso2.carbon.business.rules.web/src/components/BusinessRulesManager.jsx
+++ b/components/org.wso2.carbon.business.rules.web/src/components/BusinessRulesManager.jsx
@@ -190,7 +190,7 @@ class BusinessRulesManager extends React.Component {
     }
 
     /**
-     * Redirects to the Business Rules creator
+     * Redirects to the Business Rules creator page
      */
     loadBusinessRulesCreator() {
         window.location.href = `${appContext}/businessRuleCreator`;

--- a/components/org.wso2.carbon.business.rules.web/src/components/BusinessRulesManager.jsx
+++ b/components/org.wso2.carbon.business.rules.web/src/components/BusinessRulesManager.jsx
@@ -193,7 +193,7 @@ class BusinessRulesManager extends React.Component {
      * Redirects to the Business Rules creator
      */
     loadBusinessRulesCreator() {
-        window.href = `${appContext}/businessRuleCreator`;
+        window.location.href = `${appContext}/businessRuleCreator`;
     }
 
     /**


### PR DESCRIPTION
## Purpose
> Disabling 'Create BR' option for unauthorized user, when no BRs are available

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes