### PR TITLE
Enable multiple zkClient support for failover in distributed deployment

### DIFF
--- a/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/appCreator/SafeZkClient.java
+++ b/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/appCreator/SafeZkClient.java
@@ -19,7 +19,12 @@
 package org.wso2.carbon.sp.jobmanager.core.appCreator;
 
 import kafka.utils.ZKStringSerializer$;
+import kafka.utils.ZkUtils;
 import org.I0Itec.zkclient.ZkClient;
+import org.I0Itec.zkclient.ZkConnection;
+import org.I0Itec.zkclient.exception.ZkTimeoutException;
+import org.apache.log4j.Logger;
+import org.wso2.carbon.sp.jobmanager.core.exception.ResourceManagerException;
 
 /**
  * Helper class to use Zookeeper client.
@@ -28,13 +33,45 @@ import org.I0Itec.zkclient.ZkClient;
  */
 class SafeZkClient {
 
+    private ZkClient zkClient;
+    private ZkUtils zkUtils;
+    private static final Logger log = Logger.getLogger(SafeZkClient.class);
+
     /**
      * Creates a new Zookeeper client for the specified server URL.
      *
-     * @param zooKeeperServerUrl server URL
+     * @param zooKeeperServerUrls server URL
      * @return a new Zookeeper client
      */
-    public ZkClient createZkClient(String zooKeeperServerUrl) {
-        return new ZkClient(zooKeeperServerUrl, 10000, 8000, ZKStringSerializer$.MODULE$);
+    public ZkUtils createZkClient(String[] zooKeeperServerUrls, boolean isSecureKafkaCluster) {
+        for (String zooKeeperServerUrl : zooKeeperServerUrls) {
+            try {
+                zkClient = new ZkClient(zooKeeperServerUrl, 10000, 5000, ZKStringSerializer$.MODULE$);
+                zkUtils = new ZkUtils(zkClient, new ZkConnection(zooKeeperServerUrl), isSecureKafkaCluster);
+                break;
+            } catch (ZkTimeoutException e) {
+                log.error("Zookeeper server at " + zooKeeperServerUrl + " can not be reached.");
+            }
+        }
+        if (zkUtils != null) {
+            return zkUtils;
+        } else {
+            throw new ResourceManagerException("All listed Zookeeper servers can not be reached.");
+        }
+    }
+
+    public void closeClient() {
+        if (zkUtils != null) {
+            zkUtils.close();
+            if (log.isDebugEnabled()) {
+                log.debug("zkUtils connection closed.");
+            }
+        }
+        if (zkClient != null) {
+            zkClient.close();
+            if (log.isDebugEnabled()) {
+                log.debug("zkClient connection closed.");
+            }
+        }
     }
 }


### PR DESCRIPTION
## Purpose
> Solution for issue #1094 

## Goals
> Specify multiple zookeeper URLs so that in case of failing of one zookeeper node another will be used to create partitions when deploying distributed Siddhi applications

## Approach
> Iterate over listed zookeeper URLs and if unable to connect to server due to timeout will try next URL. Exception thrown if none of the zookeeper URLs are working

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A