### PR TITLE
Fix generating new my-node-ids each time a new DAS server is started pointing to the same DB.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,10 @@
-*.class
-
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
-
-# Package Files #
-*.jar
-*.war
-*.ear
-
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
-hs_err_pid*
+# Ignore everything in this directory
+target
+.classpath
+.settings
+.project
+*.iml
+*.iws
+*.ipr
+.idea
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,12 @@
-# Ignore everything in this directory
-target
-.classpath
-.settings
-.project
-*.iml
-*.iws
-*.ipr
-.idea
-.DS_Store
+*.class
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.ear
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*

--- a/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/Constants.java
+++ b/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/Constants.java
@@ -1,21 +1,20 @@
 /*
- *  Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
- *
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless requi    red by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied.  See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
- *
- */
+* Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* WSO2 Inc. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
 package org.wso2.carbon.analytics.dataservice.core;
 
 import org.wso2.carbon.analytics.datasource.core.AnalyticsDataSourceConstants;

--- a/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/Constants.java
+++ b/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/Constants.java
@@ -73,14 +73,26 @@ public class Constants {
     public static final String ANALYTICS_INDEXING_GROUP = "__ANALYTICS_INDEXING_GROUP__";
 
     public static final String DISABLE_LOCAL_INDEX_QUEUE_OPTION = "disableLocalIndexQueue";
-    
-    public static final String DEFAULT_INDEX_STORE_LOCATION = AnalyticsDataSourceConstants.CARBON_HOME_VAR + File.separator + "repository"
-            + File.separator + "data" + File.separator + "index_data" + File.separator;
-    public static final String INDEX_STORE_DIR_PREFIX = "shard";    
-    public static final String LOCAL_SHARD_ALLOCATION_CONFIG_LOCATION = AnalyticsDataSourceConstants.CARBON_HOME_VAR + File.separator + "repository"
-            + File.separator + "conf" + File.separator + "analytics" + File.separator + "local-shard-allocation-config.conf";    
-    public static final String MY_NODEID_LOCATION = AnalyticsDataSourceConstants.CARBON_HOME_VAR + File.separator + "repository"
-            + File.separator + "conf" + File.separator + "analytics" + File.separator + "my-node-id.dat";
+
+    public static final String DEFAULT_INDEX_STORE_LOCATION = AnalyticsDataSourceConstants.CARBON_HOME_VAR
+            + File.separator + "repository" + File.separator + "data" + File.separator + "index_data" + File.separator;
+
+    public static final String INDEX_STORE_DIR_PREFIX = "shard";
+
+    public static final String LOCAL_SHARD_ALLOCATION_CONFIG_LOCATION = AnalyticsDataSourceConstants.CARBON_HOME_VAR
+                        + File.separator + "repository" + File.separator + "data" + File.separator
+                        + "local-shard-allocation-config.conf";
+    public static final String LOCAL_SHARD_REPLICA_CONFIG_LOCATION = AnalyticsDataSourceConstants.CARBON_HOME_VAR
+                        + File.separator + "repository" + File.separator + "data" + File.separator
+                        + "local-shard-replica-config.conf";
+   public static final String MY_NODEID_LOCATION = AnalyticsDataSourceConstants.CARBON_HOME_VAR + File.separator +
+                        "repository" + File.separator + "data" + File.separator + "my-node-id.dat";
+    public static final String DEPRECATED_LOCAL_SHARD_ALLOCATION_CONFIG_LOCATION = AnalyticsDataSourceConstants
+                        .CARBON_HOME_VAR + File.separator + "repository" + File.separator + "conf" + File.separator + "analytics"
+                        + File.separator + "local-shard-allocation-config.conf";
+    public static final String DEPRECATED_MY_NODEID_LOCATION = AnalyticsDataSourceConstants
+                        .CARBON_HOME_VAR + File.separator + "repository" + File.separator + "conf" + File.separator + "analytics"
+                        + File.separator + "my-node-id.dat";
     public static final String DEFAULT_LOCAL_INDEX_STAGING_LOCATION = AnalyticsDataSourceConstants.CARBON_HOME_VAR + File.separator + "repository"
             + File.separator + "data" + File.separator + "index_staging_queues" + File.separator;
 }

--- a/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/Constants.java
+++ b/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/Constants.java
@@ -1,19 +1,20 @@
 /*
- * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
- * Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License.
- * You may obtain a copy of the License at
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *  http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ *  Unless requi    red by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
  */
 package org.wso2.carbon.analytics.dataservice.core;
 

