### PR TITLE
Displaying Sinks And Sources In The SP Editor Design View

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/eventflow/EventFlow.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/eventflow/EventFlow.java
@@ -201,7 +201,6 @@ public class EventFlow {
         }
     }
 
-
     /**
      * Creates all the edge JSONObjects for all the aggregations in the SiddhiAppMap object.
      */

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/eventflow/EventFlow.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/eventflow/EventFlow.java
@@ -22,7 +22,17 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.wso2.carbon.siddhi.editor.core.util.eventflow.constants.EdgeType;
 import org.wso2.carbon.siddhi.editor.core.util.eventflow.constants.NodeType;
-import org.wso2.carbon.siddhi.editor.core.util.eventflow.info.*;
+import org.wso2.carbon.siddhi.editor.core.util.eventflow.info.AggregationInfo;
+import org.wso2.carbon.siddhi.editor.core.util.eventflow.info.FunctionInfo;
+import org.wso2.carbon.siddhi.editor.core.util.eventflow.info.PartitionInfo;
+import org.wso2.carbon.siddhi.editor.core.util.eventflow.info.PartitionTypeInfo;
+import org.wso2.carbon.siddhi.editor.core.util.eventflow.info.QueryInfo;
+import org.wso2.carbon.siddhi.editor.core.util.eventflow.info.SinkInfo;
+import org.wso2.carbon.siddhi.editor.core.util.eventflow.info.SourceInfo;
+import org.wso2.carbon.siddhi.editor.core.util.eventflow.info.StreamInfo;
+import org.wso2.carbon.siddhi.editor.core.util.eventflow.info.TableInfo;
+import org.wso2.carbon.siddhi.editor.core.util.eventflow.info.TriggerInfo;
+import org.wso2.carbon.siddhi.editor.core.util.eventflow.info.WindowInfo;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -89,12 +99,12 @@ public class EventFlow {
         }
 
         // Create Source Nodes
