### PR TITLE
Fix regex pattern to capture more than one templated elements given without space

### DIFF
--- a/components/org.wso2.carbon.business.rules.templates.editor.core/src/main/react/constants/TemplateEditorConstants.js
+++ b/components/org.wso2.carbon.business.rules.templates.editor.core/src/main/react/constants/TemplateEditorConstants.js
@@ -20,7 +20,7 @@
  * Has values for all the constants related to the Template Editor
  */
 const TemplateEditorConstants = {
-    TEMPLATED_ELEMENT_REGEX: /\${(\S+)}/g,
+    TEMPLATED_ELEMENT_REGEX: /\${([^\$\s]+)}/g,
     STREAM_DEFINITION_REGEX: /define stream.*?\((.*?)\);/g,
     VALID_UUID_REGEX: /[a-zA-Z][a-zA-Z0-9_-]*/g,
 


### PR DESCRIPTION
## Purpose
> Fixing regex pattern to capture more than one  templated elements given without space, in a Siddhi app template. Resolves https://github.com/wso2/product-sp/issues/545

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes