### PR TITLE
Introduce permission model for Siddhi REST APIs

### DIFF
--- a/components/org.wso2.carbon.event.simulator.core/pom.xml
+++ b/components/org.wso2.carbon.event.simulator.core/pom.xml
@@ -139,6 +139,14 @@
             <groupId>org.wso2.carbon.analytics</groupId>
             <artifactId>org.wso2.carbon.analytics.msf4j.interceptor.common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.analytics-common</groupId>
+            <artifactId>org.wso2.carbon.analytics.permissions</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.analytics-common</groupId>
+            <artifactId>org.wso2.carbon.database.query.manager</artifactId>
+        </dependency>
     </dependencies>
 
     <properties>
@@ -154,6 +162,8 @@
             javax.management.*,
             javax.ws.rs.*;version="0.0.0",
             org.wso2.siddhi.*;version="${siddhi.version.range}",
+            org.wso2.carbon.analytics.permissions.*; version="${carbon.analytics-common.version.range}",
+            org.wso2.carbon.database.query.manager.*; version="${carbon.analytics-common.version.range}",
             *;resolution:=optional
         </import.package>
         <carbon.component>

--- a/components/org.wso2.carbon.event.simulator.core/src/gen/java/org/wso2/carbon/event/simulator/core/api/DatabaseApi.java
+++ b/components/org.wso2.carbon.event.simulator.core/src/gen/java/org/wso2/carbon/event/simulator/core/api/DatabaseApi.java
@@ -7,13 +7,16 @@ import org.osgi.service.component.annotations.Deactivate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.analytics.msf4j.interceptor.common.AuthenticationInterceptor;
+import org.wso2.carbon.analytics.msf4j.interceptor.common.util.InterceptorConstants;
 import org.wso2.carbon.event.simulator.core.factories.DatabaseApiServiceFactory;
 import org.wso2.carbon.event.simulator.core.model.*;
 
 
 import org.wso2.msf4j.Microservice;
+import org.wso2.msf4j.Request;
 import org.wso2.msf4j.interceptor.annotation.RequestInterceptor;
 
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.*;
 
@@ -26,30 +29,32 @@ import javax.ws.rs.*;
 @RequestInterceptor(AuthenticationInterceptor.class)
 @io.swagger.annotations.Api(description = "the connectToDatabase API")
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaMSF4JServerCodegen",
-                            date = "2017-07-20T09:30:14.336Z")
+        date = "2017-07-20T09:30:14.336Z")
 public class DatabaseApi implements Microservice {
     private final DatabaseApiService delegate = DatabaseApiServiceFactory.getConnectToDatabaseApi();
     private static final Logger log = LoggerFactory.getLogger(DatabaseApi.class);
+
     @POST
     @Path("/{tableName}/retrieveColumnNames")
     @Consumes({"application/json"})
     @Produces({"application/json"})
     @io.swagger.annotations.ApiOperation(value = "Retreive database table columns", notes = "", response = void.class,
-                                         tags = {"simulator",})
+            tags = {"simulator",})
     @io.swagger.annotations.ApiResponses(value = {
             @io.swagger.annotations.ApiResponse(code = 200, message = "Successfully retrieved the database tables",
-                                                response = void.class),
+                    response = void.class),
 
             @io.swagger.annotations.ApiResponse(code = 400, message = "Database Connection has been failed",
-                                                response = void.class)})
+                    response = void.class)})
     public Response getDatabaseTableColumns(
+            @Context Request request,
             @ApiParam(value = "Database connection parameters to get the database tables", required = true)
                     DBConnectionModel body
             ,
             @ApiParam(value = "Table name to get the columns", required = true) @PathParam("tableName") String tableName
-                                           )
+    )
             throws javax.ws.rs.NotFoundException, NotFoundException {
-        return delegate.getDatabaseTableColumns(body, tableName);
+        return delegate.getDatabaseTableColumns(body, tableName, request);
     }
 
     @POST
@@ -57,19 +62,20 @@ public class DatabaseApi implements Microservice {
     @Consumes({"application/json"})
     @Produces({"application/json"})
     @io.swagger.annotations.ApiOperation(value = "Retreive database tables", notes = "", response = void.class,
-                                         tags = {"simulator",})
+            tags = {"simulator",})
     @io.swagger.annotations.ApiResponses(value = {
             @io.swagger.annotations.ApiResponse(code = 200, message = "Successfully retrieved the database tables",
-                                                response = void.class),
+                    response = void.class),
 
             @io.swagger.annotations.ApiResponse(code = 400, message = "Database Connection has been failed",
-                                                response = void.class)})
+                    response = void.class)})
     public Response getDatabaseTables(
+            @Context Request request,
             @ApiParam(value = "Database connection parameters to get the database tables", required = true)
                     DBConnectionModel body
-                                     )
+    )
             throws javax.ws.rs.NotFoundException, NotFoundException {
-        return delegate.getDatabaseTables(body);
+        return delegate.getDatabaseTables(body, request);
     }
 
     @POST
@@ -77,17 +83,18 @@ public class DatabaseApi implements Microservice {
     @Consumes({"application/json"})
     @Produces({"application/json"})
     @io.swagger.annotations.ApiOperation(value = "Test a database connection.", notes = "", response = void.class,
-                                         tags = {"simulator",})
+            tags = {"simulator",})
     @io.swagger.annotations.ApiResponses(value = {
             @io.swagger.annotations.ApiResponse(code = 200, message = "Successfully connected to the database",
-                                                response = void.class),
+                    response = void.class),
 
             @io.swagger.annotations.ApiResponse(code = 400, message = "Database Connection has been failed",
-                                                response = void.class)})
+                    response = void.class)})
     public Response testDBConnection(
+            @Context Request request,
             @ApiParam(value = "Database connection parameters to test the database connection", required = true)
                     DBConnectionModel body) throws NotFoundException {
-        return delegate.testDBConnection(body);
+        return delegate.testDBConnection(body, request);
     }
 
     /**

--- a/components/org.wso2.carbon.event.simulator.core/src/gen/java/org/wso2/carbon/event/simulator/core/api/DatabaseApiService.java
+++ b/components/org.wso2.carbon.event.simulator.core/src/gen/java/org/wso2/carbon/event/simulator/core/api/DatabaseApiService.java
@@ -3,6 +3,7 @@ package org.wso2.carbon.event.simulator.core.api;
 import org.wso2.carbon.event.simulator.core.api.*;
 import org.wso2.carbon.event.simulator.core.model.*;
 
+import org.wso2.msf4j.Request;
 import org.wso2.msf4j.formparam.FormDataParam;
 import org.wso2.msf4j.formparam.FileInfo;
 
@@ -17,11 +18,12 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaMSF4JServerCodegen",
-                            date = "2017-07-20T09:30:14.336Z")
+        date = "2017-07-20T09:30:14.336Z")
 public abstract class DatabaseApiService {
-    public abstract Response getDatabaseTableColumns(DBConnectionModel body, String tableName) throws NotFoundException;
+    public abstract Response getDatabaseTableColumns(DBConnectionModel body, String tableName, Request request) throws
+            NotFoundException;
 
-    public abstract Response getDatabaseTables(DBConnectionModel body) throws NotFoundException;
+    public abstract Response getDatabaseTables(DBConnectionModel body, Request request) throws NotFoundException;
 
-    public abstract Response testDBConnection(DBConnectionModel body) throws NotFoundException;
+    public abstract Response testDBConnection(DBConnectionModel body, Request request) throws NotFoundException;
 }

--- a/components/org.wso2.carbon.event.simulator.core/src/gen/java/org/wso2/carbon/event/simulator/core/api/FeedApi.java
+++ b/components/org.wso2.carbon.event.simulator.core/src/gen/java/org/wso2/carbon/event/simulator/core/api/FeedApi.java
@@ -7,9 +7,11 @@ import org.osgi.service.component.annotations.Deactivate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.analytics.msf4j.interceptor.common.AuthenticationInterceptor;
+import org.wso2.carbon.analytics.msf4j.interceptor.common.util.InterceptorConstants;
 import org.wso2.carbon.event.simulator.core.factories.FeedApiServiceFactory;
 import org.wso2.carbon.event.simulator.core.model.InlineResponse200;
 import org.wso2.msf4j.Microservice;
+import org.wso2.msf4j.Request;
 import org.wso2.msf4j.interceptor.annotation.RequestInterceptor;
 
 import javax.ws.rs.Consumes;
@@ -21,6 +23,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
 
@@ -33,92 +36,99 @@ import javax.ws.rs.core.Response;
 @RequestInterceptor(AuthenticationInterceptor.class)
 @io.swagger.annotations.Api(description = "the feed API")
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaMSF4JServerCodegen",
-                            date = "2017-07-20T09:30:14.336Z")
+        date = "2017-07-20T09:30:14.336Z")
 public class FeedApi implements Microservice {
     private final FeedApiService delegate = FeedApiServiceFactory.getFeedApi();
     private static final Logger log = LoggerFactory.getLogger(FeedApi.class);
+
     @POST
     @Consumes({"text/plain"})
     @Produces({"application/json"})
     @io.swagger.annotations.ApiOperation(value = "Upload feed simulation configuration to the system", notes = "",
-                                         response = void.class, tags = {"simulator",})
+            response = void.class, tags = {"simulator",})
     @io.swagger.annotations.ApiResponses(value = {
             @io.swagger.annotations.ApiResponse(code = 200, message = "Successfully uploaded simulation",
-                                                response = void.class)})
-    public Response addFeedSimulation(@ApiParam(value = "Simulation object which is need to be saved", required = true)
-                                              String body) throws NotFoundException {
-        return delegate.addFeedSimulation(body);
+                    response = void.class)})
+    public Response addFeedSimulation(
+            @Context Request request,
+            @ApiParam(value = "Simulation object which is need to be saved", required = true)
+                    String body) throws NotFoundException {
+        return delegate.addFeedSimulation(body, request);
     }
 
     @DELETE
     @Path("/{simulationName}")
-    @Produces({ "application/json" })
+    @Produces({"application/json"})
     @io.swagger.annotations.ApiOperation(value = "Delete a simulation configuration by name",
-                                         notes = "For valid response try integer IDs with positive integer value. "
-                                                 + "Negative or non-integer values will generate API errors",
-                                         response = void.class, tags={ "simulator", })
+            notes = "For valid response try integer IDs with positive integer value. "
+                    + "Negative or non-integer values will generate API errors",
+            response = void.class, tags = {"simulator",})
     @io.swagger.annotations.ApiResponses(value = {
             @io.swagger.annotations.ApiResponse(code = 200, message = "Successfully deleted simulation configuration",
-                                                response = void.class),
+                    response = void.class),
             @io.swagger.annotations.ApiResponse(code = 404, message = "No event simulation configuration available "
-                    + "under simulation name", response = void.class) })
-    public Response deleteFeedSimulation(@ApiParam(value = "Simulation name to delete the configuration.",required=true)
-                                             @PathParam("simulationName") String simulationName)
-            throws NotFoundException {
-        return delegate.deleteFeedSimulation(simulationName);
+                    + "under simulation name", response = void.class)})
+    public Response deleteFeedSimulation(
+            @Context Request request,
+            @ApiParam(value = "Simulation name to delete the configuration.", required = true)
+            @PathParam("simulationName") String simulationName) throws NotFoundException {
+        return delegate.deleteFeedSimulation(simulationName, request);
     }
 
     @GET
     @Path("/{simulationName}")
     @Produces({"application/json"})
     @io.swagger.annotations.ApiOperation(value = "Retrieve a simulation configuration by name.", notes = "Some desc",
-                                         response = String.class, tags = {"simulator",})
+            response = String.class, tags = {"simulator",})
     @io.swagger.annotations.ApiResponses(value = {
-            @io.swagger.annotations.ApiResponse(code = 200, message = "Successfully sent simulation configuration.",
-                                                response = String.class),
+            @io.swagger.annotations.ApiResponse(code = 200, message = "Successfully sent simulation configuratio    n.",
+                    response = String.class),
             @io.swagger.annotations.ApiResponse(code = 404,
-                                                message = "No simulation configuration available under simulation name",
-                                                response = String.class)})
-    public Response getFeedSimulation(@ApiParam(value = "Simulation name to get the configuration.", required = true)
-                                          @PathParam("simulationName") String simulationName) throws NotFoundException {
-        return delegate.getFeedSimulation(simulationName);
+                    message = "No simulation configuration available under simulation name",
+                    response = String.class)})
+    public Response getFeedSimulation(
+            @Context Request request,
+            @ApiParam(value = "Simulation name to get the configuration.", required = true)
+            @PathParam("simulationName") String simulationName) throws NotFoundException {
+        return delegate.getFeedSimulation(simulationName, request);
     }
 
     @GET
     @Produces({"application/json"})
     @io.swagger.annotations.ApiOperation(value = "Retrieve all feed simulation configurations", notes = "Some desc.",
-                                         response = String.class, tags = {"simulator",})
+            response = String.class, tags = {"simulator",})
     @io.swagger.annotations.ApiResponses(value = {
             @io.swagger.annotations.ApiResponse(code = 200, message = "Successfully updated simulation configuration.",
-                                                response = String.class),
+                    response = String.class),
             @io.swagger.annotations.ApiResponse(code = 404, message = "No simulation configurations available.",
-                                                response = String.class)})
-    public Response getFeedSimulations() throws NotFoundException {
-        return delegate.getFeedSimulations();
+                    response = String.class)})
+    public Response getFeedSimulations(@Context Request request) throws NotFoundException {
+        return delegate.getFeedSimulations(request);
     }
 
     @POST
     @Path("/{simulationName}")
     @Produces({"application/json"})
     @io.swagger.annotations.ApiOperation(value = "Operate a simulation configuration by name", notes = "some desc",
-                                         response = void.class, tags = {"simulator",})
+            response = void.class, tags = {"simulator",})
     @io.swagger.annotations.ApiResponses(value = {
             @io.swagger.annotations.ApiResponse(code = 200,
-                                                message = "Successfully performed action on the feed simulation "
-                                                        + "configuration",
-                                                response = void.class),
+                    message = "Successfully performed action on the feed simulation "
+                            + "configuration",
+                    response = void.class),
             @io.swagger.annotations.ApiResponse(code = 400,
-                                                message = "Invalid action specified for simulation. Actions supported"
-                                                        + " are run, pause, resume, stop.",
-                                                response = void.class)})
+                    message = "Invalid action specified for simulation. Actions supported"
+                            + " are run, pause, resume, stop.",
+                    response = void.class)})
     public Response operateFeedSimulation(
+            @Context Request request,
             @ApiParam(value = "Action to be perform on the feed simulation eg: run, pause, resume, stop",
-                      required =  true)
+                    required = true)
             @QueryParam("action") String action,
             @ApiParam(value = "Simulation name to execute the action on the configuration.", required = true)
             @PathParam("simulationName") String simulationName)
             throws NotFoundException {
-        return delegate.operateFeedSimulation(action, simulationName);
+        return delegate.operateFeedSimulation(action, simulationName, request);
     }
 
     @PUT
@@ -126,38 +136,42 @@ public class FeedApi implements Microservice {
     @Consumes({"text/plain"})
     @Produces({"application/json"})
     @io.swagger.annotations.ApiOperation(value = "Update an uploaded simulation configuration",
-                                         notes = "Some description", response = InlineResponse200.class,
-                                         tags = {"simulator",})
+            notes = "Some description", response = InlineResponse200.class,
+            tags = {"simulator",})
     @io.swagger.annotations.ApiResponses(value = {
             @io.swagger.annotations.ApiResponse(code = 200, message = "Successfully updated simulation configuration.",
-                                                response = InlineResponse200.class),
+                    response = InlineResponse200.class),
             @io.swagger.annotations.ApiResponse(code = 404,
-                                                message = "No event simulation configuration available under "
-                                                        + "simulation name",
-                                                response = InlineResponse200.class)})
-    public Response updateFeedSimulation(@ApiParam(value = "Feed Simulation configuration name", required = true)
-                                         @PathParam("simulationName") String simulationName,
-                                         @ApiParam(value = "Simulation object which is need to be updated",
-                                                   required = true) String body) throws NotFoundException {
-        return delegate.updateFeedSimulation(simulationName, body);
+                    message = "No event simulation configuration available under "
+                            + "simulation name",
+                    response = InlineResponse200.class)})
+    public Response updateFeedSimulation(
+            @Context Request request,
+            @ApiParam(value = "Feed Simulation configuration name", required = true)
+            @PathParam("simulationName") String simulationName,
+            @ApiParam(value = "Simulation object which is need to be updated",
+                    required = true) String body) throws NotFoundException {
+        return delegate.updateFeedSimulation(simulationName, body, request);
     }
 
     @GET
     @Path("/{simulationName}/status")
-    @Produces({ "application/json" })
+    @Produces({"application/json"})
     @io.swagger.annotations.ApiOperation(value = "Retrieve a simulation configuration statusby name.",
-                                         notes = "Some desc", response = String.class, tags={ "simulator", })
+            notes = "Some desc", response = String.class, tags = {"simulator",})
     @io.swagger.annotations.ApiResponses(value = {
             @io.swagger.annotations.ApiResponse(code = 200, message = "Successfully sent simulation status.",
-                                                response = String.class),
+                    response = String.class),
 
             @io.swagger.annotations.ApiResponse(code = 404,
-                                                message = "No simulation configuration available under simulation name",
-                                                response = String.class) })
-    public Response getFeedSimulationStatus(@ApiParam(value = "Simulation name to get the configuration.",
-                                                      required=true) @PathParam("simulationName") String simulationName)
+                    message = "No simulation configuration available under simulation name",
+                    response = String.class)})
+    public Response getFeedSimulationStatus(
+            @Context Request request,
+            @ApiParam(value = "Simulation name to get the configuration.", required = true)
+            @PathParam("simulationName") String simulationName)
             throws NotFoundException {
-        return delegate.getFeedSimulationStatus(simulationName);
+        return delegate.getFeedSimulationStatus(simulationName, request);
     }
 
     /**

--- a/components/org.wso2.carbon.event.simulator.core/src/gen/java/org/wso2/carbon/event/simulator/core/api/FeedApiService.java
+++ b/components/org.wso2.carbon.event.simulator.core/src/gen/java/org/wso2/carbon/event/simulator/core/api/FeedApiService.java
@@ -1,22 +1,25 @@
 package org.wso2.carbon.event.simulator.core.api;
 
+import org.wso2.msf4j.Request;
+
 import javax.ws.rs.core.Response;
 
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaMSF4JServerCodegen",
-                            date = "2017-07-20T09:30:14.336Z")
+        date = "2017-07-20T09:30:14.336Z")
 public abstract class FeedApiService {
-    public abstract Response addFeedSimulation(String body) throws NotFoundException;
 
-    public abstract Response deleteFeedSimulation(String simulationName) throws NotFoundException;
+    public abstract Response addFeedSimulation(String body, Request request) throws NotFoundException;
 
-    public abstract Response getFeedSimulation(String simulationName) throws NotFoundException;
+    public abstract Response deleteFeedSimulation(String simulationName, Request request) throws NotFoundException;
 
-    public abstract Response getFeedSimulations() throws NotFoundException;
+    public abstract Response getFeedSimulation(String simulationName, Request request) throws NotFoundException;
 
-    public abstract Response operateFeedSimulation(String action, String simulationName) throws NotFoundException;
+    public abstract Response getFeedSimulations(Request request) throws NotFoundException;
 
-    public abstract Response updateFeedSimulation(String simulationName, String body) throws NotFoundException;
+    public abstract Response operateFeedSimulation(String action, String simulationName, Request request) throws NotFoundException;
 
-    public abstract Response getFeedSimulationStatus(String simulationName) throws NotFoundException;
+    public abstract Response updateFeedSimulation(String simulationName, String body, Request request) throws NotFoundException;
+
+    public abstract Response getFeedSimulationStatus(String simulationName, Request request) throws NotFoundException;
 
 }

--- a/components/org.wso2.carbon.event.simulator.core/src/gen/java/org/wso2/carbon/event/simulator/core/api/FilesApi.java
+++ b/components/org.wso2.carbon.event.simulator.core/src/gen/java/org/wso2/carbon/event/simulator/core/api/FilesApi.java
@@ -13,6 +13,7 @@ import org.wso2.carbon.event.simulator.core.service.EventSimulatorDataHolder;
 import org.wso2.carbon.event.simulator.core.service.EventSimulatorMap;
 import org.wso2.carbon.utils.Utils;
 import org.wso2.msf4j.Microservice;
+import org.wso2.msf4j.Request;
 import org.wso2.msf4j.formparam.FileInfo;
 import org.wso2.msf4j.formparam.FormDataParam;
 
@@ -26,6 +27,7 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
 import io.swagger.annotations.ApiParam;
@@ -41,41 +43,44 @@ import org.wso2.msf4j.interceptor.annotation.RequestInterceptor;
 @RequestInterceptor(AuthenticationInterceptor.class)
 @io.swagger.annotations.Api(description = "the files API")
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaMSF4JServerCodegen",
-                            date = "2017-07-20T09:30:14.336Z")
+        date = "2017-07-20T09:30:14.336Z")
 public class FilesApi implements Microservice {
     private final FilesApiService delegate = FilesApiServiceFactory.getFilesApi();
     private static final Logger log = LoggerFactory.getLogger(FilesApi.class);
+
     @DELETE
     @Path("/{fileName}")
     @Produces({"application/json"})
     @io.swagger.annotations.ApiOperation(value = "Update CSV file to simulate event flow", notes = "",
-                                         response = void.class, tags = {"simulator",})
+            response = void.class, tags = {"simulator",})
     @io.swagger.annotations.ApiResponses(value = {
             @io.swagger.annotations.ApiResponse(code = 200, message = "Successfully deleted the csv file",
-                                                response = void.class),
+                    response = void.class),
 
             @io.swagger.annotations.ApiResponse(code = 404,
-                                                message = "No event simulation configuration available under "
-                                                        + "simulation name",
-                                                response = void.class)})
-    public Response deleteFile( @ApiParam(value = "CSV File for name to delete", required = true)
-                                @PathParam("fileName") String fileName) throws NotFoundException {
-        return delegate.deleteFile(fileName);
+                    message = "No event simulation configuration available under "
+                            + "simulation name",
+                    response = void.class)})
+    public Response deleteFile(
+            @Context Request request,
+            @ApiParam(value = "CSV File for name to delete", required = true)
+            @PathParam("fileName") String fileName) throws NotFoundException {
+        return delegate.deleteFile(fileName, request);
     }
 
     @GET
     @Produces({"application/json"})
     @io.swagger.annotations.ApiOperation(value = "Get CSV file names", notes = "", response = InlineResponse2001.class,
-                                         tags = {"simulator",})
+            tags = {"simulator",})
     @io.swagger.annotations.ApiResponses(value = {
             @io.swagger.annotations.ApiResponse(code = 200, message = "Successfully retrieved file names",
-                                                response = InlineResponse2001.class),
+                    response = InlineResponse2001.class),
             @io.swagger.annotations.ApiResponse(code = 404,
-                                                message = "No event simulation configuration available under "
-                                                        + "simulation name",
-                                                response = InlineResponse2001.class)})
-    public Response getFileNames() throws NotFoundException {
-        return delegate.getFileNames();
+                    message = "No event simulation configuration available under "
+                            + "simulation name",
+                    response = InlineResponse2001.class)})
+    public Response getFileNames(@Context Request request) throws NotFoundException {
+        return delegate.getFileNames(request);
     }
 
     @PUT
@@ -83,39 +88,42 @@ public class FilesApi implements Microservice {
     @Consumes({"multipart/form-data"})
     @Produces({"application/json"})
     @io.swagger.annotations.ApiOperation(value = "Update CSV file to simulate event flow", notes = "",
-                                         response = void.class, tags = {"simulator",})
+            response = void.class, tags = {"simulator",})
     @io.swagger.annotations.ApiResponses(value = {
             @io.swagger.annotations.ApiResponse(code = 200, message = "Successfully updated the csv file",
-                                                response = void.class),
+                    response = void.class),
 
             @io.swagger.annotations.ApiResponse(code = 404,
-                                                message = "No event simulation configuration available under "
-                                                        + "simulation name",
-                                                response = void.class)})
-    public Response updateFile(@ApiParam(value = "CSV File for name to update", required = true)
-                                   @PathParam("fileName") String fileName,
-                               @FormDataParam("file") InputStream fileInputStream,
-                               @FormDataParam("file") FileInfo fileDetail)
+                    message = "No event simulation configuration available under "
+                            + "simulation name",
+                    response = void.class)})
+    public Response updateFile(
+            @Context Request request,
+            @ApiParam(value = "CSV File for name to update", required = true)
+            @PathParam("fileName") String fileName,
+            @FormDataParam("file") InputStream fileInputStream,
+            @FormDataParam("file") FileInfo fileDetail)
             throws NotFoundException {
-        return delegate.updateFile(fileName, fileInputStream, fileDetail);
+        return delegate.updateFile(fileName, fileInputStream, fileDetail, request);
     }
 
     @POST
     @Consumes({"multipart/form-data"})
     @Produces({"application/json"})
     @io.swagger.annotations.ApiOperation(value = "Upload CSV file to simulate event flow", notes = "",
-                                         response = void.class, tags = {"simulator",})
+            response = void.class, tags = {"simulator",})
     @io.swagger.annotations.ApiResponses(value = {
             @io.swagger.annotations.ApiResponse(code = 200, message = "Successfully uploaded file",
-                                                response = void.class),
+                    response = void.class),
 
             @io.swagger.annotations.ApiResponse(code = 404,
-                                                message = "No event simulation configuration available under simulation name",
-                                                response = void.class)})
+                    message = "No event simulation configuration available under simulation name",
+                    response = void.class)})
     public Response uploadFile(
+            @Context Request request,
             @FormDataParam("file") InputStream fileInputStream,
             @FormDataParam("file") FileInfo fileDetail) throws NotFoundException {
-        return delegate.uploadFile(fileInputStream, fileDetail);
+        return delegate.uploadFile(fileInputStream, fileDetail, request);
     }
 
     /**
@@ -128,7 +136,7 @@ public class FilesApi implements Microservice {
         //set maximum csv file size to 8MB
         EventSimulatorDataHolder.getInstance().setMaximumFileSize(8388608);
         EventSimulatorDataHolder.getInstance().setCsvFileDirectory(Paths.get(Utils.getRuntimePath().toString(),
-            EventSimulatorConstants.DIRECTORY_DEPLOYMENT, EventSimulatorConstants.DIRECTORY_CSV_FILES).toString());
+                EventSimulatorConstants.DIRECTORY_DEPLOYMENT, EventSimulatorConstants.DIRECTORY_CSV_FILES).toString());
         if (log.isDebugEnabled()) {
             log.debug("Event Simulator file service component is activated");
         }

--- a/components/org.wso2.carbon.event.simulator.core/src/gen/java/org/wso2/carbon/event/simulator/core/api/FilesApiService.java
+++ b/components/org.wso2.carbon.event.simulator.core/src/gen/java/org/wso2/carbon/event/simulator/core/api/FilesApiService.java
@@ -3,6 +3,7 @@ package org.wso2.carbon.event.simulator.core.api;
 import org.wso2.carbon.event.simulator.core.api.*;
 import org.wso2.carbon.event.simulator.core.model.*;
 
+import org.wso2.msf4j.Request;
 import org.wso2.msf4j.formparam.FormDataParam;
 import org.wso2.msf4j.formparam.FileInfo;
 
@@ -20,14 +21,15 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaMSF4JServerCodegen",
-                            date = "2017-07-20T09:30:14.336Z")
+        date = "2017-07-20T09:30:14.336Z")
 public abstract class FilesApiService {
-    public abstract Response deleteFile(String fileName) throws NotFoundException;
 
-    public abstract Response getFileNames() throws NotFoundException;
+    public abstract Response deleteFile(String fileName, Request request) throws NotFoundException;
 
-    public abstract Response updateFile(String fileName, InputStream fileInputStream, FileInfo fileDetail)
+    public abstract Response getFileNames(Request request) throws NotFoundException;
+
+    public abstract Response updateFile(String fileName, InputStream fileInputStream, FileInfo fileDetail, Request request)
             throws NotFoundException;
 
-    public abstract Response uploadFile(InputStream fileInputStream, FileInfo fileDetail) throws NotFoundException;
+    public abstract Response uploadFile(InputStream fileInputStream, FileInfo fileDetail, Request request) throws NotFoundException;
 }

--- a/components/org.wso2.carbon.event.simulator.core/src/main/java/org/wso2/carbon/event/simulator/core/impl/DatabaseApiServiceImpl.java
+++ b/components/org.wso2.carbon.event.simulator.core/src/main/java/org/wso2/carbon/event/simulator/core/impl/DatabaseApiServiceImpl.java
@@ -20,11 +20,15 @@ package org.wso2.carbon.event.simulator.core.impl;
 
 import com.zaxxer.hikari.HikariDataSource;
 import com.zaxxer.hikari.pool.PoolInitializationException;
+import org.wso2.carbon.analytics.permissions.PermissionProvider;
+import org.wso2.carbon.analytics.permissions.bean.Permission;
 import org.wso2.carbon.event.simulator.core.api.DatabaseApiService;
 import org.wso2.carbon.event.simulator.core.api.NotFoundException;
 import org.wso2.carbon.event.simulator.core.internal.generator.database.util.DatabaseConnector;
 import org.wso2.carbon.event.simulator.core.model.DBConnectionModel;
+import org.wso2.carbon.event.simulator.core.service.EventSimulatorDataHolder;
 import org.wso2.carbon.stream.processor.common.exception.ResponseMapper;
+import org.wso2.msf4j.Request;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -35,7 +39,11 @@ import javax.ws.rs.core.Response;
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaMSF4JServerCodegen",
                             date = "2017-07-20T09:30:14.336Z")
 public class DatabaseApiServiceImpl extends DatabaseApiService {
-    @Override
+
+    private static final String PERMISSION_APP_NAME = "SIM";
+    private static final String MANAGE_SIMULATOR_PERMISSION_STRING = "simulator.manage";
+    private static final String VIEW_SIMULATOR_PERMISSION_STRING = "simulator.view";
+
     public Response getDatabaseTableColumns(DBConnectionModel connectionDetails,
                                             String tableName) throws NotFoundException {
         try {
@@ -54,7 +62,6 @@ public class DatabaseApiServiceImpl extends DatabaseApiService {
         }
     }
 
-    @Override
     public Response getDatabaseTables(DBConnectionModel connectionDetails) throws NotFoundException {
         try {
             List<String> tableNames = DatabaseConnector.retrieveTableNames(connectionDetails);
@@ -72,7 +79,6 @@ public class DatabaseApiServiceImpl extends DatabaseApiService {
         }
     }
 
-    @Override
     public Response testDBConnection(DBConnectionModel connectionDetails) throws NotFoundException {
         try {
             HikariDataSource dataSource = DatabaseConnector.initializeDatasource(connectionDetails);
@@ -93,5 +99,47 @@ public class DatabaseApiServiceImpl extends DatabaseApiService {
                     .entity(new ResponseMapper(Response.Status.INTERNAL_SERVER_ERROR, e.getMessage()))
                     .build();
         }
+    }
+
+    @Override
+    public Response getDatabaseTableColumns(DBConnectionModel body, String tableName, Request request) throws NotFoundException {
+        if (getUserName(request) != null && !(getPermissionProvider().hasPermission(getUserName(request), new Permission
+                (PERMISSION_APP_NAME, MANAGE_SIMULATOR_PERMISSION_STRING)) || getPermissionProvider().hasPermission
+                (getUserName(request), new Permission(PERMISSION_APP_NAME, VIEW_SIMULATOR_PERMISSION_STRING)))) {
+            return Response.status(Response.Status.UNAUTHORIZED).entity("Insufficient permission to perform the action")
+                    .build();
+        }
+        return getDatabaseTableColumns(body, tableName);
+    }
+
+    @Override
+    public Response getDatabaseTables(DBConnectionModel body, Request request) throws NotFoundException {
+        if (getUserName(request) != null && !(getPermissionProvider().hasPermission(getUserName(request), new Permission
+                (PERMISSION_APP_NAME, MANAGE_SIMULATOR_PERMISSION_STRING)) || getPermissionProvider().hasPermission
+                (getUserName(request), new Permission(PERMISSION_APP_NAME, VIEW_SIMULATOR_PERMISSION_STRING)))) {
+            return Response.status(Response.Status.UNAUTHORIZED).entity("Insufficient permission to perform the action")
+                    .build();
+        }
+        return getDatabaseTables(body);
+    }
+
+    @Override
+    public Response testDBConnection(DBConnectionModel body, Request request) throws NotFoundException {
+        if (getUserName(request) != null && !(getPermissionProvider().hasPermission(getUserName(request), new Permission
+                (PERMISSION_APP_NAME, MANAGE_SIMULATOR_PERMISSION_STRING)) || getPermissionProvider().hasPermission
+                (getUserName(request), new Permission(PERMISSION_APP_NAME, VIEW_SIMULATOR_PERMISSION_STRING)))) {
+            return Response.status(Response.Status.UNAUTHORIZED).entity("Insufficient permission to perform the action")
+                    .build();
+        }
+        return testDBConnection(body);
+    }
+
+    private static String getUserName(Request request) {
+        Object username = request.getProperty("username");
+        return username != null ? username.toString() : null;
+    }
+
+    private PermissionProvider getPermissionProvider() {
+        return EventSimulatorDataHolder.getPermissionProvider();
     }
 }

--- a/components/org.wso2.carbon.event.simulator.core/src/main/java/org/wso2/carbon/event/simulator/core/service/EventSimulatorDataHolder.java
+++ b/components/org.wso2.carbon.event.simulator.core/src/main/java/org/wso2/carbon/event/simulator/core/service/EventSimulatorDataHolder.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.event.simulator.core.service;
 
+import org.wso2.carbon.analytics.permissions.PermissionProvider;
 import org.wso2.carbon.stream.processor.common.EventStreamService;
 
 /**
@@ -28,6 +29,7 @@ public class EventSimulatorDataHolder {
     private long maximumFileSize;
     private String csvFileDirectory;
     private EventStreamService eventStreamService;
+    private static PermissionProvider permissionProvider;
 
 
     private EventSimulatorDataHolder() {
@@ -59,5 +61,13 @@ public class EventSimulatorDataHolder {
 
     public void setCsvFileDirectory(String csvFileDirectory) {
         this.csvFileDirectory = csvFileDirectory;
+    }
+
+    public static PermissionProvider getPermissionProvider() {
+        return EventSimulatorDataHolder.permissionProvider;
+    }
+
+    public static void setPermissionProvider(PermissionProvider permissionProvider) {
+        EventSimulatorDataHolder.permissionProvider = permissionProvider;
     }
 }

--- a/components/org.wso2.carbon.event.simulator.core/src/main/java/org/wso2/carbon/event/simulator/core/service/EventSimulatorServiceComponent.java
+++ b/components/org.wso2.carbon.event.simulator.core/src/main/java/org/wso2/carbon/event/simulator/core/service/EventSimulatorServiceComponent.java
@@ -1,0 +1,29 @@
+package org.wso2.carbon.event.simulator.core.service;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.analytics.permissions.PermissionManager;
+import org.wso2.carbon.stream.processor.core.internal.StreamProcessorDataHolder;
+
+@Component(
+        name = "Event-Simulator-Service Component",
+        immediate = true
+)
+public class EventSimulatorServiceComponent {
+    @Reference(
+            name = "permission-manager",
+            service = PermissionManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetPermissionManager"
+    )
+    protected void setPermissionManager(PermissionManager permissionManager) {
+        EventSimulatorDataHolder.setPermissionProvider(permissionManager.getProvider());
+    }
+
+    protected void unsetPermissionManager(PermissionManager permissionManager) {
+        EventSimulatorDataHolder.setPermissionProvider(null);
+    }
+}

--- a/components/org.wso2.carbon.event.simulator.core/src/main/java/org/wso2/carbon/event/simulator/core/service/EventSimulatorServiceComponent.java
+++ b/components/org.wso2.carbon.event.simulator.core/src/main/java/org/wso2/carbon/event/simulator/core/service/EventSimulatorServiceComponent.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.event.simulator.core.service;
 
 import org.osgi.service.component.annotations.Component;
@@ -5,7 +23,6 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.analytics.permissions.PermissionManager;
-import org.wso2.carbon.stream.processor.core.internal.StreamProcessorDataHolder;
 
 @Component(
         name = "Event-Simulator-Service Component",

--- a/components/org.wso2.carbon.permissions.rest.api/src/gen/java/org/wso2/carbon/permissions/rest/api/PermissionsApi.java
+++ b/components/org.wso2.carbon.permissions.rest.api/src/gen/java/org/wso2/carbon/permissions/rest/api/PermissionsApi.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.permissions.rest.api.factories.PermissionsApiServiceFacto
 import org.wso2.carbon.permissions.rest.api.model.Permission;
 import org.wso2.msf4j.Microservice;
 
+import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -42,19 +43,17 @@ import javax.ws.rs.core.Response;
         immediate = true
 )
 @Path("/permissions")
-@Consumes({"application/json", "application/xml"})
-@Produces({"application/xml", "application/json"})
+@Consumes({"application/json"})
+@Produces({"application/xml"})
+@ApplicationPath("/permissions")
 @io.swagger.annotations.Api(description = "the permissions API")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaMSF4JServerCodegen",
-        date = "2017-12-07T14:05:52.168Z")
 public class PermissionsApi implements Microservice {
     private static final Logger log = LoggerFactory.getLogger(PermissionsApi.class);
     private final PermissionsApiService delegate = PermissionsApiServiceFactory.getPermissionsApi();
 
     @POST
-
     @Consumes({"application/json"})
-    @Produces({"application/xml", "application/json"})
+    @Produces({"application/json"})
     @io.swagger.annotations.ApiOperation(value = "", notes = "Add a new permission and returns its PermissionID",
             response = String.class, tags = {"permission",})
     @io.swagger.annotations.ApiResponses(value = {
@@ -70,8 +69,8 @@ public class PermissionsApi implements Microservice {
 
     @DELETE
     @Path("/{permissionID}")
-    @Consumes({"application/json", "application/xml"})
-    @Produces({"application/xml", "application/json"})
+    @Consumes({"application/json"})
+    @Produces({"application/json"})
     @io.swagger.annotations.ApiOperation(value = "", notes = "Deleting an existing permission", response = void.class,
             tags = {"permission",})
     @io.swagger.annotations.ApiResponses(value = {
@@ -87,8 +86,8 @@ public class PermissionsApi implements Microservice {
 
     @GET
     @Path("/{permissionID}/roles")
-    @Consumes({"application/json", "application/xml"})
-    @Produces({"application/xml", "application/json"})
+    @Consumes({"application/json"})
+    @Produces({"application/json"})
     @io.swagger.annotations.ApiOperation(value = "", notes = "Get granted roles for PermissionID.",
             response = void.class, tags = {"permission",})
     @io.swagger.annotations.ApiResponses(value = {
@@ -103,7 +102,7 @@ public class PermissionsApi implements Microservice {
 
     @GET
     @Path("/app/{appName}")
-    @Consumes({"application/json", "application/xml"})
+    @Consumes({"application/json"})
     @Produces({"application/json"})
     @io.swagger.annotations.ApiOperation(value = "", notes = "Get app permissions", response = void.class,
             tags = {"permission",})
@@ -112,15 +111,16 @@ public class PermissionsApi implements Microservice {
                     response = void.class),
             @io.swagger.annotations.ApiResponse(code = 404, message = "Deleting permission unsuccessful",
                     response = void.class)})
-    public Response getPermissionStrings(@ApiParam(value = "", required = true) @PathParam("appName") String appName)
+    public Response getPermissionStrings(@ApiParam(value = "AppName", required = true)
+                                             @PathParam("appName") String appName)
             throws org.wso2.carbon.permissions.rest.api.NotFoundException {
         return delegate.getPermissionStrings(appName);
     }
 
-    @POST
-    @Path("/{permissionID}}/{roleName}")
-    @Consumes({"application/json", "application/xml"})
-    @Produces({"application/xml", "application/json"})
+    @GET
+    @Path("auth/{permissionID}/{roleName}")
+    @Consumes({"application/json"})
+    @Produces({"application/json"})
     @io.swagger.annotations.ApiOperation(value = "", notes = "Check permission for a specific role.",
             response = void.class, tags = {"permission",})
     @io.swagger.annotations.ApiResponses(value = {
@@ -137,8 +137,8 @@ public class PermissionsApi implements Microservice {
 
     @POST
     @Path("/roles/{roleName}")
-    @Consumes({"application/json", "application/xml"})
-    @Produces({"application/xml", "application/json"})
+    @Consumes({"application/json"})
+    @Produces({"application/json"})
     @io.swagger.annotations.ApiOperation(value = "", notes = "Grant/Revoke permission from a specific role.",
             response = void.class, tags = {"permission",})
     @io.swagger.annotations.ApiResponses(value = {
@@ -156,9 +156,9 @@ public class PermissionsApi implements Microservice {
     }
 
     @POST
-    @Path("/{permissionID}/revoke")
-    @Consumes({"application/json", "application/xml"})
-    @Produces({"application/xml", "application/json"})
+    @Path("revoke/{permissionID}")
+    @Consumes({"application/json"})
+    @Produces({"application/json"})
     @io.swagger.annotations.ApiOperation(value = "", notes = "Revoke permission for all the roles.",
             response = void.class, tags = {"permission",})
     @io.swagger.annotations.ApiResponses(value = {

--- a/components/org.wso2.carbon.permissions.rest.api/src/main/java/org/wso2/carbon/permissions/rest/api/impl/PermissionsApiServiceImpl.java
+++ b/components/org.wso2.carbon.permissions.rest.api/src/main/java/org/wso2/carbon/permissions/rest/api/impl/PermissionsApiServiceImpl.java
@@ -23,6 +23,7 @@ import com.google.gson.GsonBuilder;
 import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.wso2.carbon.analytics.permissions.PermissionProvider;
 import org.wso2.carbon.analytics.permissions.bean.PermissionString;
 import org.wso2.carbon.analytics.permissions.bean.Role;
 import org.wso2.carbon.analytics.permissions.exceptions.PermissionException;
@@ -48,11 +49,15 @@ public class PermissionsApiServiceImpl extends PermissionsApiService {
     @Override
     public Response addPermission(Permission body) throws NotFoundException {
         String permissionID = null;
+        PermissionProvider permissionProvider = DataHolder.getInstance().getPermissionProvider();
         try {
             org.wso2.carbon.analytics.permissions.bean.Permission permission =
                     new org.wso2.carbon.analytics.permissions.bean.Permission
                             (body.getAppName(), body.getPermissionString());
-            permissionID = DataHolder.getInstance().getPermissionProvider().addPermissionAPI(permission);
+            if (!permissionProvider.isPermissionExists(permission)) {
+                permissionID = permissionProvider.addPermissionAPI(permission);
+
+            }
             return Response.ok().entity(permissionID).build();
         } catch (PermissionException e) {
             String errorMsg = String.format("Failed to add Permission with uuid %s ", permissionID);

--- a/components/org.wso2.carbon.stream.processor.core/pom.xml
+++ b/components/org.wso2.carbon.stream.processor.core/pom.xml
@@ -170,6 +170,10 @@
             <groupId>org.wso2.carbon.analytics-common</groupId>
             <artifactId>org.wso2.carbon.analytics.permissions</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.analytics-common</groupId>
+            <artifactId>org.wso2.carbon.database.query.manager</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -244,6 +248,7 @@
             org.wso2.carbon.stream.processor.common.*;version="${carbon.analytics.version.range}",
             org.wso2.msf4j.*;version="${msf4j.import.version.range}",
             org.wso2.carbon.analytics.permissions.*; version="${carbon.analytics-common.version.range}",
+            org.wso2.carbon.database.query.manager.*; version="${carbon.analytics-common.version.range}",
             javax.management.*,
             javax.ws.rs.*;version="0.0.0",
             *;resolution:=optional

--- a/components/org.wso2.carbon.stream.processor.core/pom.xml
+++ b/components/org.wso2.carbon.stream.processor.core/pom.xml
@@ -165,6 +165,11 @@
             <artifactId>commons-lang3</artifactId>
             <scope>test</scope>
         </dependency>
+        <!--analytics-common dependencies-->
+        <dependency>
+            <groupId>org.wso2.carbon.analytics-common</groupId>
+            <artifactId>org.wso2.carbon.analytics.permissions</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -238,6 +243,7 @@
             org.wso2.siddhi.*;version="${siddhi.version.range}",
             org.wso2.carbon.stream.processor.common.*;version="${carbon.analytics.version.range}",
             org.wso2.msf4j.*;version="${msf4j.import.version.range}",
+            org.wso2.carbon.analytics.permissions.*; version="${carbon.analytics-common.version.range}",
             javax.management.*,
             javax.ws.rs.*;version="0.0.0",
             *;resolution:=optional

--- a/components/org.wso2.carbon.stream.processor.core/src/gen/java/org/wso2/carbon/stream/processor/core/api/SiddhiAppsApi.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/gen/java/org/wso2/carbon/stream/processor/core/api/SiddhiAppsApi.java
@@ -19,12 +19,14 @@ package org.wso2.carbon.stream.processor.core.api;
 import io.swagger.annotations.ApiParam;
 import org.osgi.service.component.annotations.Component;
 import org.wso2.carbon.analytics.msf4j.interceptor.common.AuthenticationInterceptor;
+import org.wso2.carbon.analytics.msf4j.interceptor.common.util.InterceptorConstants;
 import org.wso2.carbon.stream.processor.core.factories.SiddhiAppsApiServiceFactory;
 import org.wso2.carbon.stream.processor.core.model.InlineResponse200;
 import org.wso2.carbon.stream.processor.core.model.InlineResponse400;
 import org.wso2.carbon.stream.processor.core.model.SiddhiAppMetrics;
 import org.wso2.carbon.stream.processor.core.model.StatsEnable;
 import org.wso2.msf4j.Microservice;
+import org.wso2.msf4j.Request;
 import org.wso2.msf4j.interceptor.annotation.RequestInterceptor;
 
 import javax.ws.rs.Consumes;
@@ -36,6 +38,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
 /**
@@ -70,9 +73,11 @@ public class SiddhiAppsApi implements Microservice {
                     "already exists.", response = InlineResponse400.class),
             @io.swagger.annotations.ApiResponse(code = 500, message = "An unexpected error occured.",
                     response = InlineResponse400.class)})
-    public Response siddhiAppsPost(@ApiParam(value = "Siddhi Application", required = true) String body)
+    public Response siddhiAppsPost(
+            @Context Request request,
+            @ApiParam(value = "Siddhi Application", required = true) String body)
             throws NotFoundException {
-        return delegate.siddhiAppsPost(body);
+        return delegate.siddhiAppsPost(body, getUserName(request));
     }
 
     @PUT
@@ -90,9 +95,11 @@ public class SiddhiAppsApi implements Microservice {
                     response = InlineResponse400.class),
             @io.swagger.annotations.ApiResponse(code = 500, message = "An unexpected error occured.",
                     response = InlineResponse400.class)})
-    public Response siddhiAppsPut(@ApiParam(value = "Siddhi Application", required = true) String body)
+    public Response siddhiAppsPut(
+            @Context Request request,
+            @ApiParam(value = "Siddhi Application", required = true) String body)
             throws NotFoundException {
-        return delegate.siddhiAppsPut(body);
+        return delegate.siddhiAppsPut(body, getUserName(request));
     }
 
     @GET
@@ -103,9 +110,10 @@ public class SiddhiAppsApi implements Microservice {
             @io.swagger.annotations.ApiResponse(code = 200, message = "The Siddhi Applications are successfully " +
                     "retrieved.", response = InlineResponse200.class)})
     public Response siddhiAppsGet(
+            @Context Request request,
             @ApiParam(value = "Retrieves only active/inactive Siddhi Applications as specified.", required = false)
             @QueryParam("isActive") String isActive) throws NotFoundException {
-        return delegate.siddhiAppsGet(isActive);
+        return delegate.siddhiAppsGet(isActive, getUserName(request));
     }
 
     @DELETE
@@ -123,9 +131,11 @@ public class SiddhiAppsApi implements Microservice {
                     response = InlineResponse400.class),
             @io.swagger.annotations.ApiResponse(code = 500, message = "An unexpected error occured.",
                     response = InlineResponse400.class)})
-    public Response siddhiAppsAppNameDelete(@ApiParam(value = "The name of the Siddhi Application", required = true)
-                                            @PathParam("appName") String appName) throws NotFoundException {
-        return delegate.siddhiAppsAppNameDelete(appName);
+    public Response siddhiAppsAppNameDelete(
+            @Context Request request,
+            @ApiParam(value = "The name of the Siddhi Application", required = true)
+            @PathParam("appName") String appName) throws NotFoundException {
+        return delegate.siddhiAppsAppNameDelete(appName, getUserName(request));
     }
 
     @GET
@@ -138,9 +148,11 @@ public class SiddhiAppsApi implements Microservice {
                     "retrieved.", response = InlineResponse200.class),
             @io.swagger.annotations.ApiResponse(code = 404, message = "The Siddhi Application specified is not found.",
                     response = InlineResponse200.class)})
-    public Response siddhiAppsAppNameGet(@ApiParam(value = "The name of the Siddhi Application", required = true)
-                                         @PathParam("appName") String appName) throws NotFoundException {
-        return delegate.siddhiAppsAppNameGet(appName);
+    public Response siddhiAppsAppNameGet(
+            @Context Request request,
+            @ApiParam(value = "The name of the Siddhi Application", required = true)
+            @PathParam("appName") String appName) throws NotFoundException {
+        return delegate.siddhiAppsAppNameGet(appName, getUserName(request));
     }
 
     @GET
@@ -153,9 +165,11 @@ public class SiddhiAppsApi implements Microservice {
                     "successfully retrieved.", response = InlineResponse200.class),
             @io.swagger.annotations.ApiResponse(code = 404, message = "The Siddhi Application specified is not found.",
                     response = InlineResponse200.class)})
-    public Response siddhiAppsAppNameStatusGet(@ApiParam(value = "The name of the Siddhi Application.", required = true)
-                                               @PathParam("appName") String appName) throws NotFoundException {
-        return delegate.siddhiAppsAppNameStatusGet(appName);
+    public Response siddhiAppsAppNameStatusGet(
+            @Context Request request,
+            @ApiParam(value = "The name of the Siddhi Application.", required = true)
+            @PathParam("appName") String appName) throws NotFoundException {
+        return delegate.siddhiAppsAppNameStatusGet(appName, getUserName(request));
     }
 
     @POST
@@ -171,10 +185,11 @@ public class SiddhiAppsApi implements Microservice {
                     response = InlineResponse400.class),
             @io.swagger.annotations.ApiResponse(code = 500, message = "An unexpected error occured.",
                     response = InlineResponse400.class)})
-    public Response siddhiAppsAppNameSnapshotPost(@ApiParam(value = "The name of the Siddhi Application.",
-            required = true)
-                                                  @PathParam("appName") String appName) throws NotFoundException {
-        return delegate.siddhiAppsAppNameBackupPost(appName);
+    public Response siddhiAppsAppNameSnapshotPost(
+            @Context Request request,
+            @ApiParam(value = "The name of the Siddhi Application.", required = true)
+            @PathParam("appName") String appName) throws NotFoundException {
+        return delegate.siddhiAppsAppNameBackupPost(appName, getUserName(request));
     }
 
     @POST
@@ -190,11 +205,12 @@ public class SiddhiAppsApi implements Microservice {
             @io.swagger.annotations.ApiResponse(code = 500, message = "An unexpected error occured.",
                     response = InlineResponse400.class)})
     public Response siddhiAppsAppNameRestorePost(
+            @Context Request request,
             @ApiParam(value = "The name of the Siddhi Application.", required = true)
             @PathParam("appName") String appName,
             @ApiParam(value = "The revision number of the backup.", required = false)
             @QueryParam("revision") String revision) throws NotFoundException {
-        return delegate.siddhiAppsAppNameRestorePost(appName, revision);
+        return delegate.siddhiAppsAppNameRestorePost(appName, revision, getUserName(request));
     }
 
     @GET
@@ -207,9 +223,10 @@ public class SiddhiAppsApi implements Microservice {
             @io.swagger.annotations.ApiResponse(code = 200, message = "The Siddhi Applications  statistics data are " +
                     "successfully retrieved.", response = SiddhiAppMetrics.class)})
     public Response siddhiAppsStatisticsGet(
+            @Context Request request,
             @ApiParam(value = "Retrieves only active/inactive Siddhi Applications as specified.", required = false)
             @QueryParam("isActive") String isActive) throws NotFoundException {
-        return delegate.siddhiAppsStatisticsGet(isActive);
+        return delegate.siddhiAppsStatisticsGet(isActive, getUserName(request));
     }
 
     @PUT
@@ -224,10 +241,11 @@ public class SiddhiAppsApi implements Microservice {
             @io.swagger.annotations.ApiResponse(code = 404, message = "The Siddhi Application specified is not" +
                     " found.", response = void.class)})
     public Response siddhiAppMetricsEnable(
+            @Context Request request,
             @ApiParam(value = "The name of the Siddhi Application.", required = true) @PathParam("appName") String appName,
             @ApiParam(value = "statsEnable", required = true) StatsEnable statsEnable)
             throws NotFoundException {
-        return delegate.siddhiAppStatsEnable(appName, statsEnable.getStatsEnable());
+        return delegate.siddhiAppStatsEnable(appName, statsEnable.getStatsEnable(), getUserName(request));
     }
 
     @PUT
@@ -242,8 +260,13 @@ public class SiddhiAppsApi implements Microservice {
             @io.swagger.annotations.ApiResponse(code = 404, message = "The Siddhi Application specified is not" +
                     " found.", response = void.class)})
     public Response siddhiAllAppMetricsEnable(
+            @Context Request request,
             @ApiParam(value = "statsEnable", required = true) StatsEnable statsEnable)
             throws NotFoundException {
-        return delegate.siddhiAppsStatsEnable(statsEnable.getStatsEnable());
+        return delegate.siddhiAppsStatsEnable(statsEnable.getStatsEnable(), getUserName(request));
+    }
+
+    private static String getUserName(Request request) {
+        return request.getProperty(InterceptorConstants.PROPERTY_USERNAME).toString();
     }
 }

--- a/components/org.wso2.carbon.stream.processor.core/src/gen/java/org/wso2/carbon/stream/processor/core/api/SiddhiAppsApiService.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/gen/java/org/wso2/carbon/stream/processor/core/api/SiddhiAppsApiService.java
@@ -27,27 +27,27 @@ import javax.ws.rs.core.Response;
         date = "2017-05-31T15:43:24.557Z")
 public abstract class SiddhiAppsApiService {
 
-    public abstract Response siddhiAppsAppNameDelete(String appName) throws NotFoundException;
+    public abstract Response siddhiAppsAppNameDelete(String appName, String username) throws NotFoundException;
 
-    public abstract Response siddhiAppsAppNameGet(String appName) throws NotFoundException;
+    public abstract Response siddhiAppsAppNameGet(String appName, String username) throws NotFoundException;
 
-    public abstract Response siddhiAppsAppNameStatusGet(String appName) throws NotFoundException;
+    public abstract Response siddhiAppsAppNameStatusGet(String appName, String username) throws NotFoundException;
 
-    public abstract Response siddhiAppsAppNameRestorePost(String appName, String revision) throws NotFoundException;
+    public abstract Response siddhiAppsAppNameRestorePost(String appName, String revision, String username) throws NotFoundException;
 
-    public abstract Response siddhiAppsAppNameBackupPost(String appName) throws NotFoundException;
+    public abstract Response siddhiAppsAppNameBackupPost(String appName, String username) throws NotFoundException;
 
-    public abstract Response siddhiAppsGet(String isActive) throws NotFoundException;
+    public abstract Response siddhiAppsGet(String isActive, String username) throws NotFoundException;
 
-    public abstract Response siddhiAppsPost(String body) throws NotFoundException;
+    public abstract Response siddhiAppsPost(String body, String username) throws NotFoundException;
 
-    public abstract Response siddhiAppsPut(String body) throws NotFoundException;
+    public abstract Response siddhiAppsPut(String body, String username) throws NotFoundException;
 
-    public abstract Response siddhiAppsStatisticsGet(String isActive) throws NotFoundException;
+    public abstract Response siddhiAppsStatisticsGet(String isActive, String username) throws NotFoundException;
 
-    public abstract Response siddhiAppStatsEnable(String appName, boolean statsEnabled) throws
+    public abstract Response siddhiAppStatsEnable(String appName, boolean statsEnabled, String username) throws
             NotFoundException;
 
-    public abstract Response siddhiAppsStatsEnable(boolean statsEnabled) throws
+    public abstract Response siddhiAppsStatsEnable(boolean statsEnabled, String username) throws
             NotFoundException;
 }

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/impl/SiddhiAppsApiServiceImpl.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/impl/SiddhiAppsApiServiceImpl.java
@@ -147,8 +147,9 @@ public class SiddhiAppsApiServiceImpl extends SiddhiAppsApiService {
         String jsonString;
         boolean isActiveValue;
 
-        if (!getPermissionProvider().hasPermission(username, new Permission(PERMISSION_APP_NAME,
-                VIEW_SIDDHI_APP_PERMISSION_STRING))) {
+        if (!(getPermissionProvider().hasPermission(username, new Permission(PERMISSION_APP_NAME,
+                VIEW_SIDDHI_APP_PERMISSION_STRING)) || getPermissionProvider().hasPermission(username, new Permission
+                (PERMISSION_APP_NAME, MANAGE_SIDDHI_APP_PERMISSION_STRING)))) {
             return Response.status(Response.Status.UNAUTHORIZED).entity("Insufficient permissions to list Siddhi Apps")
                     .build();
         }
@@ -214,8 +215,9 @@ public class SiddhiAppsApiServiceImpl extends SiddhiAppsApiService {
 
         String jsonString;
 
-        if (!getPermissionProvider().hasPermission(username, new Permission(PERMISSION_APP_NAME,
-                VIEW_SIDDHI_APP_PERMISSION_STRING))) {
+        if (!(getPermissionProvider().hasPermission(username, new Permission(PERMISSION_APP_NAME,
+                VIEW_SIDDHI_APP_PERMISSION_STRING)) || getPermissionProvider().hasPermission(username, new Permission
+                (PERMISSION_APP_NAME, MANAGE_SIDDHI_APP_PERMISSION_STRING)))) {
             return Response.status(Response.Status.UNAUTHORIZED).entity("Insufficient permissions to get Siddhi App"
                     + appName).build();
         }
@@ -242,8 +244,9 @@ public class SiddhiAppsApiServiceImpl extends SiddhiAppsApiService {
 
         String jsonString;
 
-        if (!getPermissionProvider().hasPermission(username, new Permission(PERMISSION_APP_NAME,
-                VIEW_SIDDHI_APP_PERMISSION_STRING))) {
+        if (!(getPermissionProvider().hasPermission(username, new Permission(PERMISSION_APP_NAME,
+                VIEW_SIDDHI_APP_PERMISSION_STRING)) || getPermissionProvider().hasPermission(username, new Permission
+                (PERMISSION_APP_NAME, MANAGE_SIDDHI_APP_PERMISSION_STRING)))) {
             return Response.status(Response.Status.UNAUTHORIZED).entity("Insufficient permissions to get status of " +
                     "the Siddhi App " + appFileName).build();
         }
@@ -352,8 +355,9 @@ public class SiddhiAppsApiServiceImpl extends SiddhiAppsApiService {
         String jsonString;
         boolean isActiveValue;
 
-        if (!getPermissionProvider().hasPermission(username, new Permission(PERMISSION_APP_NAME,
-                VIEW_SIDDHI_APP_PERMISSION_STRING))) {
+        if (!(getPermissionProvider().hasPermission(username, new Permission(PERMISSION_APP_NAME,
+                VIEW_SIDDHI_APP_PERMISSION_STRING)) || getPermissionProvider().hasPermission(username, new Permission
+                (PERMISSION_APP_NAME, MANAGE_SIDDHI_APP_PERMISSION_STRING)))) {
             return Response.status(Response.Status.UNAUTHORIZED).entity("Insufficient permissions to get the stats of" +
                     " Siddhi Apps").build();
         }

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/ServiceComponent.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/ServiceComponent.java
@@ -27,6 +27,8 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.wso2.carbon.analytics.permissions.PermissionManager;
+import org.wso2.carbon.analytics.permissions.PermissionProvider;
 import org.wso2.carbon.cluster.coordinator.service.ClusterCoordinator;
 import org.wso2.carbon.config.ConfigurationException;
 import org.wso2.carbon.config.provider.ConfigProvider;
@@ -400,6 +402,21 @@ public class ServiceComponent {
 
     protected void unregisterMetricsManager(MetricsServiceComponent serviceComponent) {
         //do nothing
+    }
+
+    @Reference(
+            name = "permission-manager",
+            service = PermissionManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetPermissionManager"
+    )
+    protected void setPermissionManager(PermissionManager permissionManager) {
+        StreamProcessorDataHolder.setPermissionProvider(permissionManager.getProvider());
+    }
+
+    protected void unsetPermissionManager(PermissionManager permissionManager) {
+        StreamProcessorDataHolder.setPermissionProvider(null);
     }
 
 }

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/StreamProcessorDataHolder.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/StreamProcessorDataHolder.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.stream.processor.core.internal;
 
 import org.osgi.framework.BundleContext;
+import org.wso2.carbon.analytics.permissions.PermissionProvider;
 import org.wso2.carbon.cluster.coordinator.service.ClusterCoordinator;
 import org.wso2.carbon.config.provider.ConfigProvider;
 import org.wso2.carbon.datasource.core.api.DataSourceService;
@@ -51,6 +52,7 @@ public class StreamProcessorDataHolder {
     private static NodeInfo nodeInfo;
     private static DistributionService distributionService;
     private static RecordTableHandlerManager recordTableHandlerManager;
+    private static PermissionProvider permissionProvider;
     private CarbonRuntime carbonRuntime;
     private SiddhiAppProcessorConstants.RuntimeMode runtimeMode = SiddhiAppProcessorConstants.RuntimeMode.ERROR;
     private BundleContext bundleContext;
@@ -206,5 +208,13 @@ public class StreamProcessorDataHolder {
 
     public void setConfigProvider(ConfigProvider configProvider) {
         this.configProvider = configProvider;
+    }
+
+    public static PermissionProvider getPermissionProvider() {
+        return StreamProcessorDataHolder.permissionProvider;
+    }
+
+    public static void setPermissionProvider(PermissionProvider permissionProvider) {
+        StreamProcessorDataHolder.permissionProvider = permissionProvider;
     }
 }

--- a/features/org.wso2.carbon.event.simulator.core.feature/pom.xml
+++ b/features/org.wso2.carbon.event.simulator.core.feature/pom.xml
@@ -115,6 +115,11 @@
             <artifactId>generex</artifactId>
         </dependency>
         <!--Dependencies for random event simulation ends here-->
+        <!-- Common query manager -->
+        <dependency>
+            <groupId>org.wso2.carbon.analytics-common</groupId>
+            <artifactId>org.wso2.carbon.database.query.manager</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -219,6 +224,10 @@
                                 <bundle>
                                     <symbolicName>generex</symbolicName>
                                     <version>${generex.wso2v1.version}</version>
+                                </bundle>
+                                <bundle>
+                                    <symbolicName>org.wso2.carbon.database.query.manager</symbolicName>
+                                    <version>${carbon.analytics-common.version}</version>
                                 </bundle>
                             </bundles>
                         </configuration>

--- a/features/org.wso2.carbon.permissions.rest.api.feature/pom.xml
+++ b/features/org.wso2.carbon.permissions.rest.api.feature/pom.xml
@@ -37,57 +37,6 @@
             <groupId>org.wso2.carbon.analytics</groupId>
             <artifactId>org.wso2.carbon.permissions.rest.api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.analytics-common</groupId>
-            <artifactId>org.wso2.carbon.analytics.permissions</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon</groupId>
-            <artifactId>org.wso2.carbon.core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.eclipse.osgi</groupId>
-            <artifactId>org.eclipse.osgi.services</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-        </dependency>
-
-        <!--Dependencies for event simulation begins here-->
-
-        <dependency>
-            <groupId>org.wso2.msf4j</groupId>
-            <artifactId>msf4j-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.json.wso2</groupId>
-            <artifactId>json</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.orbit.org.antlr</groupId>
-            <artifactId>antlr4-runtime</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.utils</groupId>
-            <artifactId>org.wso2.carbon.utils</artifactId>
-        </dependency>
     </dependencies>
 
     <build>
@@ -160,42 +109,6 @@
                                 <bundle>
                                     <symbolicName>org.wso2.carbon.permissions.rest.api</symbolicName>
                                     <version>${carbon.analytics.version}</version>
-                                </bundle>
-                                <bundle>
-                                    <symbolicName>org.wso2.carbon.analytics.permissions</symbolicName>
-                                    <version>${carbon.analytics-common.version}</version>
-                                </bundle>
-                                <bundle>
-                                    <symbolicName>antlr4-runtime</symbolicName>
-                                    <version>${antlr4.runtime.version}</version>
-                                </bundle>
-                                <bundle>
-                                    <symbolicName>com.google.gson</symbolicName>
-                                    <version>${gson.version}</version>
-                                </bundle>
-                                <bundle>
-                                    <symbolicName>org.wso2.carbon.stream.processor.core</symbolicName>
-                                    <version>${carbon.analytics.version}</version>
-                                </bundle>
-                                <bundle>
-                                    <symbolicName>json</symbolicName>
-                                    <version>${org.wso2.json.version}</version>
-                                </bundle>
-                                <bundle>
-                                    <symbolicName>org.apache.commons.csv</symbolicName>
-                                    <version>${apache.commons.csv.version}</version>
-                                </bundle>
-                                <bundle>
-                                    <symbolicName>org.apache.commons.fileupload</symbolicName>
-                                    <version>${apache.commons.fileupload.version}</version>
-                                </bundle>
-                                <bundle>
-                                    <symbolicName>fabricator_2.10</symbolicName>
-                                    <version>${fabricator.wso2v1.version}</version>
-                                </bundle>
-                                <bundle>
-                                    <symbolicName>generex</symbolicName>
-                                    <version>${generex.wso2v1.version}</version>
                                 </bundle>
                             </bundles>
                         </configuration>

--- a/features/org.wso2.carbon.stream.processor.core.feature/pom.xml
+++ b/features/org.wso2.carbon.stream.processor.core.feature/pom.xml
@@ -105,6 +105,11 @@
             <groupId>org.wso2.carbon.analytics</groupId>
             <artifactId>org.wso2.carbon.stream.processor.core</artifactId>
         </dependency>
+        <!-- Common query manager -->
+        <dependency>
+            <groupId>org.wso2.carbon.analytics-common</groupId>
+            <artifactId>org.wso2.carbon.database.query.manager</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -262,6 +267,10 @@
                                 <bundle>
                                     <symbolicName>org.wso2.carbon.stream.processor.core</symbolicName>
                                     <version>${carbon.analytics.version}</version>
+                                </bundle>
+                                <bundle>
+                                    <symbolicName>org.wso2.carbon.database.query.manager</symbolicName>
+                                    <version>${carbon.analytics-common.version}</version>
                                 </bundle>
                             </bundles>
                         </configuration>


### PR DESCRIPTION
## Purpose
>  This PR will introduce permission model for Siddhi REST APIs available in worker and manager runtimes.

## Goals
> Secure the Siddhi REST APIs by introducing permission model.

## Approach
> We have defined two types of permission to secure the Siddhi REST APIs as below.

1. siddhiApp.manage
2. siddhiApp.view

Users who invoke the available REST APIs, need to have appropriate permission to invoke the APIS.

## User stories
> NA
## Release note
> Introducing permission model for Siddi REST APIs.

## Documentation
> NA

## Training
> NA

## Certification
> NA

## Marketing
> Na

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> NA

## Related PRs
> NA

## Migrations (if applicable)
> NA

## Test environment
java version "1.8.0_131"
Java(TM) SE Runtime Environment (build 1.8.0_131-b11)
Java HotSpot(TM) 64-Bit Server VM (build 25.131-b11, mixed mode)
 
## Learning
> NA