### PR TITLE
Recover from a split brain situation

### DIFF
--- a/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/AnalyticsDataServiceImpl.java
+++ b/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/AnalyticsDataServiceImpl.java
@@ -58,9 +58,6 @@ import org.wso2.carbon.ntask.core.TaskInfo;
 import org.wso2.carbon.ntask.core.TaskManager;
 import org.wso2.carbon.ntask.core.service.TaskService;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
@@ -74,6 +71,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Callable;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
 
 /**
  * The implementation of {@link AnalyticsDataService}.
@@ -131,6 +131,7 @@ public class AnalyticsDataServiceImpl implements AnalyticsDataService {
     
     public AnalyticsDataServiceImpl() throws AnalyticsException {
         AnalyticsDataServiceConfiguration config = this.loadAnalyticsDataServiceConfig();
+        AnalyticsServiceHolder.setAnalyticsDataServiceConfiguration(config);
         Analyzer luceneAnalyzer;
         this.initARS(config);
         try {

--- a/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/AnalyticsServiceHolder.java
+++ b/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/AnalyticsServiceHolder.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.analytics.dataservice.core;
 import com.hazelcast.core.HazelcastInstance;
 import org.wso2.carbon.analytics.dataservice.core.clustering.AnalyticsClusterManager;
 import org.wso2.carbon.analytics.dataservice.core.clustering.AnalyticsClusterManagerImpl;
+import org.wso2.carbon.analytics.dataservice.core.config.AnalyticsDataServiceConfiguration;
 import org.wso2.carbon.analytics.dataservice.core.indexing.aggregates.AggregateFunction;
 import org.wso2.carbon.analytics.datasource.commons.exception.AnalyticsException;
 import org.wso2.carbon.ndatasource.core.DataSourceService;
@@ -49,7 +50,19 @@ public class AnalyticsServiceHolder {
 
     private static DataSourceService dataSourceService;
 
+
+    private static AnalyticsDataServiceConfiguration analyticsDataServiceConfiguration;
+
     private static Map<String, Class<? extends AggregateFunction>> aggregateFunctions = new HashMap<>();
+
+    public static void setAnalyticsDataServiceConfiguration(AnalyticsDataServiceConfiguration
+                                                                    analyticsDataServiceConfiguration) {
+        AnalyticsServiceHolder.analyticsDataServiceConfiguration = analyticsDataServiceConfiguration;
+    }
+
+    public static AnalyticsDataServiceConfiguration getAnalyticsDataServiceConfiguration() {
+        return analyticsDataServiceConfiguration;
+    }
 
     public static void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
         AnalyticsServiceHolder.hazelcastInstance = hazelcastInstance;

--- a/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/config/AnalyticsDataServiceConfiguration.java
+++ b/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/config/AnalyticsDataServiceConfiguration.java
@@ -38,7 +38,9 @@ public class AnalyticsDataServiceConfiguration {
     private AnalyticsDataPurgingConfiguration analyticsDataPurgingConfiguration;
 
     private AnalyticsFacetConfiguration analyticsFacetConfiguration;
-        
+
+    private StaticQuorumConfiguration staticQuorumConfiguration;
+
     private String primaryRecordStore;
         
     private int shardCount;
@@ -183,6 +185,15 @@ public class AnalyticsDataServiceConfiguration {
     public void setAnalyticsDataPurgingConfiguration(
             AnalyticsDataPurgingConfiguration analyticsDataPurgingConfiguration) {
         this.analyticsDataPurgingConfiguration = analyticsDataPurgingConfiguration;
+    }
+
+    @XmlElement(name = "static-quorum")
+    public StaticQuorumConfiguration getStaticQuorumConfiguration() {
+        return staticQuorumConfiguration;
+    }
+
+    public void setStaticQuorumConfiguration(StaticQuorumConfiguration staticQuorumConfiguration) {
+        this.staticQuorumConfiguration = staticQuorumConfiguration;
     }
 
 }

--- a/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/config/StaticQuorumConfiguration.java
+++ b/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/config/StaticQuorumConfiguration.java
@@ -1,0 +1,49 @@
+/*
+* Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* WSO2 Inc. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.wso2.carbon.analytics.dataservice.core.config;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+
+/**
+ * This class represents the configuration for static quorum.
+ */
+public class StaticQuorumConfiguration {
+    private boolean enabled;
+    private int quorumSize;
+
+    @XmlAttribute(required = true)
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    @XmlElement(name = "quorum-size", required = true)
+    public int getQuorumSize() {
+        return quorumSize;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public void setQuorumSize(int quorumSize) {
+        this.quorumSize = quorumSize;
+    }
+
+}

--- a/features/analytics-core/org.wso2.carbon.analytics.core.server.feature/src/main/resources/conf/analytics/analytics-config.xml
+++ b/features/analytics-core/org.wso2.carbon.analytics.core.server.feature/src/main/resources/conf/analytics/analytics-config.xml
@@ -129,4 +129,7 @@
       <!-- All records that insert before the specified retention time will be eligible to purge -->
       <data-retention-days>365</data-retention-days>
    </analytics-data-purging>
+   <static-quorum enabled="false">
+        <quorum-size>2</quorum-size>
+   </static-quorum>
 </analytics-dataservice-configuration>


### PR DESCRIPTION
## Purpose
Resolves https://github.com/wso2/product-das/issues/256

## Goals
We cannot solve this problem of Split Brain by keeping 2 nodes. We need to introduce a “dummy” node to the cluster in order to tackle such a scenario. We are using the “static quorum” approach to solve this issue. According to this strategy, you have to define a quorum size and in a 3 node case, it will be 2. Once a member got removed from the cluster, each node (other than the dummy node) will evaluate whether itself is in a cluster where the quorum is satisfied. If the quorum is satisfied, it will start to function normally, but if it is not, it will shutdown itself.

## Approach
https://docs.google.com/document/d/1D7OgQt5TjML2JQcoVpfri8vfsyGJFOijPaCIQmjseu4/edit?usp=sharing

## Release note
Solves the split-brain issue (network partitioning) of WSO2 DAS.

## Documentation
https://docs.wso2.com/display/CLUSTER44x/Handling+Split-brain+Situations+with+DAS+3.1.0

## Automation tests
 - difficult to implement since this requires a split-brain situation. Manual tests were done.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 1.8, Ubuntu
 
## Learning
https://blog.scalac.io/2016/10/13/handling-split-brain-scenarios-with-akka.html