--- a/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/Constants.java
+++ b/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/Constants.java
@@ -1,20 +1,20 @@
 /*
-* Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-* WSO2 Inc. licenses this file to you under the Apache License,
-* Version 2.0 (the "License"); you may not use this file except
-* in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.wso2.carbon.analytics.dataservice.core;
 
 import org.wso2.carbon.analytics.datasource.core.AnalyticsDataSourceConstants;
@@ -25,7 +25,7 @@ import java.io.File;
  * This class hold constants that required for data service
  */
 public class Constants {
-    
+
     public static final String PERMISSION_LIST_TABLE = "/permission/admin/manage/analytics/table/list";
     public static final String PERMISSION_CREATE_TABLE = "/permission/admin/manage/analytics/table/create";
     public static final String PERMISSION_DROP_TABLE = "/permission/admin/manage/analytics/table/drop";
@@ -80,19 +80,19 @@ public class Constants {
     public static final String INDEX_STORE_DIR_PREFIX = "shard";
 
     public static final String LOCAL_SHARD_ALLOCATION_CONFIG_LOCATION = AnalyticsDataSourceConstants.CARBON_HOME_VAR
-                        + File.separator + "repository" + File.separator + "data" + File.separator
-                        + "local-shard-allocation-config.conf";
+            + File.separator + "repository" + File.separator + "data" + File.separator
+            + "local-shard-allocation-config.conf";
     public static final String LOCAL_SHARD_REPLICA_CONFIG_LOCATION = AnalyticsDataSourceConstants.CARBON_HOME_VAR
-                        + File.separator + "repository" + File.separator + "data" + File.separator
-                        + "local-shard-replica-config.conf";
-   public static final String MY_NODEID_LOCATION = AnalyticsDataSourceConstants.CARBON_HOME_VAR + File.separator +
-                        "repository" + File.separator + "data" + File.separator + "my-node-id.dat";
+            + File.separator + "repository" + File.separator + "data" + File.separator
+            + "local-shard-replica-config.conf";
+    public static final String MY_NODEID_LOCATION = AnalyticsDataSourceConstants.CARBON_HOME_VAR + File.separator +
+            "repository" + File.separator + "data" + File.separator + "my-node-id.dat";
     public static final String DEPRECATED_LOCAL_SHARD_ALLOCATION_CONFIG_LOCATION = AnalyticsDataSourceConstants
-                        .CARBON_HOME_VAR + File.separator + "repository" + File.separator + "conf" + File.separator + "analytics"
-                        + File.separator + "local-shard-allocation-config.conf";
+            .CARBON_HOME_VAR + File.separator + "repository" + File.separator + "conf" + File.separator + "analytics"
+            + File.separator + "local-shard-allocation-config.conf";
     public static final String DEPRECATED_MY_NODEID_LOCATION = AnalyticsDataSourceConstants
-                        .CARBON_HOME_VAR + File.separator + "repository" + File.separator + "conf" + File.separator + "analytics"
-                        + File.separator + "my-node-id.dat";
+            .CARBON_HOME_VAR + File.separator + "repository" + File.separator + "conf" + File.separator + "analytics"
+            + File.separator + "my-node-id.dat";
     public static final String DEFAULT_LOCAL_INDEX_STAGING_LOCATION = AnalyticsDataSourceConstants.CARBON_HOME_VAR + File.separator + "repository"
             + File.separator + "data" + File.separator + "index_staging_queues" + File.separator;
 }

--- a/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/indexing/GlobalShardAllocationConfig.java
+++ b/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/indexing/GlobalShardAllocationConfig.java
@@ -18,50 +18,210 @@
  */
 package org.wso2.carbon.analytics.dataservice.core.indexing;
 
-import java.util.Arrays;
+import com.hazelcast.core.HazelcastInstance;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
+
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.Lock;
 
-import org.wso2.carbon.analytics.dataservice.core.Constants;
-import org.wso2.carbon.analytics.datasource.commons.Record;
+import org.wso2.carbon.analytics.dataservice.core.AnalyticsServiceHolder;
+import org.wso2.carbon.analytics.dataservice.core.clustering.AnalyticsClusterManager;
 import org.wso2.carbon.analytics.datasource.commons.exception.AnalyticsException;
 import org.wso2.carbon.analytics.datasource.core.rs.AnalyticsRecordStore;
-import org.wso2.carbon.analytics.datasource.core.util.GenericUtils;
 
 /**
  * This class contains node/shard mapping information for all the nodes.
  */
 public class GlobalShardAllocationConfig {
-        
-    private AnalyticsRecordStore recordStore;
+
+    static final String GSAC_NODEID_REPLICA_SEPERATOR = "##";
+    private AnalyticsClusterManager acm;
+    private HazelcastInstance hzInstance;
+    private static final String GSAC_GET_NODE_IDS_FOR_SHARD_LOCK = "__GSA_CONFIG_NODE_IDS_FOR_SHARD_LOCK__";
+    private static final String GSAC_WRITE_NODE_IDS_FOR_SHARD_LOCK = "__GSA_CONFIG_WRITE_NODE_IDS_FOR_SHARD_LOCK__";
+    private static final String GSAC_NODE_IDS_SET_FOR_SHARDS = "GSA_CONFIG_NODE_IDS_SET_FOR_SHARDS";
+    private static final String GSAC_REPLICAS_FOR_SHARDS = "GSA_CONFIG_REPLICAS_FOR_SHARDS";
+    private Map<Integer, Set<String>> localNodeIdsForShards = new HashMap<>();
+    private Map<Integer, Set<String>> localNodeIdsForShardsReplicas = new HashMap<>();
     
     public GlobalShardAllocationConfig(AnalyticsRecordStore recordStore) {
-        this.recordStore = recordStore;
+        acm = AnalyticsServiceHolder.getAnalyticsClusterManager();
+               hzInstance = AnalyticsServiceHolder.getHazelcastInstance(); }
+
+            public GlobalShardAllocationConfig() {
+                acm = AnalyticsServiceHolder.getAnalyticsClusterManager();
+                hzInstance = AnalyticsServiceHolder.getHazelcastInstance();
+
     }
     
     public Set<String> getNodeIdsForShard(int shardIndex) throws AnalyticsException {
-        List<Record> records = GenericUtils.listRecords(this.recordStore, this.recordStore.get(Constants.META_INFO_TENANT_ID, 
-                Constants.GLOBAL_SHARD_ALLOCATION_CONFIG_TABLE, 1, null, Arrays.asList(String.valueOf(shardIndex))));
-        if (records.size() > 0) {
-            return records.get(0).getValues().keySet();
-        } else {
-            return new HashSet<>(0);
+        return getShardSet(shardIndex, GSAC_NODE_IDS_SET_FOR_SHARDS);
+            }
+
+            Set<String> getNodeIdsWithReplica(int shardIndex) throws AnalyticsException {
+                return getShardSet(shardIndex, GSAC_REPLICAS_FOR_SHARDS);
+            }
+
+            private Set<String> getShardSet(int shardIndex, String mapRef) {
+                Lock gsacGetNodeIdLock = null;
+                Lock gsacSetNodeIdLock = null;
+                Map<Integer, Set<String>> nodeIdsSetsForShards;
+                try {
+                        if (acm.isClusteringEnabled()) {
+                                gsacGetNodeIdLock = hzInstance.getLock(GSAC_GET_NODE_IDS_FOR_SHARD_LOCK);
+                                gsacSetNodeIdLock = hzInstance.getLock(GSAC_WRITE_NODE_IDS_FOR_SHARD_LOCK);
+                                gsacGetNodeIdLock.lock();
+                                gsacSetNodeIdLock.lock();
+                                nodeIdsSetsForShards = hzInstance.getMap(mapRef);
+                            } else {
+                                nodeIdsSetsForShards = localNodeIdsForShards;
+                            }
+                        Set<String> nodeIds = nodeIdsSetsForShards.get(shardIndex);
+                        if (nodeIds != null) {
+                                return nodeIds;
+                            } else {
+                                return new HashSet<>(0);
+                            }
+                    } finally {
+                        if (gsacGetNodeIdLock != null) {
+                                gsacGetNodeIdLock.unlock();
+                            }
+                        if (gsacSetNodeIdLock != null) {
+                                gsacSetNodeIdLock.unlock();
+                            }
+                    }
+            }
+
+            public int getShardReplica(int shardIndex, String nodeId) throws AnalyticsException {
+                Lock gsacGetNodeIdLock = null;
+                Lock gsacSetNodeIdLock = null;
+                Map<Integer, Set<String>> nodeIdsSetsForShards;
+                try {
+                        if (acm.isClusteringEnabled()) {
+                            gsacGetNodeIdLock = hzInstance.getLock(GSAC_GET_NODE_IDS_FOR_SHARD_LOCK);
+                                gsacSetNodeIdLock = hzInstance.getLock(GSAC_WRITE_NODE_IDS_FOR_SHARD_LOCK);
+                                gsacGetNodeIdLock.lock();
+                                gsacSetNodeIdLock.lock();
+                                nodeIdsSetsForShards = hzInstance.getMap(GSAC_REPLICAS_FOR_SHARDS);
+                            } else {
+                                nodeIdsSetsForShards = localNodeIdsForShardsReplicas;
+                            }
+                        Set<String> nodeIds = nodeIdsSetsForShards.get(shardIndex);
+                        if (nodeIds != null) {
+                                for (String nodeIdWithReplica : nodeIds) {
+                                        if (nodeIdWithReplica.startsWith(nodeId)) {
+                                                String replicaAsString = nodeIdWithReplica.split(GSAC_NODEID_REPLICA_SEPERATOR)[1];
+                                                return Integer.valueOf(replicaAsString);
+                                            }
+                                    }
+                                return 0;
+                            } else {
+                                return 0;
+                            }
+                    } finally {
+                        if (gsacGetNodeIdLock != null) {
+                                gsacGetNodeIdLock.unlock();
+                            }
+                        if (gsacSetNodeIdLock != null) {
+                                gsacSetNodeIdLock.unlock();
+                            }
         }
     }
     
     public void removeNodeIdFromShard(int shardIndex, String nodeId) throws AnalyticsException {
         Set<String> nodeIds = this.getNodeIdsForShard(shardIndex);
-        Map<String, Object> values = new HashMap<>(nodeIds.size());
+        Set<String> nodeIdsWithShardReplica = this.getNodeIdsWithReplica(shardIndex);
+                Map<String, Object> uniqueNodeIds = new HashMap<>(nodeIds.size());
+                Map<String, Object> uniqueNodeIdsWithShardReplica = new HashMap<>(nodeIds.size());
         for (String entry : nodeIds) {
-            values.put(entry, entry);
+            uniqueNodeIds.put(entry, entry);
+                    }
+                for (String entry : nodeIdsWithShardReplica) {
+                        uniqueNodeIdsWithShardReplica.put(entry, entry);
+                    }
+                uniqueNodeIds.remove(nodeId);
+                for (Map.Entry<String, Object> entry : uniqueNodeIdsWithShardReplica.entrySet()) {
+                        if (entry.getKey().startsWith(nodeId)) {
+                                uniqueNodeIdsWithShardReplica.remove(entry.getKey());
+                                break;
+                            }
+                    }
+                updateNodeIdsSetForShardsReplicas(shardIndex, uniqueNodeIdsWithShardReplica);
+                updateNodeIdsSetForShards(shardIndex, uniqueNodeIds);
+            }
+
+            public void removeNodeIdsFromShards(Set<String> nonExistingNodeIds) throws AnalyticsException {
+                Map<Integer, Set<String>> nodeIdsSetsForShards;
+                Map<Integer, Set<String>> nodeIdsSetsForShardReplica;
+                Lock gsacWriteNodeIdLock = null;
+                try {
+                        if (!nonExistingNodeIds.isEmpty()) {
+                                if (acm.isClusteringEnabled()) {
+                                        gsacWriteNodeIdLock = hzInstance.getLock(GSAC_WRITE_NODE_IDS_FOR_SHARD_LOCK);
+                                        gsacWriteNodeIdLock.lock();
+                                        nodeIdsSetsForShards = hzInstance.getMap(GSAC_NODE_IDS_SET_FOR_SHARDS);
+                                        nodeIdsSetsForShardReplica = hzInstance.getMap(GSAC_REPLICAS_FOR_SHARDS);
+                                    } else {
+                                        nodeIdsSetsForShards = localNodeIdsForShards;
+                                        nodeIdsSetsForShardReplica = localNodeIdsForShardsReplicas;
+                                    }
+                                for (Map.Entry<Integer, Set<String>> entry : nodeIdsSetsForShards.entrySet()) {
+                                        Set<String> shardNodeIds = entry.getValue();
+                                        shardNodeIds.removeAll(nonExistingNodeIds);
+                                        nodeIdsSetsForShards.put(entry.getKey(), shardNodeIds);
+                                    }
+                                removeNonExistingNodeIdsFromReplica(nonExistingNodeIds, nodeIdsSetsForShardReplica);
+                            }
+                    } finally {
+                        if (gsacWriteNodeIdLock != null) {
+                                gsacWriteNodeIdLock.unlock();
+                            }
         }
-        values.remove(nodeId);
-        Record record = new Record(String.valueOf(shardIndex), Constants.META_INFO_TENANT_ID, 
-                Constants.GLOBAL_SHARD_ALLOCATION_CONFIG_TABLE, values);
-        this.recordStore.put(Arrays.asList(record));
+            }
+            private void removeNonExistingNodeIdsFromReplica(Set<String> nonExistingNodeIds,
+                                                     Map<Integer, Set<String>> nodeIdsSetsForShardReplica) {
+                for (Map.Entry<Integer, Set<String>> entry : nodeIdsSetsForShardReplica.entrySet()) {
+                        Set<String> nodeIdsWithReplica = entry.getValue();
+                        for (String nonExistingNodeId : nonExistingNodeIds) {
+                                for (String nodeIdWithReplica : nodeIdsWithReplica) {
+                                        if (nodeIdWithReplica.startsWith(nonExistingNodeId)) {
+                                                nodeIdsWithReplica.remove(nodeIdWithReplica);
+                                                break;
+                                            }
+                                    }
+                            }
+                        nodeIdsSetsForShardReplica.put(entry.getKey(), nodeIdsWithReplica);
+                    }
+            }
+
+            private void updateShardIndicesMap(int shardIndex, Map<String, Object> values, String mapRef,
+                                       Map<Integer, Set<String>> shardMap) {
+                Map<Integer, Set<String>> nodeIdsSetsForShards;
+                Lock gsacWriteNodeIdLock = null;
+                try {
+                        if (acm.isClusteringEnabled()) {
+                                gsacWriteNodeIdLock = hzInstance.getLock(GSAC_WRITE_NODE_IDS_FOR_SHARD_LOCK);
+                                gsacWriteNodeIdLock.lock();
+                                nodeIdsSetsForShards = hzInstance.getMap(mapRef);
+                            } else {
+                                nodeIdsSetsForShards = shardMap;
+                            }
+                        nodeIdsSetsForShards.put(shardIndex, new HashSet<>(values.keySet()));
+
+                            } finally {
+                        if (gsacWriteNodeIdLock != null) {
+                                gsacWriteNodeIdLock.unlock();
+                            }
+                    }
+            }
+    private void updateNodeIdsSetForShards(int shardIndex,  Map<String, Object> values) {
+                updateShardIndicesMap(shardIndex, values, GSAC_NODE_IDS_SET_FOR_SHARDS, localNodeIdsForShards);
+            }
+
+            private void updateNodeIdsSetForShardsReplicas(int shardIndex,  Map<String, Object> values) {
+                updateShardIndicesMap(shardIndex, values, GSAC_REPLICAS_FOR_SHARDS, localNodeIdsForShardsReplicas);
     }
     
     public void addNodeIdForShard(int shardIndex, String nodeId) throws AnalyticsException {
@@ -71,9 +231,25 @@ public class GlobalShardAllocationConfig {
             values.put(entry, entry);
         }
         values.put(nodeId, nodeId);
-        Record record = new Record(String.valueOf(shardIndex), Constants.META_INFO_TENANT_ID, 
-                Constants.GLOBAL_SHARD_ALLOCATION_CONFIG_TABLE, values);
-        this.recordStore.put(Arrays.asList(record));
+        updateNodeIdsSetForShards(shardIndex, values);
+            }
+
+            void addNodeIdForShard(int shardIndex, int replicaIndex, String nodeId) throws AnalyticsException {
+                Set<String> nodeIds = this.getNodeIdsForShard(shardIndex);
+                Set<String> nodeIdsWithShardReplica = this.getNodeIdsWithReplica(shardIndex);
+                Map<String, Object> uniqueNodeIds = new HashMap<>(nodeIds.size() + 1);
+                Map<String, Object> uniqueNodeIdsWithShardReplica = new HashMap<>(nodeIds.size() + 1);
+                for (String entry : nodeIds) {
+                        uniqueNodeIds.put(entry, entry);
+                    }
+                for (String entry : nodeIdsWithShardReplica) {
+                        uniqueNodeIdsWithShardReplica.put(entry, entry);
+                    }
+                uniqueNodeIds.put(nodeId, nodeId);
+                uniqueNodeIdsWithShardReplica.put(nodeId + GSAC_NODEID_REPLICA_SEPERATOR + replicaIndex,
+                                                          nodeId + GSAC_NODEID_REPLICA_SEPERATOR + replicaIndex);
+                updateNodeIdsSetForShards(shardIndex, uniqueNodeIds);
+                updateNodeIdsSetForShardsReplicas(shardIndex, uniqueNodeIdsWithShardReplica);
     }
     
 }

--- a/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/indexing/GlobalShardAllocationConfig.java
+++ b/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/indexing/GlobalShardAllocationConfig.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.analytics.dataservice.core.indexing;
 
 import com.hazelcast.core.HazelcastInstance;
+
 import java.util.HashMap;
 import java.util.HashSet;
 
@@ -45,185 +46,188 @@ public class GlobalShardAllocationConfig {
     private static final String GSAC_REPLICAS_FOR_SHARDS = "GSA_CONFIG_REPLICAS_FOR_SHARDS";
     private Map<Integer, Set<String>> localNodeIdsForShards = new HashMap<>();
     private Map<Integer, Set<String>> localNodeIdsForShardsReplicas = new HashMap<>();
-    
+
     public GlobalShardAllocationConfig(AnalyticsRecordStore recordStore) {
         acm = AnalyticsServiceHolder.getAnalyticsClusterManager();
-               hzInstance = AnalyticsServiceHolder.getHazelcastInstance(); }
+        hzInstance = AnalyticsServiceHolder.getHazelcastInstance();
+    }
 
-            public GlobalShardAllocationConfig() {
-                acm = AnalyticsServiceHolder.getAnalyticsClusterManager();
-                hzInstance = AnalyticsServiceHolder.getHazelcastInstance();
+    public GlobalShardAllocationConfig() {
+        acm = AnalyticsServiceHolder.getAnalyticsClusterManager();
+        hzInstance = AnalyticsServiceHolder.getHazelcastInstance();
 
     }
-    
+
     public Set<String> getNodeIdsForShard(int shardIndex) throws AnalyticsException {
         return getShardSet(shardIndex, GSAC_NODE_IDS_SET_FOR_SHARDS);
-            }
+    }
 
-            Set<String> getNodeIdsWithReplica(int shardIndex) throws AnalyticsException {
-                return getShardSet(shardIndex, GSAC_REPLICAS_FOR_SHARDS);
-            }
+    Set<String> getNodeIdsWithReplica(int shardIndex) throws AnalyticsException {
+        return getShardSet(shardIndex, GSAC_REPLICAS_FOR_SHARDS);
+    }
 
-            private Set<String> getShardSet(int shardIndex, String mapRef) {
-                Lock gsacGetNodeIdLock = null;
-                Lock gsacSetNodeIdLock = null;
-                Map<Integer, Set<String>> nodeIdsSetsForShards;
-                try {
-                        if (acm.isClusteringEnabled()) {
-                                gsacGetNodeIdLock = hzInstance.getLock(GSAC_GET_NODE_IDS_FOR_SHARD_LOCK);
-                                gsacSetNodeIdLock = hzInstance.getLock(GSAC_WRITE_NODE_IDS_FOR_SHARD_LOCK);
-                                gsacGetNodeIdLock.lock();
-                                gsacSetNodeIdLock.lock();
-                                nodeIdsSetsForShards = hzInstance.getMap(mapRef);
-                            } else {
-                                nodeIdsSetsForShards = localNodeIdsForShards;
-                            }
-                        Set<String> nodeIds = nodeIdsSetsForShards.get(shardIndex);
-                        if (nodeIds != null) {
-                                return nodeIds;
-                            } else {
-                                return new HashSet<>(0);
-                            }
-                    } finally {
-                        if (gsacGetNodeIdLock != null) {
-                                gsacGetNodeIdLock.unlock();
-                            }
-                        if (gsacSetNodeIdLock != null) {
-                                gsacSetNodeIdLock.unlock();
-                            }
-                    }
+    private Set<String> getShardSet(int shardIndex, String mapRef) {
+        Lock gsacGetNodeIdLock = null;
+        Lock gsacSetNodeIdLock = null;
+        Map<Integer, Set<String>> nodeIdsSetsForShards;
+        try {
+            if (acm.isClusteringEnabled()) {
+                gsacGetNodeIdLock = hzInstance.getLock(GSAC_GET_NODE_IDS_FOR_SHARD_LOCK);
+                gsacSetNodeIdLock = hzInstance.getLock(GSAC_WRITE_NODE_IDS_FOR_SHARD_LOCK);
+                gsacGetNodeIdLock.lock();
+                gsacSetNodeIdLock.lock();
+                nodeIdsSetsForShards = hzInstance.getMap(mapRef);
+            } else {
+                nodeIdsSetsForShards = localNodeIdsForShards;
             }
-
-            public int getShardReplica(int shardIndex, String nodeId) throws AnalyticsException {
-                Lock gsacGetNodeIdLock = null;
-                Lock gsacSetNodeIdLock = null;
-                Map<Integer, Set<String>> nodeIdsSetsForShards;
-                try {
-                        if (acm.isClusteringEnabled()) {
-                            gsacGetNodeIdLock = hzInstance.getLock(GSAC_GET_NODE_IDS_FOR_SHARD_LOCK);
-                                gsacSetNodeIdLock = hzInstance.getLock(GSAC_WRITE_NODE_IDS_FOR_SHARD_LOCK);
-                                gsacGetNodeIdLock.lock();
-                                gsacSetNodeIdLock.lock();
-                                nodeIdsSetsForShards = hzInstance.getMap(GSAC_REPLICAS_FOR_SHARDS);
-                            } else {
-                                nodeIdsSetsForShards = localNodeIdsForShardsReplicas;
-                            }
-                        Set<String> nodeIds = nodeIdsSetsForShards.get(shardIndex);
-                        if (nodeIds != null) {
-                                for (String nodeIdWithReplica : nodeIds) {
-                                        if (nodeIdWithReplica.startsWith(nodeId)) {
-                                                String replicaAsString = nodeIdWithReplica.split(GSAC_NODEID_REPLICA_SEPERATOR)[1];
-                                                return Integer.valueOf(replicaAsString);
-                                            }
-                                    }
-                                return 0;
-                            } else {
-                                return 0;
-                            }
-                    } finally {
-                        if (gsacGetNodeIdLock != null) {
-                                gsacGetNodeIdLock.unlock();
-                            }
-                        if (gsacSetNodeIdLock != null) {
-                                gsacSetNodeIdLock.unlock();
-                            }
+            Set<String> nodeIds = nodeIdsSetsForShards.get(shardIndex);
+            if (nodeIds != null) {
+                return nodeIds;
+            } else {
+                return new HashSet<>(0);
+            }
+        } finally {
+            if (gsacGetNodeIdLock != null) {
+                gsacGetNodeIdLock.unlock();
+            }
+            if (gsacSetNodeIdLock != null) {
+                gsacSetNodeIdLock.unlock();
+            }
         }
     }
-    
+
+    public int getShardReplica(int shardIndex, String nodeId) throws AnalyticsException {
+        Lock gsacGetNodeIdLock = null;
+        Lock gsacSetNodeIdLock = null;
+        Map<Integer, Set<String>> nodeIdsSetsForShards;
+        try {
+            if (acm.isClusteringEnabled()) {
+                gsacGetNodeIdLock = hzInstance.getLock(GSAC_GET_NODE_IDS_FOR_SHARD_LOCK);
+                gsacSetNodeIdLock = hzInstance.getLock(GSAC_WRITE_NODE_IDS_FOR_SHARD_LOCK);
+                gsacGetNodeIdLock.lock();
+                gsacSetNodeIdLock.lock();
+                nodeIdsSetsForShards = hzInstance.getMap(GSAC_REPLICAS_FOR_SHARDS);
+            } else {
+                nodeIdsSetsForShards = localNodeIdsForShardsReplicas;
+            }
+            Set<String> nodeIds = nodeIdsSetsForShards.get(shardIndex);
+            if (nodeIds != null) {
+                for (String nodeIdWithReplica : nodeIds) {
+                    if (nodeIdWithReplica.startsWith(nodeId)) {
+                        String replicaAsString = nodeIdWithReplica.split(GSAC_NODEID_REPLICA_SEPERATOR)[1];
+                        return Integer.valueOf(replicaAsString);
+                    }
+                }
+                return 0;
+            } else {
+                return 0;
+            }
+        } finally {
+            if (gsacGetNodeIdLock != null) {
+                gsacGetNodeIdLock.unlock();
+            }
+            if (gsacSetNodeIdLock != null) {
+                gsacSetNodeIdLock.unlock();
+            }
+        }
+    }
+
     public void removeNodeIdFromShard(int shardIndex, String nodeId) throws AnalyticsException {
         Set<String> nodeIds = this.getNodeIdsForShard(shardIndex);
         Set<String> nodeIdsWithShardReplica = this.getNodeIdsWithReplica(shardIndex);
-                Map<String, Object> uniqueNodeIds = new HashMap<>(nodeIds.size());
-                Map<String, Object> uniqueNodeIdsWithShardReplica = new HashMap<>(nodeIds.size());
+        Map<String, Object> uniqueNodeIds = new HashMap<>(nodeIds.size());
+        Map<String, Object> uniqueNodeIdsWithShardReplica = new HashMap<>(nodeIds.size());
         for (String entry : nodeIds) {
             uniqueNodeIds.put(entry, entry);
-                    }
-                for (String entry : nodeIdsWithShardReplica) {
-                        uniqueNodeIdsWithShardReplica.put(entry, entry);
-                    }
-                uniqueNodeIds.remove(nodeId);
-                for (Map.Entry<String, Object> entry : uniqueNodeIdsWithShardReplica.entrySet()) {
-                        if (entry.getKey().startsWith(nodeId)) {
-                                uniqueNodeIdsWithShardReplica.remove(entry.getKey());
-                                break;
-                            }
-                    }
-                updateNodeIdsSetForShardsReplicas(shardIndex, uniqueNodeIdsWithShardReplica);
-                updateNodeIdsSetForShards(shardIndex, uniqueNodeIds);
-            }
-
-            public void removeNodeIdsFromShards(Set<String> nonExistingNodeIds) throws AnalyticsException {
-                Map<Integer, Set<String>> nodeIdsSetsForShards;
-                Map<Integer, Set<String>> nodeIdsSetsForShardReplica;
-                Lock gsacWriteNodeIdLock = null;
-                try {
-                        if (!nonExistingNodeIds.isEmpty()) {
-                                if (acm.isClusteringEnabled()) {
-                                        gsacWriteNodeIdLock = hzInstance.getLock(GSAC_WRITE_NODE_IDS_FOR_SHARD_LOCK);
-                                        gsacWriteNodeIdLock.lock();
-                                        nodeIdsSetsForShards = hzInstance.getMap(GSAC_NODE_IDS_SET_FOR_SHARDS);
-                                        nodeIdsSetsForShardReplica = hzInstance.getMap(GSAC_REPLICAS_FOR_SHARDS);
-                                    } else {
-                                        nodeIdsSetsForShards = localNodeIdsForShards;
-                                        nodeIdsSetsForShardReplica = localNodeIdsForShardsReplicas;
-                                    }
-                                for (Map.Entry<Integer, Set<String>> entry : nodeIdsSetsForShards.entrySet()) {
-                                        Set<String> shardNodeIds = entry.getValue();
-                                        shardNodeIds.removeAll(nonExistingNodeIds);
-                                        nodeIdsSetsForShards.put(entry.getKey(), shardNodeIds);
-                                    }
-                                removeNonExistingNodeIdsFromReplica(nonExistingNodeIds, nodeIdsSetsForShardReplica);
-                            }
-                    } finally {
-                        if (gsacWriteNodeIdLock != null) {
-                                gsacWriteNodeIdLock.unlock();
-                            }
         }
+        for (String entry : nodeIdsWithShardReplica) {
+            uniqueNodeIdsWithShardReplica.put(entry, entry);
+        }
+        uniqueNodeIds.remove(nodeId);
+        for (Map.Entry<String, Object> entry : uniqueNodeIdsWithShardReplica.entrySet()) {
+            if (entry.getKey().startsWith(nodeId)) {
+                uniqueNodeIdsWithShardReplica.remove(entry.getKey());
+                break;
             }
-            private void removeNonExistingNodeIdsFromReplica(Set<String> nonExistingNodeIds,
-                                                     Map<Integer, Set<String>> nodeIdsSetsForShardReplica) {
-                for (Map.Entry<Integer, Set<String>> entry : nodeIdsSetsForShardReplica.entrySet()) {
-                        Set<String> nodeIdsWithReplica = entry.getValue();
-                        for (String nonExistingNodeId : nonExistingNodeIds) {
-                                for (String nodeIdWithReplica : nodeIdsWithReplica) {
-                                        if (nodeIdWithReplica.startsWith(nonExistingNodeId)) {
-                                                nodeIdsWithReplica.remove(nodeIdWithReplica);
-                                                break;
-                                            }
-                                    }
-                            }
-                        nodeIdsSetsForShardReplica.put(entry.getKey(), nodeIdsWithReplica);
-                    }
-            }
-
-            private void updateShardIndicesMap(int shardIndex, Map<String, Object> values, String mapRef,
-                                       Map<Integer, Set<String>> shardMap) {
-                Map<Integer, Set<String>> nodeIdsSetsForShards;
-                Lock gsacWriteNodeIdLock = null;
-                try {
-                        if (acm.isClusteringEnabled()) {
-                                gsacWriteNodeIdLock = hzInstance.getLock(GSAC_WRITE_NODE_IDS_FOR_SHARD_LOCK);
-                                gsacWriteNodeIdLock.lock();
-                                nodeIdsSetsForShards = hzInstance.getMap(mapRef);
-                            } else {
-                                nodeIdsSetsForShards = shardMap;
-                            }
-                        nodeIdsSetsForShards.put(shardIndex, new HashSet<>(values.keySet()));
-
-                            } finally {
-                        if (gsacWriteNodeIdLock != null) {
-                                gsacWriteNodeIdLock.unlock();
-                            }
-                    }
-            }
-    private void updateNodeIdsSetForShards(int shardIndex,  Map<String, Object> values) {
-                updateShardIndicesMap(shardIndex, values, GSAC_NODE_IDS_SET_FOR_SHARDS, localNodeIdsForShards);
-            }
-
-            private void updateNodeIdsSetForShardsReplicas(int shardIndex,  Map<String, Object> values) {
-                updateShardIndicesMap(shardIndex, values, GSAC_REPLICAS_FOR_SHARDS, localNodeIdsForShardsReplicas);
+        }
+        updateNodeIdsSetForShardsReplicas(shardIndex, uniqueNodeIdsWithShardReplica);
+        updateNodeIdsSetForShards(shardIndex, uniqueNodeIds);
     }
-    
+
+    public void removeNodeIdsFromShards(Set<String> nonExistingNodeIds) throws AnalyticsException {
+        Map<Integer, Set<String>> nodeIdsSetsForShards;
+        Map<Integer, Set<String>> nodeIdsSetsForShardReplica;
+        Lock gsacWriteNodeIdLock = null;
+        try {
+            if (!nonExistingNodeIds.isEmpty()) {
+                if (acm.isClusteringEnabled()) {
+                    gsacWriteNodeIdLock = hzInstance.getLock(GSAC_WRITE_NODE_IDS_FOR_SHARD_LOCK);
+                    gsacWriteNodeIdLock.lock();
+                    nodeIdsSetsForShards = hzInstance.getMap(GSAC_NODE_IDS_SET_FOR_SHARDS);
+                    nodeIdsSetsForShardReplica = hzInstance.getMap(GSAC_REPLICAS_FOR_SHARDS);
+                } else {
+                    nodeIdsSetsForShards = localNodeIdsForShards;
+                    nodeIdsSetsForShardReplica = localNodeIdsForShardsReplicas;
+                }
+                for (Map.Entry<Integer, Set<String>> entry : nodeIdsSetsForShards.entrySet()) {
+                    Set<String> shardNodeIds = entry.getValue();
+                    shardNodeIds.removeAll(nonExistingNodeIds);
+                    nodeIdsSetsForShards.put(entry.getKey(), shardNodeIds);
+                }
+                removeNonExistingNodeIdsFromReplica(nonExistingNodeIds, nodeIdsSetsForShardReplica);
+            }
+        } finally {
+            if (gsacWriteNodeIdLock != null) {
+                gsacWriteNodeIdLock.unlock();
+            }
+        }
+    }
+
+    private void removeNonExistingNodeIdsFromReplica(Set<String> nonExistingNodeIds,
+                                                     Map<Integer, Set<String>> nodeIdsSetsForShardReplica) {
+        for (Map.Entry<Integer, Set<String>> entry : nodeIdsSetsForShardReplica.entrySet()) {
+            Set<String> nodeIdsWithReplica = entry.getValue();
+            for (String nonExistingNodeId : nonExistingNodeIds) {
+                for (String nodeIdWithReplica : nodeIdsWithReplica) {
+                    if (nodeIdWithReplica.startsWith(nonExistingNodeId)) {
+                        nodeIdsWithReplica.remove(nodeIdWithReplica);
+                        break;
+                    }
+                }
+            }
+            nodeIdsSetsForShardReplica.put(entry.getKey(), nodeIdsWithReplica);
+        }
+    }
+
+    private void updateShardIndicesMap(int shardIndex, Map<String, Object> values, String mapRef,
+                                       Map<Integer, Set<String>> shardMap) {
+        Map<Integer, Set<String>> nodeIdsSetsForShards;
+        Lock gsacWriteNodeIdLock = null;
+        try {
+            if (acm.isClusteringEnabled()) {
+                gsacWriteNodeIdLock = hzInstance.getLock(GSAC_WRITE_NODE_IDS_FOR_SHARD_LOCK);
+                gsacWriteNodeIdLock.lock();
+                nodeIdsSetsForShards = hzInstance.getMap(mapRef);
+            } else {
+                nodeIdsSetsForShards = shardMap;
+            }
+            nodeIdsSetsForShards.put(shardIndex, new HashSet<>(values.keySet()));
+
+        } finally {
+            if (gsacWriteNodeIdLock != null) {
+                gsacWriteNodeIdLock.unlock();
+            }
+        }
+    }
+
+    private void updateNodeIdsSetForShards(int shardIndex, Map<String, Object> values) {
+        updateShardIndicesMap(shardIndex, values, GSAC_NODE_IDS_SET_FOR_SHARDS, localNodeIdsForShards);
+    }
+
+    private void updateNodeIdsSetForShardsReplicas(int shardIndex, Map<String, Object> values) {
+        updateShardIndicesMap(shardIndex, values, GSAC_REPLICAS_FOR_SHARDS, localNodeIdsForShardsReplicas);
+    }
+
     public void addNodeIdForShard(int shardIndex, String nodeId) throws AnalyticsException {
         Set<String> nodeIds = this.getNodeIdsForShard(shardIndex);
         Map<String, Object> values = new HashMap<>(nodeIds.size() + 1);
@@ -232,24 +236,24 @@ public class GlobalShardAllocationConfig {
         }
         values.put(nodeId, nodeId);
         updateNodeIdsSetForShards(shardIndex, values);
-            }
-
-            void addNodeIdForShard(int shardIndex, int replicaIndex, String nodeId) throws AnalyticsException {
-                Set<String> nodeIds = this.getNodeIdsForShard(shardIndex);
-                Set<String> nodeIdsWithShardReplica = this.getNodeIdsWithReplica(shardIndex);
-                Map<String, Object> uniqueNodeIds = new HashMap<>(nodeIds.size() + 1);
-                Map<String, Object> uniqueNodeIdsWithShardReplica = new HashMap<>(nodeIds.size() + 1);
-                for (String entry : nodeIds) {
-                        uniqueNodeIds.put(entry, entry);
-                    }
-                for (String entry : nodeIdsWithShardReplica) {
-                        uniqueNodeIdsWithShardReplica.put(entry, entry);
-                    }
-                uniqueNodeIds.put(nodeId, nodeId);
-                uniqueNodeIdsWithShardReplica.put(nodeId + GSAC_NODEID_REPLICA_SEPERATOR + replicaIndex,
-                                                          nodeId + GSAC_NODEID_REPLICA_SEPERATOR + replicaIndex);
-                updateNodeIdsSetForShards(shardIndex, uniqueNodeIds);
-                updateNodeIdsSetForShardsReplicas(shardIndex, uniqueNodeIdsWithShardReplica);
     }
-    
+
+    void addNodeIdForShard(int shardIndex, int replicaIndex, String nodeId) throws AnalyticsException {
+        Set<String> nodeIds = this.getNodeIdsForShard(shardIndex);
+        Set<String> nodeIdsWithShardReplica = this.getNodeIdsWithReplica(shardIndex);
+        Map<String, Object> uniqueNodeIds = new HashMap<>(nodeIds.size() + 1);
+        Map<String, Object> uniqueNodeIdsWithShardReplica = new HashMap<>(nodeIds.size() + 1);
+        for (String entry : nodeIds) {
+            uniqueNodeIds.put(entry, entry);
+        }
+        for (String entry : nodeIdsWithShardReplica) {
+            uniqueNodeIdsWithShardReplica.put(entry, entry);
+        }
+        uniqueNodeIds.put(nodeId, nodeId);
+        uniqueNodeIdsWithShardReplica.put(nodeId + GSAC_NODEID_REPLICA_SEPERATOR + replicaIndex,
+                nodeId + GSAC_NODEID_REPLICA_SEPERATOR + replicaIndex);
+        updateNodeIdsSetForShards(shardIndex, uniqueNodeIds);
+        updateNodeIdsSetForShardsReplicas(shardIndex, uniqueNodeIdsWithShardReplica);
+    }
+
 }

--- a/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/indexing/GlobalShardMemberMapping.java
+++ b/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/indexing/GlobalShardMemberMapping.java
@@ -101,7 +101,31 @@ public class GlobalShardMemberMapping {
     public void updateMemberMapping(LocalShardAddressInfo localShardAddressInfo) {
         this.nodeIdMemberMap.put(localShardAddressInfo.getNodeId(), localShardAddressInfo.getMember());
     }
-    
+
+    public Set<String> removeAndGetNonExistingMemberNodeIds() throws AnalyticsException {
+                Set<String> allNodeIds = new HashSet<>();
+                Set<String> removedNodeIds = new HashSet<>();
+                for (Map.Entry<Integer, Set<String>> entry : this.shardNodeIdMap.entrySet()) {
+                        allNodeIds.addAll(entry.getValue());
+                    }
+                for (String nodeId : allNodeIds) {
+                        Object member = nodeIdMemberMap.get(nodeId);
+                        if (member == null) {
+                                nodeIdMemberMap.remove(nodeId);
+                                removedNodeIds.add(nodeId);
+                            }
+                    }
+                if (!removedNodeIds.isEmpty()) {
+                        for (Map.Entry<Integer, Set<String>> entry : this.shardNodeIdMap.entrySet()) {
+                                Set<String> shardNodeIds = entry.getValue();
+                                shardNodeIds.removeAll(removedNodeIds);
+                                shardNodeIdMap.put(entry.getKey(), shardNodeIds);
+                            }
+                    }
+                return removedNodeIds;
+            }
+
+
     @Override
     public String toString() {
         Map<Integer, Map<String, Object>> shardNodeMemberMap = new HashMap<>();

--- a/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/indexing/GlobalShardMemberMapping.java
+++ b/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/indexing/GlobalShardMemberMapping.java
@@ -35,21 +35,21 @@ import java.util.Set;
 public class GlobalShardMemberMapping {
 
     private int shardCount;
-    
+
     private GlobalShardAllocationConfig config;
-    
+
     private Map<String, Object> nodeIdMemberMap;
-    
+
     private Map<Integer, Set<String>> shardNodeIdMap;
-    
+
     private Random random = new Random();
-    
+
     public GlobalShardMemberMapping(int shardCount, GlobalShardAllocationConfig config) throws AnalyticsException {
         this.shardCount = shardCount;
         this.config = config;
         this.reset();
     }
-    
+
     public void reset() throws AnalyticsException {
         this.nodeIdMemberMap = new HashMap<>();
         this.shardNodeIdMap = new HashMap<>();
@@ -57,7 +57,7 @@ public class GlobalShardMemberMapping {
             this.shardNodeIdMap.put(i, this.config.getNodeIdsForShard(i));
         }
     }
-    
+
     public Map<Object, Set<Integer>> generateMemberShardMappingForIndexLookup() {
         Map<Object, Set<Integer>> result = new HashMap<>();
         Object member;
@@ -74,7 +74,7 @@ public class GlobalShardMemberMapping {
         }
         return result;
     }
-    
+
     private Object lookupCandidateMemberFromNodeIds(Set<String> nodeIds) {
         List<Object> members = new ArrayList<>(nodeIds.size());
         Object member;
@@ -89,41 +89,41 @@ public class GlobalShardMemberMapping {
         }
         return members.get(AnalyticsDataIndexer.abs(this.random.nextInt()) % members.size());
     }
-    
+
     public Set<String> getNodeIdsForShard(int shardIndex) throws AnalyticsException {
         return this.shardNodeIdMap.get(shardIndex);
     }
-    
+
     public Object getMemberFromNodeId(String nodeId) {
         return this.nodeIdMemberMap.get(nodeId);
     }
-    
+
     public void updateMemberMapping(LocalShardAddressInfo localShardAddressInfo) {
         this.nodeIdMemberMap.put(localShardAddressInfo.getNodeId(), localShardAddressInfo.getMember());
     }
 
     public Set<String> removeAndGetNonExistingMemberNodeIds() throws AnalyticsException {
-                Set<String> allNodeIds = new HashSet<>();
-                Set<String> removedNodeIds = new HashSet<>();
-                for (Map.Entry<Integer, Set<String>> entry : this.shardNodeIdMap.entrySet()) {
-                        allNodeIds.addAll(entry.getValue());
-                    }
-                for (String nodeId : allNodeIds) {
-                        Object member = nodeIdMemberMap.get(nodeId);
-                        if (member == null) {
-                                nodeIdMemberMap.remove(nodeId);
-                                removedNodeIds.add(nodeId);
-                            }
-                    }
-                if (!removedNodeIds.isEmpty()) {
-                        for (Map.Entry<Integer, Set<String>> entry : this.shardNodeIdMap.entrySet()) {
-                                Set<String> shardNodeIds = entry.getValue();
-                                shardNodeIds.removeAll(removedNodeIds);
-                                shardNodeIdMap.put(entry.getKey(), shardNodeIds);
-                            }
-                    }
-                return removedNodeIds;
+        Set<String> allNodeIds = new HashSet<>();
+        Set<String> removedNodeIds = new HashSet<>();
+        for (Map.Entry<Integer, Set<String>> entry : this.shardNodeIdMap.entrySet()) {
+            allNodeIds.addAll(entry.getValue());
+        }
+        for (String nodeId : allNodeIds) {
+            Object member = nodeIdMemberMap.get(nodeId);
+            if (member == null) {
+                nodeIdMemberMap.remove(nodeId);
+                removedNodeIds.add(nodeId);
             }
+        }
+        if (!removedNodeIds.isEmpty()) {
+            for (Map.Entry<Integer, Set<String>> entry : this.shardNodeIdMap.entrySet()) {
+                Set<String> shardNodeIds = entry.getValue();
+                shardNodeIds.removeAll(removedNodeIds);
+                shardNodeIdMap.put(entry.getKey(), shardNodeIds);
+            }
+        }
+        return removedNodeIds;
+    }
 
 
     @Override
@@ -138,5 +138,5 @@ public class GlobalShardMemberMapping {
         }
         return shardNodeMemberMap.toString();
     }
-    
+
 }

--- a/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/indexing/IndexNodeCoordinator.java
+++ b/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/indexing/IndexNodeCoordinator.java
@@ -104,7 +104,7 @@ public class IndexNodeCoordinator implements GroupEventListener {
 
     /* this executor is specifically used, rather than a single thread executor, so there won't be a thread always live, mostly unused */
     private ExecutorService localShardProcessExecutor = new ThreadPoolExecutor(0, 1,
-            0L, TimeUnit.SECONDS, new LinkedBlockingQueue<Runnable>(),new ThreadFactoryBuilder().
+            0L, TimeUnit.SECONDS, new LinkedBlockingQueue<Runnable>(), new ThreadFactoryBuilder().
             setNameFormat("Thread pool- component - IndexNodeCoordinator.localShardProcessExecutor").build());
 
     public IndexNodeCoordinator(AnalyticsDataIndexer indexer) throws AnalyticsException {
@@ -114,7 +114,7 @@ public class IndexNodeCoordinator implements GroupEventListener {
         this.globalShardAllocationConfig = new GlobalShardAllocationConfig();
 
         this.shardMemberMap = new GlobalShardMemberMapping(this.indexer.getShardCount(),
-                                                           this.globalShardAllocationConfig);
+                this.globalShardAllocationConfig);
         this.stagingIndexDataStore = new StagingIndexDataStore(this.indexer, this.localShardAllocationConfig);
         this.remoteCommunicator = new RemoteMemberIndexCommunicator(indexer.getAnalyticsIndexerInfo()
                 .getIndexCommunicatorBufferSize(), this.stagingIndexDataStore);
@@ -142,7 +142,7 @@ public class IndexNodeCoordinator implements GroupEventListener {
         int shardCount = this.indexer.getShardCount();
         for (int i = 0; i < shardCount; i++) {
             if (this.globalShardAllocationConfig.getNodeIdsForShard(i).contains(this.myNodeId) &&
-                this.localShardAllocationConfig.getShardStatus(i) == null) {
+                    this.localShardAllocationConfig.getShardStatus(i) == null) {
                 result.add(i);
             }
         }
@@ -164,14 +164,14 @@ public class IndexNodeCoordinator implements GroupEventListener {
         for (int shardIndex : this.localShardAllocationConfig.getShardIndices()) {
             status = this.localShardAllocationConfig.getShardStatus(shardIndex);
             replicaIndex = this.localShardAllocationConfig.getShardReplica(shardIndex);
-                        if (status.equals(ShardStatus.NORMAL)) {
-                                this.globalShardAllocationConfig.addNodeIdForShard(shardIndex, replicaIndex, this.myNodeId);
-                            } else if (status.equals(ShardStatus.RESTORE)) {
-                                this.globalShardAllocationConfig.addNodeIdForShard(shardIndex, replicaIndex, this.myNodeId);
-                                this.localShardAllocationConfig.setShardStatus(shardIndex, replicaIndex, ShardStatus.NORMAL);
+            if (status.equals(ShardStatus.NORMAL)) {
+                this.globalShardAllocationConfig.addNodeIdForShard(shardIndex, replicaIndex, this.myNodeId);
+            } else if (status.equals(ShardStatus.RESTORE)) {
+                this.globalShardAllocationConfig.addNodeIdForShard(shardIndex, replicaIndex, this.myNodeId);
+                this.localShardAllocationConfig.setShardStatus(shardIndex, replicaIndex, ShardStatus.NORMAL);
             } else if (status.equals(ShardStatus.INIT)) {
-                            this.globalShardAllocationConfig.addNodeIdForShard(shardIndex, replicaIndex, this.myNodeId);
-                        }
+                this.globalShardAllocationConfig.addNodeIdForShard(shardIndex, replicaIndex, this.myNodeId);
+            }
         }
     }
 
@@ -184,8 +184,8 @@ public class IndexNodeCoordinator implements GroupEventListener {
     }
 
     private void syncLocalWithGlobal() throws AnalyticsException {
-        /* update the local shard allocation config with the details from the 
-         * global config, and considering the INIT entries of the local config, 
+        /* update the local shard allocation config with the details from the
+         * global config, and considering the INIT entries of the local config,
          * where other types will be marked as NORMAL after this */
         List<Integer> initShards = new ArrayList<>();
         for (int shardIndex : this.localShardAllocationConfig.getShardIndices()) {
@@ -242,7 +242,7 @@ public class IndexNodeCoordinator implements GroupEventListener {
         }
         this.syncLocalWithGlobal();
     }
-    
+
     public void init() throws AnalyticsException {
         this.indexingNode = checkIfIndexingNode();
         this.populateMyNodeId();
@@ -357,7 +357,7 @@ public class IndexNodeCoordinator implements GroupEventListener {
         for (Map.Entry<Integer, List<String>> entry : shardedIds.entrySet()) {
             Set<String> nodeIds = this.shardMemberMap.getNodeIdsForShard(entry.getKey());
             for (String nodeId : nodeIds) {
-                if (this.myNodeId.equals(nodeId) && this.indexingNode ) {
+                if (this.myNodeId.equals(nodeId) && this.indexingNode) {
                     localIds.addAll(entry.getValue());
                 } else {
                     Object memberNode = this.shardMemberMap.getMemberFromNodeId(nodeId);
@@ -406,11 +406,11 @@ public class IndexNodeCoordinator implements GroupEventListener {
             }
             //if this.put() is called from within spark executor, the jvm is not the CarbonJVM,
             //So we need a way to identify that, and specifically insert records to staging area.
-                                if (!AnalyticsDataServiceUtils.isCarbonServer() && nodeIds.isEmpty()) {
-                                for (int replica = 1; replica <= shardCopyCount; replica++) {
-                                        this.addToStaging(entry.getKey(), replica, entry.getValue());
-                                    }
-                            }
+            if (!AnalyticsDataServiceUtils.isCarbonServer() && nodeIds.isEmpty()) {
+                for (int replica = 1; replica <= shardCopyCount; replica++) {
+                    this.addToStaging(entry.getKey(), replica, entry.getValue());
+                }
+            }
         }
         this.indexer.putLocal(localRecords);
         for (Map.Entry<String, List<Record>> entry : remoteRecordsMap.entrySet()) {
@@ -428,7 +428,7 @@ public class IndexNodeCoordinator implements GroupEventListener {
                 this.remoteCommunicator.put(member, records, nodeId);
             }
         } catch (Exception e) {
-            String msg = "Error in sending remote record batch put to member: " + member + 
+            String msg = "Error in sending remote record batch put to member: " + member +
                     " with node id: " + nodeId + ": " + e.getMessage() + " -> adding to staging area for later pickup..";
             if (!this.suppressWarnMessagesInactiveMembers.contains(nodeId)) {
                 log.warn(msg);
@@ -460,7 +460,7 @@ public class IndexNodeCoordinator implements GroupEventListener {
                 this.remoteCommunicator.delete(member, tenantId, tableName, ids);
             }
         } catch (Exception e) {
-            String msg = "Error in sending remote record batch delete to member: " + member + 
+            String msg = "Error in sending remote record batch delete to member: " + member +
                     "with node id: " + nodeId + ": " + e.getMessage() + " -> adding to staging area for later pickup..";
             if (!this.suppressWarnMessagesInactiveMembers.contains(nodeId)) {
                 log.warn(msg);
@@ -479,7 +479,7 @@ public class IndexNodeCoordinator implements GroupEventListener {
 
     private void addToStaging(int shardIndex, int replica, List<Record> records) throws AnalyticsException {
         this.stagingIndexDataStore.put(shardIndex, replica, records);
-        }
+    }
 
     private void addToStaging(String nodeId, int tenantId, String tableName, List<String> ids)
             throws AnalyticsException {
@@ -492,7 +492,7 @@ public class IndexNodeCoordinator implements GroupEventListener {
         }
         AnalyticsDataService ads = AnalyticsServiceHolder.getAnalyticsDataService();
         AnalyticsDataResponse resp = ads.get(tableId.getTenantId(), tableId.getTableName(), 1, null,
-                                             Long.MIN_VALUE, Long.MAX_VALUE, 0, -1);
+                Long.MIN_VALUE, Long.MAX_VALUE, 0, -1);
         Iterator<Record> itr = AnalyticsDataServiceUtils.responseToIterator(ads, resp);
         List<Record> records = new ArrayList<>(Constants.RECORDS_BATCH_SIZE);
         Record record;
@@ -518,8 +518,8 @@ public class IndexNodeCoordinator implements GroupEventListener {
     private Map<String, Map<Integer, Integer>> loadGlobalShards() throws AnalyticsException {
         int shardCount = this.indexer.getShardCount();
         Map<String, Map<Integer, Integer>> result = new HashMap<>();
-               Set<String> nodeIdsWithShardReplica;
-                Map<Integer, Integer> shards;
+        Set<String> nodeIdsWithShardReplica;
+        Map<Integer, Integer> shards;
         for (int i = 0; i < shardCount; i++) {
             nodeIdsWithShardReplica = this.globalShardAllocationConfig.getNodeIdsWithReplica(i);
             for (String nodeIdWithReplica : nodeIdsWithShardReplica) {
@@ -538,7 +538,7 @@ public class IndexNodeCoordinator implements GroupEventListener {
     }
 
     private Map<Integer, Integer> allocateNewLocalShards(boolean initialAllocation) throws AnalyticsException {
-                Map<Integer, Integer> result = new HashMap<>();
+        Map<Integer, Integer> result = new HashMap<>();
         int shardCopyCount = this.indexer.getReplicationFactor() + 1;
         if (log.isDebugEnabled()) {
             log.debug("Replication Factor: " + this.indexer.getReplicationFactor());
@@ -594,7 +594,7 @@ public class IndexNodeCoordinator implements GroupEventListener {
             for (Map.Entry<Integer, Integer> entry : newShards.entrySet()) {
                 this.localShardAllocationConfig.setShardStatus(entry.getKey(), entry.getValue(), ShardStatus.INIT);
                 this.globalShardAllocationConfig.addNodeIdForShard(entry.getKey(), entry.getValue(), this.myNodeId);
-                }
+            }
         }
     }
 
@@ -609,8 +609,8 @@ public class IndexNodeCoordinator implements GroupEventListener {
         return myShards;
     }
 
-        private boolean populateMyNodeId() throws AnalyticsException {
-                   boolean shouldCreateNodeId = false;
+    private boolean populateMyNodeId() throws AnalyticsException {
+        boolean shouldCreateNodeId = false;
         if (this.myNodeId == null) {
             try {
                 File oldNodeIdFile = new File(GenericUtils.resolveLocation(Constants.DEPRECATED_MY_NODEID_LOCATION));
@@ -632,29 +632,29 @@ public class IndexNodeCoordinator implements GroupEventListener {
             }
         }
         log.info("My Analytics Node ID: " + this.myNodeId);
-            return shouldCreateNodeId;
-            }
+        return shouldCreateNodeId;
+    }
 
-            private void loadNodeIdIfExists(File oldNodeIdFile, File newNodeIdFile) throws IOException {
-                if (oldNodeIdFile.exists() && !newNodeIdFile.exists()) {
-                        this.myNodeId = FileUtil.readFileToString(GenericUtils.resolveLocation(
-                                        Constants.DEPRECATED_MY_NODEID_LOCATION)).trim();
-                        FileUtils.copyFile(oldNodeIdFile, newNodeIdFile);
-                        oldNodeIdFile.delete();
-                    } else {
-                        this.myNodeId = FileUtil.readFileToString(GenericUtils.resolveLocation(
-                                        Constants.MY_NODEID_LOCATION)).trim();
-                    }
-            }
+    private void loadNodeIdIfExists(File oldNodeIdFile, File newNodeIdFile) throws IOException {
+        if (oldNodeIdFile.exists() && !newNodeIdFile.exists()) {
+            this.myNodeId = FileUtil.readFileToString(GenericUtils.resolveLocation(
+                    Constants.DEPRECATED_MY_NODEID_LOCATION)).trim();
+            FileUtils.copyFile(oldNodeIdFile, newNodeIdFile);
+            oldNodeIdFile.delete();
+        } else {
+            this.myNodeId = FileUtil.readFileToString(GenericUtils.resolveLocation(
+                    Constants.MY_NODEID_LOCATION)).trim();
+        }
+    }
 
-            private void createNewNodeIDFile() throws AnalyticsException {
-                this.myNodeId = UUID.randomUUID().toString();
-                try {
-                        FileUtils.writeStringToFile(new File(GenericUtils.resolveLocation(
-                                        Constants.MY_NODEID_LOCATION)), this.myNodeId);
-                    } catch (IOException e) {
-                        throw new AnalyticsException("Error in writing my node id: " + e.getMessage(), e);
-                    }
+    private void createNewNodeIDFile() throws AnalyticsException {
+        this.myNodeId = UUID.randomUUID().toString();
+        try {
+            FileUtils.writeStringToFile(new File(GenericUtils.resolveLocation(
+                    Constants.MY_NODEID_LOCATION)), this.myNodeId);
+        } catch (IOException e) {
+            throw new AnalyticsException("Error in writing my node id: " + e.getMessage(), e);
+        }
     }
 
     @Override
@@ -696,7 +696,7 @@ public class IndexNodeCoordinator implements GroupEventListener {
         this.suppressWarnMessagesInactiveMembers.clear();
         AnalyticsClusterManager acm = AnalyticsServiceHolder.getAnalyticsClusterManager();
         List<LocalShardAddressInfo> result = acm.executeAll(Constants.ANALYTICS_INDEXING_GROUP,
-                                                            new QueryLocalShardsAndAddressCall());
+                new QueryLocalShardsAndAddressCall());
         for (LocalShardAddressInfo entry : result) {
             this.shardMemberMap.updateMemberMapping(entry);
         }
@@ -751,26 +751,26 @@ public class IndexNodeCoordinator implements GroupEventListener {
     }
 
     private void processOldStagingData() {
-                if (!this.indexingNode) {
-                        return;
-                    }
-                int localShardIndices = this.indexer.getShardCount();
-                if (localShardIndices == 0) {
-                        return;
-                    }
-                this.oldStagingWorkerExecutor = Executors.newFixedThreadPool(localShardIndices,
-                                new ThreadFactoryBuilder().setNameFormat("Thread pool- component - IndexNodeCoordinator.OldStagingWorkerExecutor").build());
-                this.oldStagingDataIndexWorkers = new ArrayList<>(this.indexer.getShardCount());
-                for (int i = 0; i < localShardIndices; i++) {
-                        OldStagingDataIndexWorker worker = new OldStagingDataIndexWorker(i);
-                        this.oldStagingDataIndexWorkers.add(worker);
-                        this.oldStagingWorkerExecutor.execute(worker);
-                    }
-                if (log.isDebugEnabled()) {
-                        log.debug("Created " + this.oldStagingDataIndexWorkers.size() + " staging worker threads for older " +
-                                "staging tables");
-                    }
-            }
+        if (!this.indexingNode) {
+            return;
+        }
+        int localShardIndices = this.indexer.getShardCount();
+        if (localShardIndices == 0) {
+            return;
+        }
+        this.oldStagingWorkerExecutor = Executors.newFixedThreadPool(localShardIndices,
+                new ThreadFactoryBuilder().setNameFormat("Thread pool- component - IndexNodeCoordinator.OldStagingWorkerExecutor").build());
+        this.oldStagingDataIndexWorkers = new ArrayList<>(this.indexer.getShardCount());
+        for (int i = 0; i < localShardIndices; i++) {
+            OldStagingDataIndexWorker worker = new OldStagingDataIndexWorker(i);
+            this.oldStagingDataIndexWorkers.add(worker);
+            this.oldStagingWorkerExecutor.execute(worker);
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Created " + this.oldStagingDataIndexWorkers.size() + " staging worker threads for older " +
+                    "staging tables");
+        }
+    }
 
     public void close() {
         this.remoteCommunicator.close();
@@ -792,8 +792,8 @@ public class IndexNodeCoordinator implements GroupEventListener {
             this.syncLocalWithGlobal();
         }
         log.info("Indexing Initialized: " + (this.isClusteringEnabled() ?
-                                             "CLUSTERED " + this.shardMemberMap : "STANDALONE") + " | Current Node Indexing: " +
-                 (this.indexingNode ? "Yes" : "No"));
+                "CLUSTERED " + this.shardMemberMap : "STANDALONE") + " | Current Node Indexing: " +
+                (this.indexingNode ? "Yes" : "No"));
     }
 
     public void waitForIndexing(long maxWait) throws AnalyticsException {
@@ -1035,7 +1035,7 @@ public class IndexNodeCoordinator implements GroupEventListener {
             this.indexer.deleteLocal(entry.getTenantId(), entry.getTableName(), new ArrayList<>(deleteIds));
             if (log.isDebugEnabled()) {
                 log.debug("Processing staged operation [" + shardIndex + "] PUT: " +
-                        +                          records.size() + " DELETE: " + deleteIds.size());
+                        +records.size() + " DELETE: " + deleteIds.size());
             }
         } catch (AnalyticsInterruptException e) {
             throw e;
@@ -1103,55 +1103,56 @@ public class IndexNodeCoordinator implements GroupEventListener {
     }
 
     /**
-         * This class consumes the index staging data that is been put by data publishers like the Spark analytics tables,
-          * which does not have direct visibility to indexing nodes.
+     * This class consumes the index staging data that is been put by data publishers like the Spark analytics tables,
+     * which does not have direct visibility to indexing nodes.
      */
     private class OldStagingDataIndexWorker implements Runnable {
         private static final int STAGING_INDEXER_WORKER_SLEEP = 5000;
         private int shardIndex;
         private boolean stop;
+
         public OldStagingDataIndexWorker(int shardIndex) {
             this.shardIndex = shardIndex;
-            }
-
-                    @Override
-                    public void run() {
-                       while (!this.stop) {
-                                try {
-                                        List<StagingIndexDataEntry> entries =
-                                                stagingIndexDataStore.loadEntriesInOldStagingTables(myNodeId, this.shardIndex);
-                                        if (!entries.isEmpty()) {
-                                                for (StagingIndexDataEntry entry : entries) {
-                                                        processStagingEntry(this.shardIndex, entry);
-                                                        stagingIndexDataStore.removeEntriesFromOldStagingTables(myNodeId, shardIndex,
-                                                                Arrays.asList(entry.getRecordId()));
-                                                    }
-                                            } else {
-                                                Thread.sleep(STAGING_INDEXER_WORKER_SLEEP);
-                                                if (log.isDebugEnabled()) {
-                                                        log.debug("No data available in Old staging table for shard: " + shardIndex + ", hence " +
-                                                                          "stopping the old staging index worker for shard: " + shardIndex + ".");
-                                                    }
-                                                stop();
-                                                stagingIndexDataStore.deleteStagingEntryLocation(myNodeId, this.shardIndex);
-                                            }
-                                    } catch (AnalyticsInterruptException | InterruptedException e) {
-                                        // This exception can be thrown from data queues, if the shutdown hook is triggered
-                                                log.debug("Old staging Data Index Worker Interuppted [" + this.shardIndex + "]: " + e.getMessage(),
-                                                                  e);
-                                        return;
-                                    } catch (Exception e) {
-                                        log.error("Error in processing Old staging index data: " + e.getMessage(), e);
-                                    }
-                            }
-                        if (log.isDebugEnabled()) {
-                                log.debug("Old Staging Data Index Worker Exiting [" + this.shardIndex + "]");
-                            }
         }
 
-                public void stop() {
-                        this.stop = true;
+        @Override
+        public void run() {
+            while (!this.stop) {
+                try {
+                    List<StagingIndexDataEntry> entries =
+                            stagingIndexDataStore.loadEntriesInOldStagingTables(myNodeId, this.shardIndex);
+                    if (!entries.isEmpty()) {
+                        for (StagingIndexDataEntry entry : entries) {
+                            processStagingEntry(this.shardIndex, entry);
+                            stagingIndexDataStore.removeEntriesFromOldStagingTables(myNodeId, shardIndex,
+                                    Arrays.asList(entry.getRecordId()));
+                        }
+                    } else {
+                        Thread.sleep(STAGING_INDEXER_WORKER_SLEEP);
+                        if (log.isDebugEnabled()) {
+                            log.debug("No data available in Old staging table for shard: " + shardIndex + ", hence " +
+                                    "stopping the old staging index worker for shard: " + shardIndex + ".");
+                        }
+                        stop();
+                        stagingIndexDataStore.deleteStagingEntryLocation(myNodeId, this.shardIndex);
                     }
+                } catch (AnalyticsInterruptException | InterruptedException e) {
+                    // This exception can be thrown from data queues, if the shutdown hook is triggered
+                    log.debug("Old staging Data Index Worker Interuppted [" + this.shardIndex + "]: " + e.getMessage(),
+                            e);
+                    return;
+                } catch (Exception e) {
+                    log.error("Error in processing Old staging index data: " + e.getMessage(), e);
+                }
+            }
+            if (log.isDebugEnabled()) {
+                log.debug("Old Staging Data Index Worker Exiting [" + this.shardIndex + "]");
+            }
+        }
+
+        public void stop() {
+            this.stop = true;
+        }
     }
 
 

--- a/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/indexing/LocalShardAllocationConfig.java
+++ b/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/indexing/LocalShardAllocationConfig.java
@@ -39,20 +39,70 @@ public class LocalShardAllocationConfig implements Serializable {
     private static final long serialVersionUID = -5632823561738758193L;
 
     private Map<Integer, ShardStatus> shardStatusMap = new HashMap<>();
+    private Map<Integer, Integer> shardReplicaMap = new HashMap<>();
 
     private boolean init;
 
     public LocalShardAllocationConfig() throws AnalyticsException {
-        String config = null;
+
         try {
-            config = FileUtil.readFileToString(GenericUtils.resolveLocation(Constants.LOCAL_SHARD_ALLOCATION_CONFIG_LOCATION));
+            initShardStatusMap();
+            initShardReplicaMap();
         } catch (FileNotFoundException e) {
             this.init = false;
             return;
         } catch (Exception e) {
             throw new AnalyticsException("Error in loading local shard allocation configuration: " + e.getMessage(), e);
         }
-        String[] entries = config.split("\n");
+    }
+            private void initShardReplicaMap() throws AnalyticsException {
+                String[] entries;
+                String[] entryStrArray;
+                int shardIndex;
+                String shardReplicaConfig;
+                try {
+                        shardReplicaConfig = FileUtil.readFileToString(GenericUtils.resolveLocation(Constants
+                                       .LOCAL_SHARD_REPLICA_CONFIG_LOCATION));
+                    } catch (FileNotFoundException e) {
+                        shardReplicaConfig = "";
+                    }  catch (IOException e) {
+                        throw new AnalyticsException("Error in loading local shard allocation configuration: " + e.getMessage(), e);
+                    }
+                entries = shardReplicaConfig.split("\n");
+                int replica;
+                for (String entry : entries) {
+                        entry = entry.trim();
+                        if (!entry.isEmpty()) {
+                            entryStrArray = entry.split(",");
+                                shardIndex = Integer.parseInt(entryStrArray[0].trim());
+                                replica = Integer.valueOf(entryStrArray[1].trim());
+                                this.shardReplicaMap.put(shardIndex, replica);
+                            }
+                    }
+        }
+
+            private void initShardStatusMap() throws IOException {
+                String shardStatusConfig;
+                        File oldShardAllocationFile = new File(
+                                GenericUtils.resolveLocation(Constants.DEPRECATED_LOCAL_SHARD_ALLOCATION_CONFIG_LOCATION));
+                File newShardAllocationFile = new File(
+                                GenericUtils.resolveLocation(Constants.LOCAL_SHARD_ALLOCATION_CONFIG_LOCATION));
+                File indexStagingLocation = new File(GenericUtils.resolveLocation(
+                                Constants.DEFAULT_LOCAL_INDEX_STAGING_LOCATION));
+                File indexStoreLocation = new File(GenericUtils.resolveLocation(
+                                Constants.DEFAULT_LOCAL_INDEX_STAGING_LOCATION));
+                if (oldShardAllocationFile.exists() && !newShardAllocationFile.exists()) {
+                        if (indexStagingLocation.exists()) {
+                                FileUtils.deleteDirectory(indexStagingLocation);
+                            }
+                        if (indexStoreLocation.exists()) {
+                                FileUtils.deleteDirectory(indexStoreLocation);
+                            }
+                        oldShardAllocationFile.delete();
+                    }
+                shardStatusConfig = FileUtil.readFileToString(GenericUtils.resolveLocation(Constants
+                                .LOCAL_SHARD_ALLOCATION_CONFIG_LOCATION));
+                String[] entries = shardStatusConfig.split("\n");
         int shardIndex;
         ShardStatus status;
         String[] entryStrArray;
@@ -72,6 +122,13 @@ public class LocalShardAllocationConfig implements Serializable {
         return init;
     }
 
+    public int getShardReplica(int shardIndex) {
+        if (this.shardReplicaMap.containsKey(shardIndex)) {
+                        return this.shardReplicaMap.get(shardIndex);
+                    }
+                return 0;
+        }
+
     public ShardStatus getShardStatus(int shardIndex) {
         return this.shardStatusMap.get(shardIndex);
     }
@@ -84,6 +141,8 @@ public class LocalShardAllocationConfig implements Serializable {
         try {
             FileUtils.writeStringToFile(new File(GenericUtils.resolveLocation(
                     Constants.LOCAL_SHARD_ALLOCATION_CONFIG_LOCATION)), this.toString());
+            FileUtils.writeStringToFile(new File(GenericUtils.resolveLocation(Constants
+                                        .LOCAL_SHARD_REPLICA_CONFIG_LOCATION)), this.shardReplicaToString());
         } catch (IOException e) {
             throw new AnalyticsException("Error in saving local shard allocation configuration: " + e.getMessage(), e);
         }
@@ -91,11 +150,26 @@ public class LocalShardAllocationConfig implements Serializable {
 
     public void removeShardIndex(int shardIndex) throws AnalyticsException {
         this.shardStatusMap.remove(shardIndex);
+        this.shardReplicaMap.remove(shardIndex);
     }
 
     public void setShardStatus(int shardIndex, ShardStatus status) throws AnalyticsException {
         this.shardStatusMap.put(shardIndex, status);
     }
+
+    void setShardStatus(int shardIndex, int replica, ShardStatus status) throws AnalyticsException {
+                this.shardStatusMap.put(shardIndex, status);
+                this.shardReplicaMap.put(shardIndex, replica);
+            }
+
+            private String shardReplicaToString() {
+                StringBuilder builder = new StringBuilder();
+                for (Map.Entry<Integer, Integer> entry : this.shardReplicaMap.entrySet()) {
+                        builder.append(entry.getKey() + "," + entry.getValue().toString() + "\n");
+                    }
+                return builder.toString();
+            }
+
 
     @Override
     public String toString() {

--- a/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/indexing/LocalShardAllocationConfig.java
+++ b/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/indexing/LocalShardAllocationConfig.java
@@ -55,54 +55,55 @@ public class LocalShardAllocationConfig implements Serializable {
             throw new AnalyticsException("Error in loading local shard allocation configuration: " + e.getMessage(), e);
         }
     }
-            private void initShardReplicaMap() throws AnalyticsException {
-                String[] entries;
-                String[] entryStrArray;
-                int shardIndex;
-                String shardReplicaConfig;
-                try {
-                        shardReplicaConfig = FileUtil.readFileToString(GenericUtils.resolveLocation(Constants
-                                       .LOCAL_SHARD_REPLICA_CONFIG_LOCATION));
-                    } catch (FileNotFoundException e) {
-                        shardReplicaConfig = "";
-                    }  catch (IOException e) {
-                        throw new AnalyticsException("Error in loading local shard allocation configuration: " + e.getMessage(), e);
-                    }
-                entries = shardReplicaConfig.split("\n");
-                int replica;
-                for (String entry : entries) {
-                        entry = entry.trim();
-                        if (!entry.isEmpty()) {
-                            entryStrArray = entry.split(",");
-                                shardIndex = Integer.parseInt(entryStrArray[0].trim());
-                                replica = Integer.valueOf(entryStrArray[1].trim());
-                                this.shardReplicaMap.put(shardIndex, replica);
-                            }
-                    }
-        }
 
-            private void initShardStatusMap() throws IOException {
-                String shardStatusConfig;
-                        File oldShardAllocationFile = new File(
-                                GenericUtils.resolveLocation(Constants.DEPRECATED_LOCAL_SHARD_ALLOCATION_CONFIG_LOCATION));
-                File newShardAllocationFile = new File(
-                                GenericUtils.resolveLocation(Constants.LOCAL_SHARD_ALLOCATION_CONFIG_LOCATION));
-                File indexStagingLocation = new File(GenericUtils.resolveLocation(
-                                Constants.DEFAULT_LOCAL_INDEX_STAGING_LOCATION));
-                File indexStoreLocation = new File(GenericUtils.resolveLocation(
-                                Constants.DEFAULT_LOCAL_INDEX_STAGING_LOCATION));
-                if (oldShardAllocationFile.exists() && !newShardAllocationFile.exists()) {
-                        if (indexStagingLocation.exists()) {
-                                FileUtils.deleteDirectory(indexStagingLocation);
-                            }
-                        if (indexStoreLocation.exists()) {
-                                FileUtils.deleteDirectory(indexStoreLocation);
-                            }
-                        oldShardAllocationFile.delete();
-                    }
-                shardStatusConfig = FileUtil.readFileToString(GenericUtils.resolveLocation(Constants
-                                .LOCAL_SHARD_ALLOCATION_CONFIG_LOCATION));
-                String[] entries = shardStatusConfig.split("\n");
+    private void initShardReplicaMap() throws AnalyticsException {
+        String[] entries;
+        String[] entryStrArray;
+        int shardIndex;
+        String shardReplicaConfig;
+        try {
+            shardReplicaConfig = FileUtil.readFileToString(GenericUtils.resolveLocation(Constants
+                    .LOCAL_SHARD_REPLICA_CONFIG_LOCATION));
+        } catch (FileNotFoundException e) {
+            shardReplicaConfig = "";
+        } catch (IOException e) {
+            throw new AnalyticsException("Error in loading local shard allocation configuration: " + e.getMessage(), e);
+        }
+        entries = shardReplicaConfig.split("\n");
+        int replica;
+        for (String entry : entries) {
+            entry = entry.trim();
+            if (!entry.isEmpty()) {
+                entryStrArray = entry.split(",");
+                shardIndex = Integer.parseInt(entryStrArray[0].trim());
+                replica = Integer.valueOf(entryStrArray[1].trim());
+                this.shardReplicaMap.put(shardIndex, replica);
+            }
+        }
+    }
+
+    private void initShardStatusMap() throws IOException {
+        String shardStatusConfig;
+        File oldShardAllocationFile = new File(
+                GenericUtils.resolveLocation(Constants.DEPRECATED_LOCAL_SHARD_ALLOCATION_CONFIG_LOCATION));
+        File newShardAllocationFile = new File(
+                GenericUtils.resolveLocation(Constants.LOCAL_SHARD_ALLOCATION_CONFIG_LOCATION));
+        File indexStagingLocation = new File(GenericUtils.resolveLocation(
+                Constants.DEFAULT_LOCAL_INDEX_STAGING_LOCATION));
+        File indexStoreLocation = new File(GenericUtils.resolveLocation(
+                Constants.DEFAULT_LOCAL_INDEX_STAGING_LOCATION));
+        if (oldShardAllocationFile.exists() && !newShardAllocationFile.exists()) {
+            if (indexStagingLocation.exists()) {
+                FileUtils.deleteDirectory(indexStagingLocation);
+            }
+            if (indexStoreLocation.exists()) {
+                FileUtils.deleteDirectory(indexStoreLocation);
+            }
+            oldShardAllocationFile.delete();
+        }
+        shardStatusConfig = FileUtil.readFileToString(GenericUtils.resolveLocation(Constants
+                .LOCAL_SHARD_ALLOCATION_CONFIG_LOCATION));
+        String[] entries = shardStatusConfig.split("\n");
         int shardIndex;
         ShardStatus status;
         String[] entryStrArray;
@@ -124,10 +125,10 @@ public class LocalShardAllocationConfig implements Serializable {
 
     public int getShardReplica(int shardIndex) {
         if (this.shardReplicaMap.containsKey(shardIndex)) {
-                        return this.shardReplicaMap.get(shardIndex);
-                    }
-                return 0;
+            return this.shardReplicaMap.get(shardIndex);
         }
+        return 0;
+    }
 
     public ShardStatus getShardStatus(int shardIndex) {
         return this.shardStatusMap.get(shardIndex);
@@ -142,7 +143,7 @@ public class LocalShardAllocationConfig implements Serializable {
             FileUtils.writeStringToFile(new File(GenericUtils.resolveLocation(
                     Constants.LOCAL_SHARD_ALLOCATION_CONFIG_LOCATION)), this.toString());
             FileUtils.writeStringToFile(new File(GenericUtils.resolveLocation(Constants
-                                        .LOCAL_SHARD_REPLICA_CONFIG_LOCATION)), this.shardReplicaToString());
+                    .LOCAL_SHARD_REPLICA_CONFIG_LOCATION)), this.shardReplicaToString());
         } catch (IOException e) {
             throw new AnalyticsException("Error in saving local shard allocation configuration: " + e.getMessage(), e);
         }
@@ -158,17 +159,17 @@ public class LocalShardAllocationConfig implements Serializable {
     }
 
     void setShardStatus(int shardIndex, int replica, ShardStatus status) throws AnalyticsException {
-                this.shardStatusMap.put(shardIndex, status);
-                this.shardReplicaMap.put(shardIndex, replica);
-            }
+        this.shardStatusMap.put(shardIndex, status);
+        this.shardReplicaMap.put(shardIndex, replica);
+    }
 
-            private String shardReplicaToString() {
-                StringBuilder builder = new StringBuilder();
-                for (Map.Entry<Integer, Integer> entry : this.shardReplicaMap.entrySet()) {
-                        builder.append(entry.getKey() + "," + entry.getValue().toString() + "\n");
-                    }
-                return builder.toString();
-            }
+    private String shardReplicaToString() {
+        StringBuilder builder = new StringBuilder();
+        for (Map.Entry<Integer, Integer> entry : this.shardReplicaMap.entrySet()) {
+            builder.append(entry.getKey() + "," + entry.getValue().toString() + "\n");
+        }
+        return builder.toString();
+    }
 
 
     @Override

--- a/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/indexing/StagingIndexDataStore.java
+++ b/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/indexing/StagingIndexDataStore.java
@@ -43,16 +43,24 @@ public class StagingIndexDataStore {
     private Log log = LogFactory.getLog(StagingIndexDataStore.class);
     
     private AnalyticsDataIndexer indexer;
+    private LocalShardAllocationConfig localShardAllocationConfig;
     
     public StagingIndexDataStore(AnalyticsDataIndexer indexer) {
         this.indexer = indexer;
     }
+
+    public StagingIndexDataStore(AnalyticsDataIndexer indexer, LocalShardAllocationConfig config) {
+        this.indexer = indexer;
+                this.localShardAllocationConfig = config; }
     
     public void initStagingTables(String nodeId) throws AnalyticsException {
         AnalyticsRecordStore rs = this.indexer.getAnalyticsRecordStore();
         int shardCount = this.indexer.getShardCount();
         for (int i = 0; i < shardCount; i++) {
-            rs.createTable(Constants.META_INFO_TENANT_ID, this.generateTableName(nodeId, i));
+            String tableName = this.generateTableName(nodeId, i);
+            if (tableName != null){
+                rs.createTable(Constants.META_INFO_TENANT_ID, tableName);
+                }
         }
     }
     
@@ -74,6 +82,20 @@ public class StagingIndexDataStore {
         if (log.isDebugEnabled()) {
             log.debug("Staging index data put: " + records.size());
         }
+    }
+
+            public void put(int shardIndex, int replica, List<Record> records) throws AnalyticsException {
+                Collection<List<Record>> recordBatches = GenericUtils.generateRecordBatches(records);
+                for (List<Record> recordBatch : recordBatches) {
+                        int tenantId = recordBatch.get(0).getTenantId();
+                        String tableName = recordBatch.get(0).getTableName();
+                        List<String> ids = new ArrayList<>();
+                        for (Record record : recordBatch) {
+                                ids.add(record.getId());
+                            }
+                        StagingIndexDataEntry indexEntry = new StagingIndexDataEntry(tenantId, tableName, ids);
+                        this.addEntryToShard(shardIndex, replica, indexEntry);
+                    }
     }
     
     public void delete(String nodeId, int tenantId, String tableName, List<String> ids) throws AnalyticsException {
@@ -102,17 +124,57 @@ public class StagingIndexDataStore {
             rs.put(Arrays.asList(record));
         }
     }
-    
-    private String generateTableName(String nodeId, int shardIndex) {
+
+    private void addEntryToShard(int shardIndex, int replica, StagingIndexDataEntry entry) throws AnalyticsException {
+                String tableName = this.generateTableName(shardIndex, replica);
+                int tenantId = Constants.META_INFO_TENANT_ID;
+                Map<String, Object> values = new HashMap<>(1);
+                values.put(Constants.INDEX_STAGING_DATA_COLUMN, entry);
+                AnalyticsRecordStore rs = this.indexer.getAnalyticsRecordStore();
+                Record record = new Record(GenericUtils.generateRecordID(), tenantId, tableName, values);
+                entry.setRecordId(record.getId());
+                try {
+                        rs.put(Arrays.asList(record));
+                    } catch (AnalyticsTableNotAvailableException e) {
+                        rs.createTable(tenantId, tableName);
+                        rs.put(Arrays.asList(record));
+                    }
+            }
+
+    private String generateTableNameForOlderStagingTable(String nodeId, int shardIndex) {
         return Constants.INDEX_STAGING_DATA_TABLE + shardIndex + "_" + nodeId;
     }
+
+    private String generateTableName(String nodeId, int shardIndex) {
+                int shardReplica = localShardAllocationConfig.getShardReplica(shardIndex);
+                if (shardReplica != 0) {
+                        return Constants.INDEX_STAGING_DATA_TABLE + shardIndex + "_" + shardReplica;
+                    }
+                return null;
+            }
+
+            private String generateTableName(int shardIndex, int replica) {
+                return Constants.INDEX_STAGING_DATA_TABLE + shardIndex + "_" + replica;
+            }
     
     public List<StagingIndexDataEntry> loadEntries(String nodeId, int shardIndex) throws AnalyticsException {
+        return getStagingIndexDataEntries(this.generateTableName(nodeId, shardIndex));
+           }
+
+           public List<StagingIndexDataEntry> loadEntriesInOldStagingTables(String nodeId, int shardIndex) throws
+                                                                                              AnalyticsException {
+                return getStagingIndexDataEntries(this.generateTableNameForOlderStagingTable(nodeId, shardIndex));
+            }
+
+            private List<StagingIndexDataEntry> getStagingIndexDataEntries(String stagingTable)
+            throws AnalyticsException {
+                if (stagingTable == null) {
+                        return new ArrayList<>(0); }
         AnalyticsRecordStore rs = this.indexer.getAnalyticsRecordStore();
         try {
-            List<Record> records = GenericUtils.listRecords(rs, rs.get(Constants.META_INFO_TENANT_ID, 
-                    this.generateTableName(nodeId, shardIndex), 1, null, 
-                    Long.MIN_VALUE, Long.MAX_VALUE, 0, Constants.RECORDS_BATCH_SIZE));
+            List<Record> records = GenericUtils.listRecords(rs, rs.get(Constants.META_INFO_TENANT_ID,
+                    stagingTable, 1, null, Long.MIN_VALUE, Long.MAX_VALUE, 0,
+                    Constants.RECORDS_BATCH_SIZE));
             List<StagingIndexDataEntry> result = new ArrayList<>(records.size());
             for (Record record : records) {
                 result.add((StagingIndexDataEntry) record.getValue(Constants.INDEX_STAGING_DATA_COLUMN));
@@ -124,10 +186,24 @@ public class StagingIndexDataStore {
     }
     
     public void removeEntries(String nodeId, int shardIndex, List<String> ids) throws AnalyticsException {
+        removeStagingEntries(this.generateTableName(nodeId, shardIndex), ids);
+        }
+
+            public void removeEntriesFromOldStagingTables(String nodeId, int shardIndex, List<String> ids) throws
+            AnalyticsException {
+                removeStagingEntries(this.generateTableNameForOlderStagingTable(nodeId, shardIndex), ids);
+            }
+
+            public void deleteStagingEntryLocation(String nodeId, int shardIndex) throws AnalyticsException {
         AnalyticsRecordStore rs = this.indexer.getAnalyticsRecordStore();
-        rs.delete(Constants.META_INFO_TENANT_ID, this.generateTableName(nodeId, shardIndex), ids);
+                rs.deleteTable(Constants.META_INFO_TENANT_ID, generateTableNameForOlderStagingTable(nodeId, shardIndex));
     }
-    
+
+    private void removeStagingEntries(String stagingTable, List<String> ids) throws AnalyticsException {
+                AnalyticsRecordStore rs = this.indexer.getAnalyticsRecordStore();
+                rs.delete(Constants.META_INFO_TENANT_ID, stagingTable, ids);
+            }
+
     public static class StagingIndexDataEntry implements Serializable {
         
         private static final long serialVersionUID = 2811642328079107132L;

--- a/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/indexing/StagingIndexDataStore.java
+++ b/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/indexing/StagingIndexDataStore.java
@@ -41,29 +41,30 @@ import org.wso2.carbon.analytics.datasource.core.util.GenericUtils;
 public class StagingIndexDataStore {
 
     private Log log = LogFactory.getLog(StagingIndexDataStore.class);
-    
+
     private AnalyticsDataIndexer indexer;
     private LocalShardAllocationConfig localShardAllocationConfig;
-    
+
     public StagingIndexDataStore(AnalyticsDataIndexer indexer) {
         this.indexer = indexer;
     }
 
     public StagingIndexDataStore(AnalyticsDataIndexer indexer, LocalShardAllocationConfig config) {
         this.indexer = indexer;
-                this.localShardAllocationConfig = config; }
-    
+        this.localShardAllocationConfig = config;
+    }
+
     public void initStagingTables(String nodeId) throws AnalyticsException {
         AnalyticsRecordStore rs = this.indexer.getAnalyticsRecordStore();
         int shardCount = this.indexer.getShardCount();
         for (int i = 0; i < shardCount; i++) {
             String tableName = this.generateTableName(nodeId, i);
-            if (tableName != null){
+            if (tableName != null) {
                 rs.createTable(Constants.META_INFO_TENANT_ID, tableName);
-                }
+            }
         }
     }
-    
+
     public void put(String nodeId, List<Record> records) throws AnalyticsException {
         Map<Integer, List<Record>> shardedRecords = this.indexer.extractShardedRecords(records);
         for (Map.Entry<Integer, List<Record>> entry : shardedRecords.entrySet()) {
@@ -84,20 +85,20 @@ public class StagingIndexDataStore {
         }
     }
 
-            public void put(int shardIndex, int replica, List<Record> records) throws AnalyticsException {
-                Collection<List<Record>> recordBatches = GenericUtils.generateRecordBatches(records);
-                for (List<Record> recordBatch : recordBatches) {
-                        int tenantId = recordBatch.get(0).getTenantId();
-                        String tableName = recordBatch.get(0).getTableName();
-                        List<String> ids = new ArrayList<>();
-                        for (Record record : recordBatch) {
-                                ids.add(record.getId());
-                            }
-                        StagingIndexDataEntry indexEntry = new StagingIndexDataEntry(tenantId, tableName, ids);
-                        this.addEntryToShard(shardIndex, replica, indexEntry);
-                    }
+    public void put(int shardIndex, int replica, List<Record> records) throws AnalyticsException {
+        Collection<List<Record>> recordBatches = GenericUtils.generateRecordBatches(records);
+        for (List<Record> recordBatch : recordBatches) {
+            int tenantId = recordBatch.get(0).getTenantId();
+            String tableName = recordBatch.get(0).getTableName();
+            List<String> ids = new ArrayList<>();
+            for (Record record : recordBatch) {
+                ids.add(record.getId());
+            }
+            StagingIndexDataEntry indexEntry = new StagingIndexDataEntry(tenantId, tableName, ids);
+            this.addEntryToShard(shardIndex, replica, indexEntry);
+        }
     }
-    
+
     public void delete(String nodeId, int tenantId, String tableName, List<String> ids) throws AnalyticsException {
         Map<Integer, List<String>> shardedIds = this.indexer.extractShardedIds(ids);
         for (Map.Entry<Integer, List<String>> entry : shardedIds.entrySet()) {
@@ -108,7 +109,7 @@ public class StagingIndexDataStore {
             log.debug("Staging index data delete: " + ids.size());
         }
     }
-    
+
     private void addEntryToShard(String nodeId, int shardIndex, StagingIndexDataEntry entry) throws AnalyticsException {
         String tableName = this.generateTableName(nodeId, shardIndex);
         int tenantId = Constants.META_INFO_TENANT_ID;
@@ -126,50 +127,51 @@ public class StagingIndexDataStore {
     }
 
     private void addEntryToShard(int shardIndex, int replica, StagingIndexDataEntry entry) throws AnalyticsException {
-                String tableName = this.generateTableName(shardIndex, replica);
-                int tenantId = Constants.META_INFO_TENANT_ID;
-                Map<String, Object> values = new HashMap<>(1);
-                values.put(Constants.INDEX_STAGING_DATA_COLUMN, entry);
-                AnalyticsRecordStore rs = this.indexer.getAnalyticsRecordStore();
-                Record record = new Record(GenericUtils.generateRecordID(), tenantId, tableName, values);
-                entry.setRecordId(record.getId());
-                try {
-                        rs.put(Arrays.asList(record));
-                    } catch (AnalyticsTableNotAvailableException e) {
-                        rs.createTable(tenantId, tableName);
-                        rs.put(Arrays.asList(record));
-                    }
-            }
+        String tableName = this.generateTableName(shardIndex, replica);
+        int tenantId = Constants.META_INFO_TENANT_ID;
+        Map<String, Object> values = new HashMap<>(1);
+        values.put(Constants.INDEX_STAGING_DATA_COLUMN, entry);
+        AnalyticsRecordStore rs = this.indexer.getAnalyticsRecordStore();
+        Record record = new Record(GenericUtils.generateRecordID(), tenantId, tableName, values);
+        entry.setRecordId(record.getId());
+        try {
+            rs.put(Arrays.asList(record));
+        } catch (AnalyticsTableNotAvailableException e) {
+            rs.createTable(tenantId, tableName);
+            rs.put(Arrays.asList(record));
+        }
+    }
 
     private String generateTableNameForOlderStagingTable(String nodeId, int shardIndex) {
         return Constants.INDEX_STAGING_DATA_TABLE + shardIndex + "_" + nodeId;
     }
 
     private String generateTableName(String nodeId, int shardIndex) {
-                int shardReplica = localShardAllocationConfig.getShardReplica(shardIndex);
-                if (shardReplica != 0) {
-                        return Constants.INDEX_STAGING_DATA_TABLE + shardIndex + "_" + shardReplica;
-                    }
-                return null;
-            }
+        int shardReplica = localShardAllocationConfig.getShardReplica(shardIndex);
+        if (shardReplica != 0) {
+            return Constants.INDEX_STAGING_DATA_TABLE + shardIndex + "_" + shardReplica;
+        }
+        return null;
+    }
 
-            private String generateTableName(int shardIndex, int replica) {
-                return Constants.INDEX_STAGING_DATA_TABLE + shardIndex + "_" + replica;
-            }
-    
+    private String generateTableName(int shardIndex, int replica) {
+        return Constants.INDEX_STAGING_DATA_TABLE + shardIndex + "_" + replica;
+    }
+
     public List<StagingIndexDataEntry> loadEntries(String nodeId, int shardIndex) throws AnalyticsException {
         return getStagingIndexDataEntries(this.generateTableName(nodeId, shardIndex));
-           }
+    }
 
-           public List<StagingIndexDataEntry> loadEntriesInOldStagingTables(String nodeId, int shardIndex) throws
-                                                                                              AnalyticsException {
-                return getStagingIndexDataEntries(this.generateTableNameForOlderStagingTable(nodeId, shardIndex));
-            }
+    public List<StagingIndexDataEntry> loadEntriesInOldStagingTables(String nodeId, int shardIndex) throws
+            AnalyticsException {
+        return getStagingIndexDataEntries(this.generateTableNameForOlderStagingTable(nodeId, shardIndex));
+    }
 
-            private List<StagingIndexDataEntry> getStagingIndexDataEntries(String stagingTable)
+    private List<StagingIndexDataEntry> getStagingIndexDataEntries(String stagingTable)
             throws AnalyticsException {
-                if (stagingTable == null) {
-                        return new ArrayList<>(0); }
+        if (stagingTable == null) {
+            return new ArrayList<>(0);
+        }
         AnalyticsRecordStore rs = this.indexer.getAnalyticsRecordStore();
         try {
             List<Record> records = GenericUtils.listRecords(rs, rs.get(Constants.META_INFO_TENANT_ID,
@@ -184,40 +186,41 @@ public class StagingIndexDataStore {
             return new ArrayList<>(0);
         }
     }
-    
+
     public void removeEntries(String nodeId, int shardIndex, List<String> ids) throws AnalyticsException {
         removeStagingEntries(this.generateTableName(nodeId, shardIndex), ids);
-        }
+    }
 
-            public void removeEntriesFromOldStagingTables(String nodeId, int shardIndex, List<String> ids) throws
+    public void removeEntriesFromOldStagingTables(String nodeId, int shardIndex, List<String> ids) throws
             AnalyticsException {
-                removeStagingEntries(this.generateTableNameForOlderStagingTable(nodeId, shardIndex), ids);
-            }
+        removeStagingEntries(this.generateTableNameForOlderStagingTable(nodeId, shardIndex), ids);
+    }
 
-            public void deleteStagingEntryLocation(String nodeId, int shardIndex) throws AnalyticsException {
+    public void deleteStagingEntryLocation(String nodeId, int shardIndex) throws AnalyticsException {
         AnalyticsRecordStore rs = this.indexer.getAnalyticsRecordStore();
-                rs.deleteTable(Constants.META_INFO_TENANT_ID, generateTableNameForOlderStagingTable(nodeId, shardIndex));
+        rs.deleteTable(Constants.META_INFO_TENANT_ID, generateTableNameForOlderStagingTable(nodeId, shardIndex));
     }
 
     private void removeStagingEntries(String stagingTable, List<String> ids) throws AnalyticsException {
-                AnalyticsRecordStore rs = this.indexer.getAnalyticsRecordStore();
-                rs.delete(Constants.META_INFO_TENANT_ID, stagingTable, ids);
-            }
+        AnalyticsRecordStore rs = this.indexer.getAnalyticsRecordStore();
+        rs.delete(Constants.META_INFO_TENANT_ID, stagingTable, ids);
+    }
 
     public static class StagingIndexDataEntry implements Serializable {
-        
+
         private static final long serialVersionUID = 2811642328079107132L;
 
         private int tenantId;
-        
+
         private String tableName;
-        
+
         private List<String> ids;
-        
+
         private String recordId;
-        
-        public StagingIndexDataEntry() { }
-        
+
+        public StagingIndexDataEntry() {
+        }
+
         public StagingIndexDataEntry(int tenantId, String tableName, List<String> ids) {
             this.tenantId = tenantId;
             this.tableName = tableName;
@@ -255,7 +258,7 @@ public class StagingIndexDataStore {
         public void setRecordId(String recordId) {
             this.recordId = recordId;
         }
-        
+
     }
-    
+
 }

--- a/components/analytics-data-connectors/org.wso2.carbon.analytics.datasource.rdbms/src/test/java/org/wso2/carbon/analytics/datasource/rdbms/h2/H2AnalyticsDataServiceClusteredTest.java
+++ b/components/analytics-data-connectors/org.wso2.carbon.analytics.datasource.rdbms/src/test/java/org/wso2/carbon/analytics/datasource/rdbms/h2/H2AnalyticsDataServiceClusteredTest.java
@@ -8,7 +8,7 @@
  *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing,
+ *  Unless requi    red by applicable law or agreed to in writing,
  *  software distributed under the License is distributed on an
  *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  *  KIND, either express or implied.  See the License for the
@@ -18,6 +18,7 @@
  */
 package org.wso2.carbon.analytics.datasource.rdbms.h2;
 
+import java.io.File;
 import java.io.IOException;
 
 import javax.naming.NamingException;
@@ -29,6 +30,7 @@ import org.wso2.carbon.analytics.dataservice.core.AnalyticsServiceHolder;
 import org.wso2.carbon.analytics.dataservice.core.clustering.AnalyticsClusterManagerImpl;
 import org.wso2.carbon.analytics.datasource.commons.exception.AnalyticsException;
 import org.wso2.carbon.analytics.datasource.core.AnalyticsDataServiceTest;
+import org.wso2.carbon.analytics.datasource.core.AnalyticsDataSourceConstants;
 import org.wso2.carbon.analytics.datasource.core.util.GenericUtils;
 
 import com.hazelcast.core.Hazelcast;
@@ -41,6 +43,11 @@ public class H2AnalyticsDataServiceClusteredTest extends AnalyticsDataServiceTes
     @BeforeClass
     public void setup() throws NamingException, AnalyticsException, IOException {
         GenericUtils.clearGlobalCustomDataSourceRepo();
+        File dataDir = new File(GenericUtils.resolveLocation(AnalyticsDataSourceConstants.CARBON_HOME_VAR + File
+                .separator + "repository"));
+                if (!dataDir.exists() || !dataDir.isDirectory()) {
+                        dataDir.mkdir();
+                    }
         System.setProperty(GenericUtils.WSO2_ANALYTICS_CONF_DIRECTORY_SYS_PROP, "src/test/resources/conf8");
         Hazelcast.shutdownAll();
         AnalyticsServiceHolder.setHazelcastInstance(Hazelcast.newHazelcastInstance());

--- a/components/analytics-data-connectors/org.wso2.carbon.analytics.datasource.rdbms/src/test/java/org/wso2/carbon/analytics/datasource/rdbms/h2/H2AnalyticsDataServiceClusteredTest.java
+++ b/components/analytics-data-connectors/org.wso2.carbon.analytics.datasource.rdbms/src/test/java/org/wso2/carbon/analytics/datasource/rdbms/h2/H2AnalyticsDataServiceClusteredTest.java
@@ -45,16 +45,16 @@ public class H2AnalyticsDataServiceClusteredTest extends AnalyticsDataServiceTes
         GenericUtils.clearGlobalCustomDataSourceRepo();
         File dataDir = new File(GenericUtils.resolveLocation(AnalyticsDataSourceConstants.CARBON_HOME_VAR + File
                 .separator + "repository"));
-                if (!dataDir.exists() || !dataDir.isDirectory()) {
-                        dataDir.mkdir();
-                    }
+        if (!dataDir.exists() || !dataDir.isDirectory()) {
+            dataDir.mkdir();
+        }
         System.setProperty(GenericUtils.WSO2_ANALYTICS_CONF_DIRECTORY_SYS_PROP, "src/test/resources/conf8");
         Hazelcast.shutdownAll();
         AnalyticsServiceHolder.setHazelcastInstance(Hazelcast.newHazelcastInstance());
         AnalyticsServiceHolder.setAnalyticsClusterManager(new AnalyticsClusterManagerImpl());
         this.init(new AnalyticsDataServiceImpl());
     }
-    
+
     @AfterClass
     public void done() throws NamingException, AnalyticsException, IOException {
         this.service.destroy();
@@ -62,5 +62,5 @@ public class H2AnalyticsDataServiceClusteredTest extends AnalyticsDataServiceTes
         AnalyticsServiceHolder.setHazelcastInstance(null);
         AnalyticsServiceHolder.setAnalyticsDataService(null);
     }
-    
+
 }

--- a/components/analytics-data-connectors/org.wso2.carbon.analytics.datasource.rdbms/src/test/java/org/wso2/carbon/analytics/datasource/rdbms/h2/H2AnalyticsDataServiceStandaloneTest.java
+++ b/components/analytics-data-connectors/org.wso2.carbon.analytics.datasource.rdbms/src/test/java/org/wso2/carbon/analytics/datasource/rdbms/h2/H2AnalyticsDataServiceStandaloneTest.java
@@ -36,7 +36,7 @@ import org.wso2.carbon.analytics.datasource.core.util.GenericUtils;
  * Standalone test implementation of {@link AnalyticsDataServiceTest}.
  */
 public class H2AnalyticsDataServiceStandaloneTest extends AnalyticsDataServiceTest {
-    
+
     @BeforeClass
     public void setup() throws NamingException, AnalyticsException, IOException {
         GenericUtils.clearGlobalCustomDataSourceRepo();
@@ -51,12 +51,12 @@ public class H2AnalyticsDataServiceStandaloneTest extends AnalyticsDataServiceTe
         System.setProperty(AnalyticsServiceHolder.FORCE_INDEXING_ENV_PROP, Boolean.TRUE.toString());
         this.init(AnalyticsServiceHolder.getAnalyticsDataService());
     }
-    
+
     @AfterClass
     public void done() throws NamingException, AnalyticsException, IOException {
         this.service.destroy();
         System.clearProperty(AnalyticsServiceHolder.FORCE_INDEXING_ENV_PROP);
         AnalyticsServiceHolder.setAnalyticsDataService(null);
     }
-    
+
 }

--- a/components/analytics-data-connectors/org.wso2.carbon.analytics.datasource.rdbms/src/test/java/org/wso2/carbon/analytics/datasource/rdbms/h2/H2AnalyticsDataServiceStandaloneTest.java
+++ b/components/analytics-data-connectors/org.wso2.carbon.analytics.datasource.rdbms/src/test/java/org/wso2/carbon/analytics/datasource/rdbms/h2/H2AnalyticsDataServiceStandaloneTest.java
@@ -18,6 +18,7 @@
  */
 package org.wso2.carbon.analytics.datasource.rdbms.h2;
 
+import java.io.File;
 import java.io.IOException;
 
 import javax.naming.NamingException;
@@ -25,8 +26,10 @@ import javax.naming.NamingException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.wso2.carbon.analytics.dataservice.core.AnalyticsServiceHolder;
+import org.wso2.carbon.analytics.dataservice.core.Constants;
 import org.wso2.carbon.analytics.datasource.commons.exception.AnalyticsException;
 import org.wso2.carbon.analytics.datasource.core.AnalyticsDataServiceTest;
+import org.wso2.carbon.analytics.datasource.core.AnalyticsDataSourceConstants;
 import org.wso2.carbon.analytics.datasource.core.util.GenericUtils;
 
 /**
@@ -37,6 +40,11 @@ public class H2AnalyticsDataServiceStandaloneTest extends AnalyticsDataServiceTe
     @BeforeClass
     public void setup() throws NamingException, AnalyticsException, IOException {
         GenericUtils.clearGlobalCustomDataSourceRepo();
+        File dataDir = new File(GenericUtils.resolveLocation(AnalyticsDataSourceConstants.CARBON_HOME_VAR + File
+                .separator + "repository"));
+        if (!dataDir.exists() || !dataDir.isDirectory()) {
+            dataDir.mkdir();
+        }
         System.setProperty(GenericUtils.WSO2_ANALYTICS_CONF_DIRECTORY_SYS_PROP, "src/test/resources/conf1");
         AnalyticsServiceHolder.setHazelcastInstance(null);
         AnalyticsServiceHolder.setAnalyticsClusterManager(null);

--- a/pom.xml
+++ b/pom.xml
@@ -1331,8 +1331,8 @@
         <carbon.commons.version>4.6.19</carbon.commons.version>
         <carbon.commons.imp.pkg.version>[4.5, 5)</carbon.commons.imp.pkg.version>
         <carbon.data.version>4.4.2</carbon.data.version>
-        <carbon.event-processing.version>2.1.4</carbon.event-processing.version>
-        <carbon.analytics.common.version>5.1.3</carbon.analytics.common.version>
+        <carbon.event-processing.version>2.1.20</carbon.event-processing.version>
+        <carbon.analytics.common.version>5.1.33</carbon.analytics.common.version>
         <carbon.analytics.common.imp.pkg.version>[5.0, 6.0)</carbon.analytics.common.imp.pkg.version>
 
         <carbon.data.import.pkg.version>[4.3, 5)</carbon.data.import.pkg.version>
@@ -1477,7 +1477,7 @@
         <roaringbitmap.import.version>[0.4.5, 0.5.0)</roaringbitmap.import.version>
         <objenesis.orbit.version>2.1.wso2v1</objenesis.orbit.version>
 
-        <siddhi.version>3.2.0</siddhi.version>
+        <siddhi.version>3.2.2</siddhi.version>
         <siddhi.version.range>[3.2.0,4.0.0)</siddhi.version.range>
         <version.noggit>0.6.wso2v1</version.noggit>
         <hector.version>1.0-5</hector.version>

--- a/pom.xml
+++ b/pom.xml
@@ -329,11 +329,6 @@
                 <version>${com.datastax.cassandra.driver.orbit.verison}</version>
             </dependency>
             <dependency>
-                <groupId>org.mongodb</groupId>
-            	<artifactId>mongo-java-driver</artifactId>
-            	<version>${mongo.driver.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.wso2.carbon.data</groupId>
                 <artifactId>org.wso2.carbon.datasource.reader.cassandra</artifactId>
                 <version>${carbon.data.version}</version>
@@ -1299,23 +1294,23 @@
         <carbon.ml.version>1.1.3</carbon.ml.version>
 
         <!-- Dashboards and Jaggery -->
-        <carbon.dashboard.version>2.0.2</carbon.dashboard.version>
+        <carbon.dashboard.version>2.0.16</carbon.dashboard.version>
         <shindig.version>2.0.2</shindig.version>
         <jaggery.version>0.12.6</jaggery.version>
         <jaggery.modules.carbon.version>1.5.5</jaggery.modules.carbon.version>
         <jaggery.modules.process.version>1.5.5</jaggery.modules.process.version>
         <jaggery.modules.i18n.version>1.5.5</jaggery.modules.i18n.version>
-        <jaggery.modules.ws.version>1.5.5</jaggery.modules.ws.version>
+        <jagcagery.modules.ws.version>1.5.5</jagcagery.modules.ws.version>
         <sso.feature.version>1.5.5</sso.feature.version>
 
         <cipher.tool.version>1.0.0-wso2v3</cipher.tool.version>
 
         <!-- Data TG repo -->
-        <carbon.registry.version>4.6.0</carbon.registry.version>
+        <carbon.registry.version>4.6.27</carbon.registry.version>
 
         <carbon.identity.version>5.2.0</carbon.identity.version>
-        <carbon.deployment.version>4.7.0</carbon.deployment.version>
-        <carbon.multitenancy.version>4.6.0</carbon.multitenancy.version>
+        <carbon.deployment.version>4.7.15</carbon.deployment.version>
+        <carbon.multitenancy.version>4.6.9</carbon.multitenancy.version>
         <carbon.identity.saml2.version>5.1.3</carbon.identity.saml2.version>
         <carbon.metrics.version>1.2.2</carbon.metrics.version>
 
@@ -1324,7 +1319,7 @@
         <carbon.analytics.imp.pkg.version>[1.0, 2)</carbon.analytics.imp.pkg.version>
 
         <!-- Carbon platform version -->
-        <carbon.kernel.version>4.4.9</carbon.kernel.version>
+        <carbon.kernel.version>4.4.25</carbon.kernel.version>
         <carbon.kernel.version.import.version.range>[4.4, 4.5)</carbon.kernel.version.import.version.range>
 
         <!-- WSO2 repository versions -->


### PR DESCRIPTION
## Purpose
> In current (3.1.0) DAS, the data index consists of several smaller indices called shards. By default there are 6 shards in repository/data folder. In clustered mode, these shards are distributed among other nodes. The shard information (which shard is kept in which node) is kept in a meta table in the Event store DB which is common to all nodes. The node is identified with the node-id (which is stored in my-node-id.dat in repository/conf/analytics). Sometimes users completely delete the server and start setting up again. But user is unaware of the my-node-id.dat file, so with the pack he deletes that file also. Still the node-id is there in the Event store DB. When user setup a new DAS server, at the first startup, it will create a new node-id for itself and store that in DB and also in its my-node-id.dat. Problem is, since the older node id is still in DB, the shards will distributed among 3 nodes. But the 2nd DAS node was deleted and the data to be indexed and sent to the shards which are allocated to 2nd DAS node will always retain in DB Staging area. That data will never be indexed. This will lead to indexing inconsistencies and always user will have to stop the servers and re-index data and clean the stale node ids, if user is not aware of the my-node-id.dat file beforehand.

## Goals
> N/A

## Approach
> N/A

## User stories
> N/A

## Release note
> N?A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> Ubuntu 16.04, JDK 1.8_144

## Learning
> N/A

## Steps to reproduce:
- Setup a two node cluster.
- Publish some data (index few fields so we can search)
- Completely delete one node.
- Start a new node as a replacement for the deleted node.
- Again publish some data with indexing enabled
- Search for data in data explorer.
- You will notice that each time you search it returns different result counts or sometimes returns less number of matching records.