### PR TITLE
Adding data types for data provider configuration variables in API response

### DIFF
--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/InputFieldTypes.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/InputFieldTypes.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.data.provider;
+
+/**
+ * Constants representing type of input fields to render
+ */
+public class InputFieldTypes {
+    public static final String TEXT_FIELD = "TEXT_FIELD";
+    public static final String TEXT_AREA = "TEXT_AREA";
+    public static final String NUMBER = "NUMBER";
+    public static final String SWITCH = "SWITCH";
+    public static final String SQL_CODE = "SQL_CODE";
+    public static final String SIDDHI_CODE = "SIDDHI_CODE";
+}

--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/rdbms/AbstractRDBMSDataProvider.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/rdbms/AbstractRDBMSDataProvider.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import org.wso2.carbon.config.ConfigurationException;
 import org.wso2.carbon.data.provider.AbstractDataProvider;
 import org.wso2.carbon.data.provider.DataProvider;
+import org.wso2.carbon.data.provider.InputFieldTypes;
 import org.wso2.carbon.data.provider.ProviderConfig;
 import org.wso2.carbon.data.provider.bean.DataSetMetadata;
 import org.wso2.carbon.data.provider.exception.DataProviderException;
@@ -41,9 +42,7 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Locale;
+import java.util.*;
 import javax.sql.DataSource;
 
 import static org.wso2.carbon.data.provider.rdbms.utils.RDBMSProviderConstants.CUSTOM_QUERY_PLACEHOLDER;
@@ -281,7 +280,18 @@ public class AbstractRDBMSDataProvider extends AbstractDataProvider {
 
     @Override
     public String providerConfig() {
-        return new Gson().toJson(new RDBMSDataProviderConf());
+        Map<String, String> renderingTypes = new HashMap<>();
+        renderingTypes.put("publishingInterval", InputFieldTypes.NUMBER);
+        renderingTypes.put("purgingInterval", InputFieldTypes.NUMBER);
+        renderingTypes.put("isPurgingEnable", InputFieldTypes.SWITCH);
+        renderingTypes.put("publishingLimit", InputFieldTypes.NUMBER);
+        renderingTypes.put("purgingLimit", InputFieldTypes.NUMBER);
+        renderingTypes.put("datasourceName", InputFieldTypes.TEXT_FIELD);
+        renderingTypes.put("query", InputFieldTypes.SQL_CODE);
+        renderingTypes.put("tableName", InputFieldTypes.TEXT_FIELD);
+        renderingTypes.put("incrementalColumn", InputFieldTypes.TEXT_FIELD);
+        renderingTypes.put("timeColumns", InputFieldTypes.TEXT_FIELD);
+        return new Gson().toJson(new Object[]{renderingTypes, new RDBMSDataProviderConf()});
     }
 
     @Override


### PR DESCRIPTION
## Purpose
> Adding data types for data provider configuration variables in the respective API response.
> The response is produced as follows:
```
[  
   {  
      "purgingInterval":"NUMBER",
      "publishingInterval":"NUMBER",
      "publishingLimit":"NUMBER",
      "isPurgingEnable":"SWITCH",
      "purgingLimit":"NUMBER",
      "query":"SQL_CODE",
      "datasourceName":"TEXT_FIELD",
      "incrementalColumn":"TEXT_FIELD",
      "timeColumns":"TEXT_FIELD",
      "tableName":"TEXT_FIELD"
   },
   {  
      "datasourceName":"",
      "query":"",
      "tableName":"",
      "incrementalColumn":"",
      "timeColumns":"",
      "publishingInterval":1,
      "purgingInterval":60,
      "publishingLimit":30,
      "purgingLimit":30,
      "isPurgingEnable":false
   }
]
```

## Goals
> - Rendering fields disregard of empty values or not
> - Rendering code editors for SQL & Siddhi query fields

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes