### PR TITLE
Adding Deployment information for Business Rules

### DIFF
--- a/components/org.wso2.carbon.business.rules.core/src/gen/java/org/wso2/carbon/business/rules/core/api/BusinessRulesApi.java
+++ b/components/org.wso2.carbon.business.rules.core/src/gen/java/org/wso2/carbon/business/rules/core/api/BusinessRulesApi.java
@@ -196,6 +196,26 @@ public class BusinessRulesApi implements Microservice {
         return delegate.loadBusinessRule(request, businessRuleInstanceID);
     }
 
+    @GET
+    @Path("/instances/{businessRuleInstanceID}/deployment-info")
+    @Produces({"application/json"})
+    @io.swagger.annotations.ApiOperation(value = "Returns deployment information of a business rule instance",
+            notes = "Gets deployment information of the business rule instance that has the given ID",
+                response = Object.class,
+            tags = {"business-rules",})
+    @io.swagger.annotations.ApiResponses(value = {
+            @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Object.class),
+
+            @io.swagger.annotations.ApiResponse(code = 404, message = "Business rule not found",
+                    response = Object.class)})
+    public Response loadDeploymentInfo(@Context Request request,
+                                     @ApiParam(value = "ID of the business rule instance", required = true)
+                                     @PathParam("businessRuleInstanceID") String businessRuleInstanceID
+    )
+            throws NotFoundException {
+        return delegate.loadDeploymentInfo(request, businessRuleInstanceID);
+    }
+
     @POST
     @Path("/instances/{businessRuleInstanceID}")
     @Consumes({"application/json"})

--- a/components/org.wso2.carbon.business.rules.core/src/gen/java/org/wso2/carbon/business/rules/core/api/BusinessRulesApiService.java
+++ b/components/org.wso2.carbon.business.rules.core/src/gen/java/org/wso2/carbon/business/rules/core/api/BusinessRulesApiService.java
@@ -49,6 +49,9 @@ public abstract class BusinessRulesApiService {
     public abstract Response loadBusinessRule(Request request, String businessRuleInstanceID
     ) throws NotFoundException;
 
+    public abstract Response loadDeploymentInfo(Request request, String businessRuleInstanceID
+    ) throws NotFoundException;
+
     public abstract Response redeployBusinessRule(Request request, String businessRuleInstanceID
     ) throws NotFoundException;
 

--- a/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/api/impl/BusinessRulesApiServiceImpl.java
+++ b/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/api/impl/BusinessRulesApiServiceImpl.java
@@ -17,6 +17,9 @@
  */
 package org.wso2.carbon.business.rules.core.api.impl;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.analytics.permissions.PermissionProvider;
@@ -30,25 +33,18 @@ import org.wso2.carbon.business.rules.core.bean.TemplateManagerInstance;
 import org.wso2.carbon.business.rules.core.bean.scratch.BusinessRuleFromScratch;
 import org.wso2.carbon.business.rules.core.bean.template.BusinessRuleFromTemplate;
 import org.wso2.carbon.business.rules.core.datasource.configreader.DataHolder;
-import org.wso2.carbon.business.rules.core.exceptions.BusinessRuleNotFoundException;
-import org.wso2.carbon.business.rules.core.exceptions.RuleTemplateScriptException;
-import org.wso2.carbon.business.rules.core.exceptions.TemplateInstanceCountViolationException;
-import org.wso2.carbon.business.rules.core.exceptions.TemplateManagerServiceException;
+import org.wso2.carbon.business.rules.core.exceptions.*;
 import org.wso2.carbon.business.rules.core.services.TemplateManagerService;
 import org.wso2.carbon.business.rules.core.util.LogEncoder;
 import org.wso2.carbon.business.rules.core.util.TemplateManagerConstants;
 import org.wso2.carbon.business.rules.core.util.TemplateManagerHelper;
 import org.wso2.msf4j.Request;
+import sun.rmi.transport.ObjectTable;
 
+import javax.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
-import javax.ws.rs.core.Response;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonObject;
 
 /**
  * Implementation of business rules REST API
@@ -347,6 +343,49 @@ public class BusinessRulesApiServiceImpl extends BusinessRulesApiService {
             responseData.add("Loaded business rule with uuid '" + businessRuleInstanceID + "'");
             responseData.add(businessRule);
             return Response.ok().entity(gson.toJson(responseData)).build();
+        } catch (TemplateManagerServiceException e) {
+            log.error(String.format("Failed to load business rule with uuid %s ",
+                    LogEncoder.removeCRLFCharacters(businessRuleInstanceID)), e);
+            responseData.add("Failed to load");
+            responseData.add("Failed to load business rule with uuid '" + businessRuleInstanceID + "'");
+            responseData.add(new String[]{});
+            return Response.serverError().entity(gson.toJson(responseData)).build();
+        }
+    }
+
+    @Override
+    public Response loadDeploymentInfo(Request request, String businessRuleInstanceID) throws NotFoundException {
+        if (!hasPermission(request, RequestMethod.LOAD_BUSINESS_RULE)) {
+            return Response.status(Response.Status.UNAUTHORIZED).build();
+        }
+        List<Object> responseData = new ArrayList<>();
+        Gson gson = new GsonBuilder().disableHtmlEscaping().setPrettyPrinting().create();
+        TemplateManagerService templateManagerService = TemplateManagerInstance.getInstance();
+        try {
+            List<Map<String, Object>> deploymentInfo =
+                    templateManagerService.loadDeploymentInfo(businessRuleInstanceID);
+            if (deploymentInfo == null) {
+                String message = String.format("No deployed nodes found for business rule with uuid %s",
+                        LogEncoder.removeCRLFCharacters(businessRuleInstanceID));
+                log.error(message);
+                responseData.add("No Deployed Nodes Found");
+                responseData.add(message);
+                responseData.add(null);
+                return Response.serverError().entity(gson.toJson(responseData)).build();
+            }
+            responseData.add("Retreived Business Rule Deployment Information");
+            responseData.add("Retreived nodewise Siddhi App deployment information for '" +
+                    businessRuleInstanceID + "'");
+            responseData.add(deploymentInfo);
+            return Response.ok().entity(gson.toJson(responseData)).build();
+        } catch (BusinessRulesDatasourceException e) {
+            String message = String.format("Unable to find Siddhi apps from the business rule with uuid %s",
+                    LogEncoder.removeCRLFCharacters(businessRuleInstanceID));
+            log.error(message, e);
+            responseData.add("Unable to find Siddhi Apps");
+            responseData.add(message);
+            responseData.add(null);
+            return Response.serverError().entity(gson.toJson(responseData)).build();
         } catch (TemplateManagerServiceException e) {
             log.error(String.format("Failed to load business rule with uuid %s ",
                     LogEncoder.removeCRLFCharacters(businessRuleInstanceID)), e);

--- a/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/services/TemplateManagerService.java
+++ b/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/services/TemplateManagerService.java
@@ -18,40 +18,25 @@
 
 package org.wso2.carbon.business.rules.core.services;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wso2.carbon.business.rules.core.bean.Artifact;
-import org.wso2.carbon.business.rules.core.bean.BusinessRule;
-import org.wso2.carbon.business.rules.core.bean.RuleTemplate;
-import org.wso2.carbon.business.rules.core.bean.Template;
-import org.wso2.carbon.business.rules.core.bean.TemplateGroup;
+import org.wso2.carbon.business.rules.core.bean.*;
 import org.wso2.carbon.business.rules.core.bean.scratch.BusinessRuleFromScratch;
 import org.wso2.carbon.business.rules.core.bean.scratch.BusinessRuleFromScratchProperty;
 import org.wso2.carbon.business.rules.core.bean.template.BusinessRuleFromTemplate;
 import org.wso2.carbon.business.rules.core.datasource.QueryExecutor;
-import org.wso2.carbon.business.rules.core.deployer.SiddhiAppApiHelper;
 import org.wso2.carbon.business.rules.core.datasource.configreader.ConfigReader;
-import org.wso2.carbon.business.rules.core.exceptions.BusinessRuleNotFoundException;
-import org.wso2.carbon.business.rules.core.exceptions.BusinessRulesDatasourceException;
-import org.wso2.carbon.business.rules.core.exceptions.RuleTemplateScriptException;
-import org.wso2.carbon.business.rules.core.exceptions.SiddhiAppsApiHelperException;
-import org.wso2.carbon.business.rules.core.exceptions.TemplateInstanceCountViolationException;
-import org.wso2.carbon.business.rules.core.exceptions.TemplateManagerHelperException;
-import org.wso2.carbon.business.rules.core.exceptions.TemplateManagerServiceException;
+import org.wso2.carbon.business.rules.core.deployer.SiddhiAppApiHelper;
+import org.wso2.carbon.business.rules.core.exceptions.*;
 import org.wso2.carbon.business.rules.core.util.LogEncoder;
 import org.wso2.carbon.business.rules.core.util.TemplateManagerConstants;
 import org.wso2.carbon.business.rules.core.util.TemplateManagerHelper;
 
 import java.io.File;
 import java.io.UnsupportedEncodingException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
+import java.util.*;
 
 /**
  * The exposed Template Manager service, which contains methods related to
@@ -331,6 +316,92 @@ public class TemplateManagerService implements BusinessRulesService {
             }
         }
         throw new BusinessRuleNotFoundException("No Business Rule found with the UUID : " + businessRuleUUID);
+    }
+
+    /**
+     * Gets deployment information of the business rule with the given UUID
+     *
+     * @param businessRuleUUID                  UUID of the business rule
+     * @return                                  List of nodes & Siddhi app deployment statuses
+     * @throws TemplateManagerServiceException  Exception occurred in Template Manager Service
+     * @throws BusinessRulesDatasourceException Exception occurred within the data source
+     */
+    public List<Map<String, Object>> loadDeploymentInfo(String businessRuleUUID)
+            throws TemplateManagerServiceException, BusinessRulesDatasourceException {
+        BusinessRule businessRule = loadBusinessRule(businessRuleUUID);
+        List<String> deployingNodes = null;
+        if (businessRule instanceof BusinessRuleFromTemplate) {
+            deployingNodes = getNodesList(((BusinessRuleFromTemplate) businessRule).getRuleTemplateUUID());
+        } else {
+            deployingNodes = getNodeListForBusinessRuleFromScratch((BusinessRuleFromScratch) businessRule);
+        }
+        if (null == deployingNodes) {
+            return null;
+        }
+        return getNodeWiseDeploymentStatuses(deployingNodes, businessRule);
+    }
+
+    /**
+     * Gets deployment status of the Siddhi apps belonging to the given business rules, in the given list of nodes
+     * @param deployingNodes                    Nodes in which, Siddhi apps of the given BR should be deployed
+     * @param businessRule                      Business rule object
+     * @return                                  Map of Siddhi apps and their deployment statuses
+     * @throws BusinessRulesDatasourceException Exception occurred within the data source
+     */
+    private List<Map<String, Object>> getNodeWiseDeploymentStatuses(List<String> deployingNodes,
+                                                                    BusinessRule businessRule)
+            throws BusinessRulesDatasourceException {
+        int businessRuleStatus = getDeploymentState(businessRule);
+        List<Map<String, Object>> nodeWiseDeploymentStatuses = new ArrayList<>();
+        for (String nodeURL : deployingNodes) {
+            Map<String, Integer> siddhiAppDeploymentStatuses;
+            if (businessRule instanceof BusinessRuleFromScratch) {
+                siddhiAppDeploymentStatuses = new HashMap<>(1);
+                siddhiAppDeploymentStatuses.put(businessRule.getUuid(), getDeploymentStatus(nodeURL,
+                        businessRule.getUuid(), businessRuleStatus));
+            } else {
+                int siddhiAppCount = queryExecutor.executeRetrieveArtifactCountQuery(businessRule.getUuid());
+                siddhiAppDeploymentStatuses = new HashMap<>(siddhiAppCount);
+                for (int i = 0; i < siddhiAppCount; i++) {
+                    String siddhiAppName = businessRule.getUuid() + "_" + i;
+                    siddhiAppDeploymentStatuses.put(siddhiAppName, getDeploymentStatus(nodeURL, siddhiAppName,
+                            businessRuleStatus));
+                }
+            }
+            Map<String, Object> currentNodeStatuses = new HashMap<>();
+            currentNodeStatuses.put("nodeURL", nodeURL);
+            currentNodeStatuses.put("siddhiAppStatuses", siddhiAppDeploymentStatuses);
+            nodeWiseDeploymentStatuses.add(currentNodeStatuses);
+        }
+        return nodeWiseDeploymentStatuses;
+    }
+
+    /**
+     * Gets deployment state of the given Siddhi app, in the given node.
+     * 1    - Deployed
+     * 0    - Not Deployed
+     * -1   - Not Reachable
+     *
+     * @param nodeURL               URL of the node in which, the deployment status is checked
+     * @param siddhiAppName         Name of the Siddhi app, that is checked for deployment
+     * @param businessRuleStatus    Status of the business rule, which consists the Siddhi app
+     * @return                      Deployment status of the Siddhi app
+     */
+    private int getDeploymentStatus(String nodeURL, String siddhiAppName, int businessRuleStatus) {
+        if (businessRuleStatus == TemplateManagerConstants.SAVED) {
+            return TemplateManagerConstants.SIDDHI_APP_NOT_DEPLOYED;
+        }
+        try {
+            if (isDeployedInNode(nodeURL, siddhiAppName)) {
+                return TemplateManagerConstants.SIDDHI_APP_DEPLOYED;
+            }
+            return TemplateManagerConstants.SIDDHI_APP_NOT_DEPLOYED;
+        } catch (SiddhiAppsApiHelperException e) {
+            if (businessRuleStatus == TemplateManagerConstants.PARTIALLY_DEPLOYED) {
+                return TemplateManagerConstants.SIDDHI_APP_NOT_DEPLOYED;
+            }
+            return TemplateManagerConstants.SIDDHI_APP_UNREACHABLE;
+        }
     }
 
     public int deleteBusinessRule(String uuid, Boolean forceDeleteEnabled) throws BusinessRuleNotFoundException,
@@ -756,12 +827,13 @@ public class TemplateManagerService implements BusinessRulesService {
                         log.error(String.format("Get status of the siddhi app %s failed.",
                                 removeCRLFCharacters(siddhiAppName)), e);
                     }
-                    if (TemplateManagerConstants.SAVED == queryExecutor.executeRetrieveDeploymentStatus(
-                            (businessRule.getUuid()))) {
-                        return TemplateManagerConstants.SAVED;
-                    } else {
-                        return TemplateManagerConstants.DEPLOYMENT_FAILURE;
+                    int queriedState = queryExecutor.executeRetrieveDeploymentStatus((businessRule.getUuid()));
+                    if (queriedState == TemplateManagerConstants.SAVED ||
+                            queriedState == TemplateManagerConstants.PARTIALLY_DEPLOYED ||
+                            queriedState == TemplateManagerConstants.PARTIALLY_UNDEPLOYED) {
+                        return queriedState;
                     }
+                    return TemplateManagerConstants.DEPLOYMENT_FAILURE;
                 }
             }
             deployedNodesCount += 1;