-        for (SourceInfo source: siddhiAppMap.getSources()) {
+        for (SourceInfo source : siddhiAppMap.getSources()) {
             createNode(NodeType.SOURCE, source.getId(), source.getName(), source.getDefinition());
         }
 
         // Create Sink Nodes
-        for (SinkInfo sink: siddhiAppMap.getSinks()) {
+        for (SinkInfo sink : siddhiAppMap.getSinks()) {
             createNode(NodeType.SINK, sink.getId(), sink.getName(), sink.getDefinition());
         }
 
@@ -177,7 +187,7 @@ public class EventFlow {
      * Creates all the edge JSONObjects for all the Sources in the SiddhhiAppMap object.
      */
     private void setSourceEdges() {
-        for (SourceInfo source: siddhiAppMap.getSources()) {
+        for (SourceInfo source : siddhiAppMap.getSources()) {
             createEdge(EdgeType.DEFAULT, source.getId(), source.getStreamId());
         }
     }
@@ -186,7 +196,7 @@ public class EventFlow {
      * Creates all the edge JSONObjects for all the Sinks in the SiddhiAppMap object.
      */
     private void setSinkEdges() {
-        for (SinkInfo sink: siddhiAppMap.getSinks()) {
+        for (SinkInfo sink : siddhiAppMap.getSinks()) {
             createEdge(EdgeType.DEFAULT, sink.getStreamId(), sink.getId());
         }
     }

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/eventflow/EventFlow.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/eventflow/EventFlow.java
@@ -22,15 +22,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.wso2.carbon.siddhi.editor.core.util.eventflow.constants.EdgeType;
 import org.wso2.carbon.siddhi.editor.core.util.eventflow.constants.NodeType;
-import org.wso2.carbon.siddhi.editor.core.util.eventflow.info.AggregationInfo;
-import org.wso2.carbon.siddhi.editor.core.util.eventflow.info.FunctionInfo;
-import org.wso2.carbon.siddhi.editor.core.util.eventflow.info.PartitionInfo;
-import org.wso2.carbon.siddhi.editor.core.util.eventflow.info.PartitionTypeInfo;
-import org.wso2.carbon.siddhi.editor.core.util.eventflow.info.QueryInfo;
-import org.wso2.carbon.siddhi.editor.core.util.eventflow.info.StreamInfo;
-import org.wso2.carbon.siddhi.editor.core.util.eventflow.info.TableInfo;
-import org.wso2.carbon.siddhi.editor.core.util.eventflow.info.TriggerInfo;
-import org.wso2.carbon.siddhi.editor.core.util.eventflow.info.WindowInfo;
+import org.wso2.carbon.siddhi.editor.core.util.eventflow.info.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -94,6 +86,16 @@ public class EventFlow {
         // Create Stream Nodes
         for (StreamInfo stream : siddhiAppMap.getStreams()) {
             createNode(NodeType.STREAM, stream.getId(), stream.getName(), stream.getDefinition());
+        }
+
+        // Create Source Nodes
+        for (SourceInfo source: siddhiAppMap.getSources()) {
+            createNode(NodeType.SOURCE, source.getId(), source.getName(), source.getDefinition());
+        }
+
+        // Create Sink Nodes
+        for (SinkInfo sink: siddhiAppMap.getSinks()) {
+            createNode(NodeType.SINK, sink.getId(), sink.getName(), sink.getDefinition());
         }
 
         // Create Table Nodes
@@ -163,11 +165,32 @@ public class EventFlow {
      * and then add these JSONObjects to the edges JSONArray.
      */
     private void setEdges() {
+        setSourceEdges();
+        setSinkEdges();
         setAggregationEdges();
         setQueryEdges();
         setPartitionEdges();
         eventFlowJSON.put(EDGE, edges);
     }
+
+    /**
+     * Creates all the edge JSONObjects for all the Sources in the SiddhhiAppMap object.
+     */
+    private void setSourceEdges() {
+        for (SourceInfo source: siddhiAppMap.getSources()) {
+            createEdge(EdgeType.DEFAULT, source.getId(), source.getStreamId());
+        }
+    }
+
+    /**
+     * Creates all the edge JSONObjects for all the Sinks in the SiddhiAppMap object.
+     */
+    private void setSinkEdges() {
+        for (SinkInfo sink: siddhiAppMap.getSinks()) {
+            createEdge(EdgeType.DEFAULT, sink.getStreamId(), sink.getId());
+        }
+    }
+
 
     /**
      * Creates all the edge JSONObjects for all the aggregations in the SiddhiAppMap object.

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/eventflow/SiddhiAppMap.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/eventflow/SiddhiAppMap.java
@@ -19,18 +19,12 @@
 package org.wso2.carbon.siddhi.editor.core.util.eventflow;
 
 import org.wso2.carbon.siddhi.editor.core.util.eventflow.constants.SiddhiAnnotationType;
-import org.wso2.carbon.siddhi.editor.core.util.eventflow.info.AggregationInfo;
-import org.wso2.carbon.siddhi.editor.core.util.eventflow.info.FunctionInfo;
-import org.wso2.carbon.siddhi.editor.core.util.eventflow.info.PartitionInfo;
-import org.wso2.carbon.siddhi.editor.core.util.eventflow.info.PartitionTypeInfo;
-import org.wso2.carbon.siddhi.editor.core.util.eventflow.info.QueryInfo;
-import org.wso2.carbon.siddhi.editor.core.util.eventflow.info.StreamInfo;
-import org.wso2.carbon.siddhi.editor.core.util.eventflow.info.TableInfo;
-import org.wso2.carbon.siddhi.editor.core.util.eventflow.info.TriggerInfo;
-import org.wso2.carbon.siddhi.editor.core.util.eventflow.info.WindowInfo;
+import org.wso2.carbon.siddhi.editor.core.util.eventflow.info.*;
 import org.wso2.siddhi.core.SiddhiAppRuntime;
 import org.wso2.siddhi.core.SiddhiManager;
 import org.wso2.siddhi.core.exception.SiddhiAppCreationException;
+import org.wso2.siddhi.core.stream.input.source.Source;
+import org.wso2.siddhi.core.stream.output.sink.Sink;
 import org.wso2.siddhi.query.api.SiddhiApp;
 import org.wso2.siddhi.query.api.SiddhiElement;
 import org.wso2.siddhi.query.api.annotation.Annotation;
@@ -51,10 +45,7 @@ import org.wso2.siddhi.query.api.execution.query.selection.OutputAttribute;
 import org.wso2.siddhi.query.api.expression.AttributeFunction;
 import org.wso2.siddhi.query.compiler.SiddhiCompiler;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 /**
  * Obtains a Siddhi App as a string and parses it to a SiddhiApp object to identify map the data in it.
@@ -69,6 +60,8 @@ public class SiddhiAppMap {
     private String appDescription;
 
     private List<StreamInfo> streams = new ArrayList<>();
+    private List<SourceInfo> sources = new ArrayList<>();
+    private List<SinkInfo> sinks = new ArrayList<>();
     private List<TableInfo> tables = new ArrayList<>();
     private List<WindowInfo> windows = new ArrayList<>();
     private List<TriggerInfo> triggers = new ArrayList<>();
@@ -105,6 +98,8 @@ public class SiddhiAppMap {
         // as the latter is dependent on the former.
         loadTriggers();
         loadStreams();
+        loadSources();
+        loadSinks();
         loadTables();
         loadWindows();
         loadAggregations();
@@ -158,6 +153,42 @@ public class SiddhiAppMap {
                     throw new IllegalArgumentException("The partitioned inner stream definition map" +
                             " does not have an instance of class type 'StreamDefinition'");
                 }
+            }
+        }
+    }
+
+    /**
+     * Obtains information of all the Sources from the SiddhiAppRuntime object.
+     */
+    private void loadSources() {
+        for (List<Source> sourceList : siddhiAppRuntime.getSources()) {
+            for (Source source : sourceList) {
+                SourceInfo sourceInfo = new SourceInfo();
+                sourceInfo.setId(UUID.randomUUID().toString());
+                sourceInfo.setName(source.getType().toUpperCase());
+                sourceInfo.setDefinition("undefined");
+                sourceInfo.setType(source.getType());
+                sourceInfo.setStreamId(source.getStreamDefinition().getId());
+
+                sources.add(sourceInfo);
+            }
+        }
+    }
+
+    /**
+     * Obtains information of all the Sinks from the SiddhiAppRuntime object.
+     */
+    private void loadSinks() {
+        for (List<Sink> sinkList : siddhiAppRuntime.getSinks()) {
+            for (Sink sink : sinkList) {
+                SinkInfo sinkInfo = new SinkInfo();
+                sinkInfo.setId(UUID.randomUUID().toString());
+                sinkInfo.setName(sink.getType().toUpperCase());
+                sinkInfo.setDefinition("undefined");
+                sinkInfo.setType(sink.getType());
+                sinkInfo.setStreamId(sink.getStreamDefinition().getId());
+
+                sinks.add(sinkInfo);
             }
         }
     }
@@ -440,6 +471,14 @@ public class SiddhiAppMap {
 
     public List<StreamInfo> getStreams() {
         return streams;
+    }
+
+    public List<SourceInfo> getSources() {
+        return sources;
+    }
+
+    public List<SinkInfo> getSinks() {
+        return sinks;
     }
 
     public List<TableInfo> getTables() {

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/eventflow/constants/NodeType.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/eventflow/constants/NodeType.java
@@ -27,6 +27,8 @@ public enum NodeType {
     PARTITION("partition"),
     PARTITION_TYPE("partition-type"),
     QUERY("query"),
+    SINK("sink"),
+    SOURCE("source"),
     STREAM("stream"),
     TABLE("table"),
     TRIGGER("trigger"),

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/eventflow/info/SinkInfo.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/eventflow/info/SinkInfo.java
@@ -1,18 +1,30 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.siddhi.editor.core.util.eventflow.info;
 
+/**
+ * Defines a Siddhi Sink Annotation
+ */
 public class SinkInfo extends SiddhiElementInfo {
 
     private String type;
     private String streamId;
-
-    public SinkInfo() {
-    }
-
-    public SinkInfo(String id, String name, String definition, String type, String streamId) {
-        super(id, name, definition);
-        this.type = type;
-        this.streamId = streamId;
-    }
 
     public void setType(String type) {
         this.type = type;

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/eventflow/info/SinkInfo.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/eventflow/info/SinkInfo.java
@@ -1,0 +1,33 @@
+package org.wso2.carbon.siddhi.editor.core.util.eventflow.info;
+
+public class SinkInfo extends SiddhiElementInfo {
+
+    private String type;
+    private String streamId;
+
+    public SinkInfo() {
+    }
+
+    public SinkInfo(String id, String name, String definition, String type, String streamId) {
+        super(id, name, definition);
+        this.type = type;
+        this.streamId = streamId;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public void setStreamId(String streamId) {
+        this.streamId = streamId;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getStreamId() {
+        return streamId;
+    }
+
+}

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/eventflow/info/SourceInfo.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/eventflow/info/SourceInfo.java
@@ -1,18 +1,30 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.siddhi.editor.core.util.eventflow.info;
 
+/**
+ * Defines a Siddhi Source Annotation
+ */
 public class SourceInfo extends SiddhiElementInfo {
 
     private String type;
     private String streamId;
-
-    public SourceInfo() {
-    }
-
-    public SourceInfo(String id, String name, String definition, String type, String streamId) {
-        super(id, name, definition);
-        this.type = type;
-        this.streamId = streamId;
-    }
 
     public String getType() {
         return type;

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/eventflow/info/SourceInfo.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/eventflow/info/SourceInfo.java
@@ -1,0 +1,33 @@
+package org.wso2.carbon.siddhi.editor.core.util.eventflow.info;
+
+public class SourceInfo extends SiddhiElementInfo {
+
+    private String type;
+    private String streamId;
+
+    public SourceInfo() {
+    }
+
+    public SourceInfo(String id, String name, String definition, String type, String streamId) {
+        super(id, name, definition);
+        this.type = type;
+        this.streamId = streamId;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getStreamId() {
+        return streamId;
+    }
+
+    public void setStreamId(String streamId) {
+        this.streamId = streamId;
+    }
+
+}

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/eventflow/info/StreamInfo.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/eventflow/info/StreamInfo.java
@@ -23,6 +23,9 @@ package org.wso2.carbon.siddhi.editor.core.util.eventflow.info;
  */
 public class StreamInfo extends SiddhiElementInfo {
 
+    public StreamInfo() {
+    }
+
     public StreamInfo(String id, String name, String definition) {
         super(id, name, definition);
     }

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/css/event-flow.css
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/css/event-flow.css
@@ -35,7 +35,6 @@
     margin: 5px;
 }
 
-
 .siddhi-app-name {
     color: #fff;
     font-size: 1.8rem;
@@ -112,11 +111,11 @@
 }
 
 .source-colour {
-    background-color: yellow;
+    background-color: #30A6AB;
 }
 
 .sink-colour {
-    background-color: white;
+    background-color: #9C382F;
 }
 
 .table-colour {

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/css/event-flow.css
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/css/event-flow.css
@@ -111,6 +111,14 @@
     background-color: #2196F3;
 }
 
+.source-colour {
+    background-color: yellow;
+}
+
+.sink-colour {
+    background-color: white;
+}
+
 .table-colour {
     background-color: #8BC34A;
 }

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
@@ -238,6 +238,14 @@
                         <span class="legend-text">Stream</span>
                     </li>
                     <li class="legend-key col-md-3">
+                        <span class="legend-colour source-colour"></span>
+                        <span class="legend-text">Source</span>
+                    </li>
+                    <li class="legend-key col-md-3">
+                        <span class="legend-colour sink-colour"></span>
+                        <span class="legend-text">Sink</span>
+                    </li>
+                    <li class="legend-key col-md-3">
                         <span class="legend-colour table-colour"></span>
                         <span class="legend-text">Table</span>
                     </li>

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/event-flow/event-flow.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/event-flow/event-flow.js
@@ -52,6 +52,16 @@ define(['require', 'log', 'lodash', 'jquery', 'alerts', 'd3', 'dagre_d3', 'overl
                         nodeStyle: defaultNodeStyle,
                         cssClass: "indicator stream-colour"
                     },
+                    source: {
+                      name: "source",
+                      nodeStyle: defaultNodeStyle,
+                      cssClass: "indicator source-colour"
+                    },
+                    sink: {
+                        name: "sink",
+                        nodeStyle: defaultNodeStyle,
+                        cssClass: "indicator sink-colour"
+                    },
                     table: {
                         name: "table",
                         nodeStyle: defaultNodeStyle,
@@ -235,6 +245,22 @@ define(['require', 'log', 'lodash', 'jquery', 'alerts', 'd3', 'dagre_d3', 'overl
                                 + "</div>";
                             // The _.clone() method must be used to avoid passing by reference.
                             nodeStyle = _.clone(nodeOptions.stream.nodeStyle);
+                            nodeStyle.label = html;
+                            break;
+                        case nodeOptions.source.name:
+                            html = "<div class='node-content' title='" + node.description + "'>"
+                                + "<span class='" + nodeOptions.source.cssClass + "'></span>"
+                                + "<span class='nodeLabel'>" + node.name + "</span>"
+                                + "</div>";
+                            nodeStyle = _.clone(nodeOptions.source.nodeStyle);
+                            nodeStyle.label = html;
+                            break;
+                        case nodeOptions.sink.name:
+                            html = "<div class='node-content' title='" + node.description + "'>"
+                                + "<span class='" + nodeOptions.sink.cssClass + "'></span>"
+                                + "<span class='nodeLabel'>" + node.name + "</span>"
+                                + "</div>";
+                            nodeStyle = _.clone(nodeOptions.sink.nodeStyle);
                             nodeStyle.label = html;
                             break;
                         case nodeOptions.table.name:


### PR DESCRIPTION
## Purpose
Currently, the design view of the SP Editor does not identify sinks and sources as different components and considers them as part of the stream. This code will display sinks and sources as separated nodes in the design view of the Stream Processor Editor and link them with the necessary edges to the streams that they belong too.

## Goals
* Identify and display sources as separate nodes and link them to their respective streams
* Identify and display sinks as separate nodes and link them to their respective streams

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
A sample of the Sources and Sinks generated in the design view for the 'RecieveAndCount' sample in the SP Editor is shown below:
![ssdemo](https://user-images.githubusercontent.com/25219255/37771124-a24c4f3a-2dfc-11e8-9a47-dafbfbef89aa.gif)

This also supports distributed sources and sink:
![image](https://user-images.githubusercontent.com/25219255/37771505-cb718866-2dfd-11e8-8a5b-c2992d92c3b6.png)


