### PR TITLE
Upgrading the carbon commons version and changing SPARK_EVENTING_TASK…

### DIFF
--- a/components/analytics-processors/org.wso2.carbon.analytics.spark.event/src/main/java/org/wso2/carbon/analytics/spark/event/EventingConstants.java
+++ b/components/analytics-processors/org.wso2.carbon.analytics.spark.event/src/main/java/org/wso2/carbon/analytics/spark/event/EventingConstants.java
@@ -31,7 +31,7 @@ public class EventingConstants {
     public static final String ANALYTICS_SPARK_EVENTING_TASK_NAME = "STORE_EVENT_ROUTER_TASK";
     public static final String DISABLE_EVENT_SINK_SYS_PROP = "disableEventSink";
     public static final String DISABLE_SPARK_EVENTING_TASK_SYS_PROP = "disableSparkEventingTask";
-    public static final int SPARK_EVENTING_TASK_RUN_INTERVAL_MS = 10000;
+    public static final long SPARK_EVENTING_TASK_RUN_INTERVAL_MS = 10000;
     public static final String EVENT_META_DATA_PREFIX = "meta_";
     public static final String EVENT_CORRELATION_DATA_PREFIX = "correlation_";
     

--- a/pom.xml
+++ b/pom.xml
@@ -1328,7 +1328,7 @@
         <carbon.kernel.version.import.version.range>[4.4, 4.5)</carbon.kernel.version.import.version.range>
 
         <!-- WSO2 repository versions -->
-        <carbon.commons.version>4.5.4</carbon.commons.version>
+        <carbon.commons.version>4.6.19</carbon.commons.version>
         <carbon.commons.imp.pkg.version>[4.5, 5)</carbon.commons.imp.pkg.version>
         <carbon.data.version>4.4.2</carbon.data.version>
         <carbon.event-processing.version>2.1.4</carbon.event-processing.version>


### PR DESCRIPTION
## Purpose
- Upgrading the carbon commons version 
- Changing SPARK_EVENTING_TASK_RUN_INTERVAL_MS from int to long due the change in latest carbon commons