--- a/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/util/TemplateManagerConstants.java
+++ b/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/util/TemplateManagerConstants.java
@@ -62,6 +62,10 @@ public class TemplateManagerConstants {
     public static final int DEPLOYMENT_FAILURE = 4;
     public static final int ERROR = 5;
 
+    public static final int SIDDHI_APP_UNREACHABLE = -1;
+    public static final int SIDDHI_APP_NOT_DEPLOYED = 0;
+    public static final int SIDDHI_APP_DEPLOYED = 1;
+
     public static final int SUCCESSFULLY_DELETED = 6;
     public static final int SCRIPT_EXECUTION_ERROR = 7;
 

--- a/components/org.wso2.carbon.business.rules.web/src/api/BusinessRulesAPICaller.js
+++ b/components/org.wso2.carbon.business.rules.web/src/api/BusinessRulesAPICaller.js
@@ -110,6 +110,14 @@ class BusinessRulesAPICaller {
     }
 
     /**
+     * Gets deployment info of the business rule with the given ID
+     * @param businessRuleID
+     */
+    getDeploymentInfo(businessRuleID) {
+        return this.getHTTPClient().get('/instances/' + businessRuleID + '/deployment-info');
+    }
+
+    /**
      * Updates the business rule with the given ID, with the given JSON of a business rule; with deployment status
      * as specified
      *

--- a/components/org.wso2.carbon.business.rules.web/src/components/BusinessRule.jsx
+++ b/components/org.wso2.carbon.business.rules.web/src/components/BusinessRule.jsx
@@ -17,15 +17,16 @@
  */
 
 import React from 'react';
-import { Link } from 'react-router-dom';
+import {Link} from 'react-router-dom';
 // Material UI Components
 import IconButton from 'material-ui/IconButton';
 import RefreshIcon from 'material-ui-icons/Refresh';
 import EditIcon from 'material-ui-icons/Edit';
 import DeleteIcon from 'material-ui-icons/Delete';
-import { TableCell, TableRow } from 'material-ui/Table';
+import {TableCell, TableRow} from 'material-ui/Table';
 import Tooltip from 'material-ui/Tooltip';
 import VisibilityIcon from 'material-ui-icons/Visibility';
+import DnsIcon from 'material-ui-icons/Dns';
 // App Constants
 import BusinessRulesConstants from '../constants/BusinessRulesConstants';
 // CSS
@@ -117,6 +118,12 @@ class BusinessRule extends React.Component {
             // Manager permissions
             actionButtonsCell =
                 <TableCell>
+                    <Tooltip id="tooltip-right" title="Deployment Info" placement="right-end">
+                        <IconButton aria-label="View" onClick={() => this.props.showDeploymentInfo(this.props.uuid)}>
+                            <DnsIcon/>
+                        </IconButton>
+                    </Tooltip>
+                    &nbsp;
                     <Tooltip id="tooltip-right" title="View" placement="right-end">
                         <Link
                             to={appContext + '/businessRuleFrom' + (this.props.type.charAt(0).toUpperCase() +
@@ -156,6 +163,12 @@ class BusinessRule extends React.Component {
             // Viewer permissions only
             actionButtonsCell =
                 <TableCell>
+                    <Tooltip id="tooltip-right" title="Deployment Info" placement="right-end">
+                        <IconButton aria-label="View" onClick={() => this.props.showDeploymentInfo(this.props.uuid)}>
+                            <DnsIcon/>
+                        </IconButton>
+                    </Tooltip>
+                    &nbsp;
                     <Tooltip id="tooltip-right" title="View" placement="right-end">
                         <Link
                             to={appContext + '/businessRuleFrom' +

--- a/components/org.wso2.carbon.business.rules.web/src/components/BusinessRuleFromTemplateForm.jsx
+++ b/components/org.wso2.carbon.business.rules.web/src/components/BusinessRuleFromTemplateForm.jsx
@@ -42,15 +42,6 @@ import BusinessRulesMessages from '../constants/BusinessRulesMessages';
 import BusinessRulesAPICaller from '../api/BusinessRulesAPICaller';
 // CSS
 import '../index.css';
-// Custom Theme
-import { createMuiTheme, MuiThemeProvider } from 'material-ui/styles';
-import { Orange } from '../theme/BusinessRulesManagerColors';
-
-const theme = createMuiTheme({
-    palette: {
-        primary: Orange,
-    },
-});
 
 /**
  * Styles related to this component
@@ -627,7 +618,7 @@ class BusinessRuleFromTemplateForm extends React.Component {
         }
 
         return (
-            <MuiThemeProvider theme={theme}>
+            <div>
                 <Header />
                 <br />
                 <div>
@@ -660,7 +651,7 @@ class BusinessRuleFromTemplateForm extends React.Component {
                         </Grid>
                     </Grid>
                 </div>
-            </MuiThemeProvider>
+            </div>
         )
     }
 }

--- a/components/org.wso2.carbon.business.rules.web/src/components/BusinessRulesManager.jsx
+++ b/components/org.wso2.carbon.business.rules.web/src/components/BusinessRulesManager.jsx
@@ -17,18 +17,19 @@
  */
 
 import React from 'react';
-import { Link } from 'react-router-dom';
+import {Link} from 'react-router-dom';
 // Material UI Components
 import Typography from 'material-ui/Typography';
-import Table, { TableBody, TableCell, TableHead, TableRow } from 'material-ui/Table';
+import Table, {TableBody, TableCell, TableHead, TableRow} from 'material-ui/Table';
 import Button from 'material-ui/Button';
 import AddIcon from 'material-ui-icons/Add';
-import Dialog, { DialogActions, DialogContent, DialogContentText, DialogTitle } from 'material-ui/Dialog';
+import Dialog, {DialogActions, DialogContent, DialogContentText, DialogTitle} from 'material-ui/Dialog';
 import Paper from 'material-ui/Paper';
 import Snackbar from 'material-ui/Snackbar';
 import Slide from 'material-ui/transitions/Slide';
 // App Components
 import BusinessRule from './BusinessRule';
+import DeploymentInfo from './DeploymentInfo';
 import Header from './common/Header';
 import ProgressDisplay from './ProgressDisplay';
 // App Constants
@@ -38,31 +39,31 @@ import BusinessRulesConstants from '../constants/BusinessRulesConstants';
 import BusinessRulesAPICaller from '../api/BusinessRulesAPICaller';
 // CSS
 import '../index.css';
-// Custom Theme
-import { createMuiTheme, MuiThemeProvider } from 'material-ui/styles';
-import { Orange } from '../theme/BusinessRulesManagerColors';
-
-const theme = createMuiTheme({
-    palette: {
-        primary: Orange,
-    },
-});
 
 /**
  * Styles related to this component
  */
 const styles = {
     container: {
-        maxWidth: 1020,
+        maxWidth: 1020
     },
     paper: {
         maxWidth: 400,
         paddingTop: 30,
         paddingBottom: 30
     },
+    card: {
+        width: 345,
+        height: 200,
+        margin: 15
+    },
+    chip: {
+        margin: 5
+    },
+    spacing: '0',
     snackbar: {
         direction: 'up'
-    },
+    }
 };
 
 /**
@@ -89,6 +90,11 @@ class BusinessRulesManager extends React.Component {
             // To show dialog when deleting a business rule
             displayDeleteDialog: false,
             businessRuleUUIDToBeDeleted: '',
+
+            // To show business rule's deployment info
+            displayDeploymentInfo: false,
+            deploymentInfo: {},
+            deploymentInfoBusinessRule: {}
         };
     }
 
@@ -153,6 +159,31 @@ class BusinessRulesManager extends React.Component {
     }
 
     /**
+     * Views the given business rule's deployment info
+     * @param businessRule  Array with Business rule object and status
+     */
+    showDeploymentInfo(businessRule) {
+        new BusinessRulesAPICaller(BusinessRulesConstants.BASE_URL).getDeploymentInfo(businessRule[0].uuid)
+            .then((response) => {
+                this.setState({
+                    deploymentInfo: response.data[2],
+                    deploymentInfoBusinessRule: businessRule
+                });
+                this.toggleDeploymentInfoView();
+            })
+            .catch(() => {
+                this.displaySnackBar('Unable to retrieve deployment info');
+            });
+    }
+
+    /**
+     * Toggles the visibility of deployment info display
+     */
+    toggleDeploymentInfoView() {
+        this.setState({displayDeploymentInfo: !this.state.displayDeploymentInfo});
+    }
+
+    /**
      * Displays snackbar with the given message
      *
      * @param message
@@ -210,6 +241,7 @@ class BusinessRulesManager extends React.Component {
                         permissions={this.state.permissions}
                         redeploy={(uuid) => this.redeployBusinessRule(uuid)}
                         showDeleteDialog={(uuid) => this.displayDeleteDialog(uuid)}
+                        showDeploymentInfo={() => this.showDeploymentInfo(businessRule)}
                     />
                 );
 
@@ -317,12 +349,18 @@ class BusinessRulesManager extends React.Component {
             </Dialog>);
 
         return (
-            <MuiThemeProvider theme={theme}>
+            <div>
                 <Header hideHomeButton />
                 <br />
                 <div>
                     {snackbar}
                     {deleteConfirmationDialog}
+                    <DeploymentInfo
+                        businessRule={this.state.deploymentInfoBusinessRule}
+                        info={this.state.deploymentInfo}
+                        open={this.state.displayDeploymentInfo}
+                        onRequestClose={() => this.toggleDeploymentInfoView()}
+                    />
                     <center>
                         <br />
                         <div>
@@ -337,7 +375,7 @@ class BusinessRulesManager extends React.Component {
                         {this.displayAvailableBusinessRules()}
                     </center>
                 </div>
-            </MuiThemeProvider>
+            </div>
         )
     }
 }

--- a/components/org.wso2.carbon.business.rules.web/src/components/DeploymentInfo.jsx
+++ b/components/org.wso2.carbon.business.rules.web/src/components/DeploymentInfo.jsx
@@ -1,0 +1,152 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+import React from 'react';
+// Material UI Components
+import Grid from 'material-ui/Grid';
+import Typography from 'material-ui/Typography';
+import Card, {CardContent} from 'material-ui/Card';
+import Dialog, {DialogContent, DialogTitle} from 'material-ui/Dialog';
+import Chip from 'material-ui/Chip';
+import Avatar from 'material-ui/Avatar';
+import DoneIcon from 'material-ui-icons/Done';
+import RemoveIcon from 'material-ui-icons/Remove';
+import PriorityHighIcon from 'material-ui-icons/PriorityHigh';
+import Tooltip from 'material-ui/Tooltip';
+// App Constants
+import BusinessRulesConstants from '../constants/BusinessRulesConstants';
+// CSS
+import '../index.css';
+import BusinessRulesUtilityFunctions from "../utils/BusinessRulesUtilityFunctions";
+
+/**
+ * Styles related to this component
+ */
+const styles = {
+    root: {
+        display: 'flex',
+        justifyContent: 'center',
+        flexWrap: 'wrap',
+    },
+    card: {
+        minWidth: 300,
+        maxWidth: 360,
+        margin: 15
+    },
+    chip: {
+        margin: 10
+    },
+    deployedAvatar: {
+        color: '#FFF',
+        backgroundColor: '#4CAF50'
+    },
+    notDeployedAvatar: {
+        color: '#FFF',
+        backgroundColor: '#795548'
+    },
+    unreachableAvatar: {
+        color: '#FFF',
+        backgroundColor: '#F44336'
+    },
+    spacing: '0'
+};
+
+/**
+ * Displays deployment information of a business rule
+ */
+class DeploymentInfo extends React.Component {
+    /**
+     * Renders a node with URL and deployment status
+     * @param nodeURL
+     * @param status
+     */
+    static displayNode(nodeURL, status) {
+        let statusIcon;
+        let avatarStyle;
+        switch (status) {
+            case 1:
+                statusIcon = <DoneIcon/>;
+                avatarStyle = styles.deployedAvatar;
+                break;
+            case 0:
+                statusIcon = <RemoveIcon/>;
+                avatarStyle = styles.notDeployedAvatar;
+                break;
+            default:
+                statusIcon = <PriorityHighIcon/>;
+                avatarStyle = styles.unreachableAvatar;
+        }
+        return (
+            <Tooltip
+                id="tooltip-bottom"
+                title={BusinessRulesConstants.SIDDHI_APP_DEPLOYMENT_STATUSES[status + 1]}
+                placement="bottom">
+                <Chip
+                    avatar={
+                        <Avatar style={avatarStyle}>
+                            {statusIcon}
+                        </Avatar>
+                    }
+                    label={nodeURL}
+                    style={styles.chip}
+                />
+            </Tooltip>);
+    }
+
+    render() {
+        return (
+            <Dialog open={this.props.open} onRequestClose={() => this.props.onRequestClose()}>
+                {!BusinessRulesUtilityFunctions.isEmpty(this.props.businessRule) ?
+                    (<div>
+                        <DialogTitle>
+                            Deployment Information
+                            <Typography type="body2">
+                                {`${this.props.businessRule[0].name} ` +
+                                `(${BusinessRulesConstants.BUSINESS_RULE_STATUSES[this.props.businessRule[1]]})`}
+                            </Typography>
+                        </DialogTitle>
+                        <DialogContent>
+                            <Grid container style={styles.root}>
+                                <Grid item xs={12}>
+                                    <Grid container justify="center" spacing={Number(styles.spacing)}>
+                                        {this.props.info.map((node) =>
+                                            (<Grid item key={node.nodeURL}>
+                                                <Card style={styles.card}>
+                                                    <CardContent>
+                                                        <Typography type="subheading">
+                                                            {node.nodeURL}
+                                                        </Typography>
+                                                        <br/>
+                                                        <div style={styles.root}>
+                                                            {Object.keys(node.siddhiAppStatuses).map((siddhiAppName) =>
+                                                                (DeploymentInfo.displayNode(siddhiAppName,
+                                                                    node.siddhiAppStatuses[siddhiAppName])))}
+                                                        </div>
+                                                    </CardContent>
+                                                </Card>
+                                            </Grid>))}
+                                    </Grid>
+                                </Grid>
+                            </Grid>
+                        </DialogContent>
+                    </div>) : (null)}
+            </Dialog>);
+    }
+}
+
+export default DeploymentInfo;

--- a/components/org.wso2.carbon.business.rules.web/src/constants/BusinessRulesConstants.js
+++ b/components/org.wso2.carbon.business.rules.web/src/constants/BusinessRulesConstants.js
@@ -67,6 +67,13 @@ const BusinessRulesConstants = {
         'Error', // 5
     ],
 
+    // Siddhi App deployment statuses
+    SIDDHI_APP_DEPLOYMENT_STATUSES: [
+        'Unreachable', // -1
+        'Not Deployed', // 0
+        'Deployed' // 1
+    ],
+
     BUSINESS_RULE_STATUS_DEPLOYED_STRING: 'Deployed',
     BUSINESS_RULE_STATUS_NOT_DEPLOYED_STRING: 'Not Deployed',
     BUSINESS_RULE_STATUS_DEPLOYMENT_FAILED_STRING: 'Deployment Failed',


### PR DESCRIPTION
## Purpose
> Adding deployment information view for Siddhi apps, that belong to a business rule.

## Goals
> Displaying status of SIddhi apps in required nodes, whether Deployed, Not Deployed or Unreachable

## Approach
> 
![image](https://user-images.githubusercontent.com/24828296/37330402-f9bac3d8-26c6-11e8-9ea1-da388039fad7.png)

## Documentation
> JSON Response body with deployment information:
```
[  
   {  
      "nodeURL":"localhost:9090",
      "siddhiAppStatuses":{  
         "app1":1,
         "app2":0
      }
   },
   {  
      "nodeURL":"10.100.4.168:9090",
      "siddhiAppStatuses":{  
         "app1":1,
         "app2":0
      }
   }
]
```
Siddhi app statuses:
-1 - Unreachable
0  - Not deployed
1  - Deployed

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
