### PR TITLE
Read analytics configuration folder path through carbon

### DIFF
--- a/components/analytics-processors/org.wso2.carbon.analytics.spark.core/src/main/java/org/wso2/carbon/analytics/spark/core/internal/SparkAnalyticsExecutor.java
+++ b/components/analytics-processors/org.wso2.carbon.analytics.spark.core/src/main/java/org/wso2/carbon/analytics/spark/core/internal/SparkAnalyticsExecutor.java
@@ -582,7 +582,7 @@ public class SparkAnalyticsExecutor implements GroupEventListener {
 
     private void setAdditionalConfigs(SparkConf conf) throws AnalyticsException {
         //executor constants for spark env
-        String carbonHome = null, carbonConfDir, analyticsSparkConfDir;
+        String carbonHome = null, carbonConfDir = null, analyticsSparkConfDir;
         try {
             carbonHome = conf.get(AnalyticsConstants.CARBON_DAS_SYMBOLIC_LINK);
             logDebug("[Spark init - configs] CARBON HOME set with the symbolic link " + carbonHome);
@@ -594,15 +594,14 @@ public class SparkAnalyticsExecutor implements GroupEventListener {
         } catch (NoSuchElementException e) {
             try {
                 carbonHome = CarbonUtils.getCarbonHome();
+                carbonConfDir = CarbonUtils.getCarbonConfigDirPath();
             } catch (Throwable ex) {
                 logDebug("CARBON HOME can not be found. Spark conf in non-carbon environment");
             }
         }
         logDebug("CARBON HOME used for Spark Conf : " + carbonHome);
 
-        if (carbonHome != null) {
-            carbonConfDir = carbonHome + File.separator + "repository" + File.separator + "conf";
-        } else {
+        if (carbonConfDir == null) {
             logDebug("CARBON HOME is NULL. Spark conf in non-carbon environment. Using the custom conf path");
             carbonConfDir = GenericUtils.getAnalyticsConfDirectory();
         }
@@ -646,8 +645,7 @@ public class SparkAnalyticsExecutor implements GroupEventListener {
         conf.setIfMissing(AnalyticsConstants.SPARK_RECOVERY_MODE_FACTORY,
                 AnalyticsRecoveryModeFactory.class.getName());
 
-        String agentConfPath = carbonHome + File.separator + "repository" + File.separator +
-                "conf" + File.separator + "data-bridge" + File.separator + "data-agent-config.xml";
+        String agentConfPath = carbonConfDir + File.separator + "data-bridge" + File.separator + "data-agent-config.xml";
 
         String jvmOpts = " -Dwso2_custom_conf_dir=" + carbonConfDir
                 + " -Dcarbon.home=" + carbonHome


### PR DESCRIPTION
## Purpose
> The purpose of this PR is to get Analytics conf folder path through carbon, instead of constructing the conf folder path. 

## Goals
> The folder structure of some products is changed, the conf folder is moved from <Analytics_Home>/repository/conf> to <Analytics_Home>/conf>(e.g: wso2 IoT server). Therefore, instead of constructing analytics configuration folder path get it by CarbonConfigDirPath().

## Approach
> N/A

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A