### PR TITLE
Fix OSGI import in event table component and Upgrade Siddhi version to 3.2.0

### DIFF
--- a/components/analytics-io/org.wso2.carbon.analytics.eventtable/pom.xml
+++ b/components/analytics-io/org.wso2.carbon.analytics.eventtable/pom.xml
@@ -104,9 +104,11 @@
                         <Export-Package>!org.wso2.carbon.analytics.eventtable.internal.*,
                             org.wso2.carbon.analytics.eventtable.*
                         </Export-Package>
-			<Import-Package>com.google.common.cache;version="${guava.import.version}",
-					*;resolution:=optional
-			</Import-Package>
+                        <Import-Package>com.google.common.cache;version="${guava.import.version}",
+                            org.wso2.siddhi.core.*;version="${siddhi.version.range}",
+                            org.wso2.siddhi.query.*;version="${siddhi.version.range}",
+                            *;resolution:=optional
+                        </Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>
                     </instructions>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1477,7 +1477,7 @@
         <roaringbitmap.import.version>[0.4.5, 0.5.0)</roaringbitmap.import.version>
         <objenesis.orbit.version>2.1.wso2v1</objenesis.orbit.version>
 
-        <siddhi.version>3.1.3</siddhi.version>
+        <siddhi.version>3.2.0</siddhi.version>
         <siddhi.version.range>[3.2.0,4.0.0)</siddhi.version.range>
         <version.noggit>0.6.wso2v1</version.noggit>
         <hector.version>1.0-5</hector.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1478,6 +1478,7 @@
         <objenesis.orbit.version>2.1.wso2v1</objenesis.orbit.version>
 
         <siddhi.version>3.1.3</siddhi.version>
+        <siddhi.version.range>[3.2.0,4.0.0)</siddhi.version.range>
         <version.noggit>0.6.wso2v1</version.noggit>
         <hector.version>1.0-5</hector.version>
 


### PR DESCRIPTION
## Purpose
Fix OSGI import in event table component and Upgrade Siddhi version to 3.2.0

## Goals
 Fix OSGI import in event table component and Upgrade Siddhi version to 3.2.0

## Approach
 Fix OSGI import in event table component and Upgrade Siddhi version to 3.2.0

## User stories
NA

## Release note
NA

## Documentation
NA

## Training
NA

## Marketing
NA

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
NA

## Related PRs
NA

## Migrations (if applicable)
NA

## Test environment
java version "1.8.0_161"
Java(TM) SE Runtime Environment (build 1.8.0_161-b12)
Java HotSpot(TM) 64-Bit Server VM (build 25.161-b12, mixed mode)
 
## Learning
NA