### PR TITLE
Remove hard-code '/portal` context path from DataProviderAPI

### DIFF
--- a/components/org.wso2.carbon.data.provider/pom.xml
+++ b/components/org.wso2.carbon.data.provider/pom.xml
@@ -68,6 +68,12 @@
             <artifactId>javax.websocket-api</artifactId>
         </dependency>
 
+        <!--UI Server-->
+        <dependency>
+            <groupId>org.wso2.carbon.uiserver</groupId>
+            <artifactId>org.wso2.carbon.uiserver</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>

--- a/components/org.wso2.carbon.data.provider/pom.xml
+++ b/components/org.wso2.carbon.data.provider/pom.xml
@@ -154,6 +154,8 @@
             org.wso2.msf4j.*;version="${msf4j.import.version.range}",
             javax.ws.rs.*;version="${javax.ws.rs.version.range}",
             javax.websocket.*;version="${javax.websocket.version.range}",
+            org.wso2.carbon.uiserver.api.*; version="${carbon.uiserver.version.range}",
+            org.wso2.carbon.uiserver.spi.*; version="${carbon.uiserver.version.range}",
             org.slf4j.*;version="${slf4j.version.range}",
             com.google.gson.*; version="${gson.version.range}",
             org.wso2.siddhi.*;version="${siddhi.version.range}",
@@ -163,7 +165,7 @@
         </import.package>
         <carbon.component>
             osgi.service; objectClass="org.wso2.msf4j.websocket.WebSocketEndpoint",
-            osgi.service; objectClass="org.wso2.msf4j.Microservice"; serviceCount="1",
+            osgi.service; objectClass="org.wso2.carbon.uiserver.spi.RestApiProvider",
             osgi.service; objectClass="org.wso2.carbon.data.provider.DataProvider";serviceCount="2"
         </carbon.component>
     </properties>

--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/endpoint/DataProviderEndPoint.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/endpoint/DataProviderEndPoint.java
@@ -48,7 +48,6 @@ import static org.wso2.carbon.data.provider.utils.DataProviderValueHolder.getDat
  * Data provider web socket endpoint.
  */
 @Component(
-        name = "org.wso2.carbon.analytics.data.provider.endpoint",
         service = WebSocketEndpoint.class,
         immediate = true
 )

--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/internal/DashboardRestApiProvider.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/internal/DashboardRestApiProvider.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.data.provider.internal;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.carbon.data.provider.DataProvider;
+import org.wso2.carbon.uiserver.api.App;
+import org.wso2.carbon.uiserver.spi.RestApiProvider;
+import org.wso2.msf4j.Microservice;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.wso2.carbon.data.provider.utils.DataProviderValueHolder.getDataProviderHelper;
+
+/**
+ * Provider that supplies Microservices for the {@link #DASHBOARD_PORTAL_APP_NAME} web app.
+ */
+@Component(service = RestApiProvider.class, immediate = true)
+public class DashboardRestApiProvider implements RestApiProvider {
+
+    public static final String DASHBOARD_PORTAL_APP_NAME = "portal";
+    private static final Logger LOGGER = LoggerFactory.getLogger(DashboardRestApiProvider.class);
+
+    @Activate
+    protected void activate(BundleContext bundleContext) {
+        LOGGER.debug("{} activated.", this.getClass().getName());
+    }
+
+    @Deactivate
+    protected void deactivate(BundleContext bundleContext) {
+        LOGGER.debug("{} deactivated.", this.getClass().getName());
+    }
+
+    @Reference(
+            service = DataProvider.class,
+            cardinality = ReferenceCardinality.AT_LEAST_ONE,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetDataProvider"
+    )
+    protected void setDataProvider(DataProvider dataProvider) {
+        getDataProviderHelper().setDataProvider(dataProvider.providerName(), dataProvider);
+    }
+
+    protected void unsetDataProvider(DataProvider dataProvider) {
+        getDataProviderHelper().removeDataProviderClass(dataProvider.providerName());
+    }
+
+    @Override
+    public String getAppName() {
+        return DASHBOARD_PORTAL_APP_NAME;
+    }
+
+    @Override
+    public Map<String, Microservice> getMicroservices(App app) {
+        return Collections.singletonMap(DataProviderAPI.API_CONTEXT_PATH, new DataProviderAPI());
+    }
+}

--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/internal/DataProviderAPI.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/internal/DataProviderAPI.java
@@ -19,13 +19,7 @@
 package org.wso2.carbon.data.provider.internal;
 
 import com.google.gson.JsonElement;
-import org.osgi.framework.BundleContext;
-import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
-import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.analytics.msf4j.interceptor.common.AuthenticationInterceptor;
@@ -48,57 +42,27 @@ import static org.wso2.carbon.data.provider.utils.DataProviderValueHolder.getDat
 /**
  * Data provider api service component.
  */
-@Component(
-        name = "data-provider-api",
-        service = Microservice.class,
-        immediate = true
-)
-@Path("/portal/apis/data-provider")
 @RequestInterceptor(AuthenticationInterceptor.class)
 public class DataProviderAPI implements Microservice {
+
+    public static final String API_CONTEXT_PATH = "/apis/data-provider";
     private static final Logger log = LoggerFactory.getLogger(DataProviderAPI.class);
-
-    public DataProviderAPI() {
-    }
-
-    /**
-     * This is the activation method of ServiceComponent. This will be called when its references are
-     * satisfied.
-     *
-     * @param bundleContext the bundle context instance of this bundle.
-     * @throws Exception this will be thrown if an issue occurs while executing the activate method
-     */
-    @Activate
-    protected void start(BundleContext bundleContext) throws Exception {
-        log.info("Data Provider Service Component is activated");
-    }
-
-    /**
-     * This is the deactivation method of ServiceComponent. This will be called when this component
-     * is being stopped or references are satisfied during runtime.
-     *
-     * @throws Exception this will be thrown if an issue occurs while executing the de-activate method
-     */
-    @Deactivate
-    protected void stop() throws Exception {
-        log.info("Data Provider Service Component is deactivated");
-    }
 
     @GET
     @Path("/list")
     @Produces("application/json")
     public Response dataProviderList() {
         try {
-            return Response.status(Response.Status.OK)
+            return Response.ok()
                     .entity(getDataProviderHelper().getDataProviderNameSet())
                     .type(MediaType.APPLICATION_JSON)
                     .build();
-        } catch (Throwable throwable) {
-            log.error("Server error occurred when listing data providers.", throwable);
-            return Response.serverError().entity("Server error occurred when listing data providers: " +
-                    throwable.getMessage()).build();
+        } catch (Exception e) {
+            log.error("Cannot list data providers.", e);
+            return Response.serverError()
+                    .entity("Server error occurred when listing data providers.")
+                    .build();
         }
-
     }
 
     @GET
@@ -106,15 +70,16 @@ public class DataProviderAPI implements Microservice {
     @Produces("application/json")
     public Response dataProviderConfig(@PathParam("providerName") String providerName) {
         try {
-            return Response.status(Response.Status.OK)
+            return Response.ok()
                     .entity(getDataProviderHelper().getDataProvider(providerName).providerConfig())
                     .type(MediaType.APPLICATION_JSON)
                     .build();
-        } catch (Throwable throwable) {
-            log.error("Server error occurred when retrieving configuration of data provider: '{}'.",
-                    replaceCRLFCharacters(providerName), throwable);
-            return Response.serverError().entity("Server error occurred when when retrieving configuration " +
-                    "of data provider: '" + providerName + "'. " + throwable.getMessage()).build();
+        } catch (IllegalAccessException | InstantiationException e) {
+            log.error("Cannot retrieve configuration of data provider '{}'.", replaceCRLFCharacters(providerName), e);
+            return Response.serverError()
+                    .entity("Server error occurred when when retrieving configuration of data provider '" +
+                            providerName + "'. ")
+                    .build();
         }
 
     }
@@ -129,29 +94,18 @@ public class DataProviderAPI implements Microservice {
             DataProvider dataProvider = getDataProviderHelper().getDataProvider(providerName);
             //mock the topic and session as it only needs to validate the configuration.
             dataProvider.init("mock_topic", "mock_session", dataProviderConfig);
-            return Response.ok(dataProvider.dataSetMetadata(), MediaType.APPLICATION_JSON)
+            return Response.ok()
+                    .entity(dataProvider.dataSetMetadata())
+                    .type(MediaType.APPLICATION_JSON)
                     .build();
         } catch (DataProviderException | IllegalAccessException | InstantiationException e) {
-            log.error("Server error occurred when validating the provider name: '{}'.",
-                    replaceCRLFCharacters(providerName), e);
-            return Response.serverError().entity("Server error occurred when validating the provider name: '" +
-                    providerName + "'. " + e.getMessage()).build();
+            log.error("Cannot validate configurations '{}' for data provider '{}'.", dataProviderConfig,
+                      replaceCRLFCharacters(providerName), e);
+            return Response.serverError()
+                    .entity("Server error occurred when validating configuration for data provider '" + providerName +
+                            "'.")
+                    .build();
         }
-    }
-
-    @Reference(
-            name = "data-providers-service",
-            service = DataProvider.class,
-            cardinality = ReferenceCardinality.AT_LEAST_ONE,
-            policy = ReferencePolicy.DYNAMIC,
-            unbind = "unsetCarbonTransport"
-    )
-    protected void setCarbonTransport(DataProvider dataProvider) {
-        getDataProviderHelper().setDataProvider(dataProvider.providerName(), dataProvider);
-    }
-
-    protected void unsetCarbonTransport(DataProvider dataProvider) {
-        getDataProviderHelper().removeDataProviderClass(dataProvider.providerName());
     }
 
     private String replaceCRLFCharacters(String str) {

--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/internal/DataProviderAPI.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/internal/DataProviderAPI.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package org.wso2.carbon.data.provider;
+package org.wso2.carbon.data.provider.internal;
 
 import com.google.gson.JsonElement;
 import org.osgi.framework.BundleContext;
@@ -29,6 +29,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.analytics.msf4j.interceptor.common.AuthenticationInterceptor;
+import org.wso2.carbon.data.provider.DataProvider;
 import org.wso2.carbon.data.provider.exception.DataProviderException;
 import org.wso2.msf4j.Microservice;
 import org.wso2.msf4j.interceptor.annotation.RequestInterceptor;

--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/rdbms/RDBMSBatchDataProvider.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/rdbms/RDBMSBatchDataProvider.java
@@ -32,7 +32,6 @@ import java.util.ArrayList;
  * RDBMS batch data provider instance.
  */
 @Component(
-        name = "rdbms-batch-data-provider",
         service = DataProvider.class,
         immediate = true
 )

--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/rdbms/RDBMSStreamingDataProvider.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/rdbms/RDBMSStreamingDataProvider.java
@@ -34,7 +34,6 @@ import static org.wso2.carbon.data.provider.rdbms.utils.RDBMSProviderConstants.L
  * RDBMS streaming data provider instance.
  */
 @Component(
-        name = "rdbms-streaming-data-provider",
         service = DataProvider.class,
         immediate = true
 )

--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/siddhi/SiddhiProvider.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/siddhi/SiddhiProvider.java
@@ -44,7 +44,6 @@ import java.util.Locale;
 import java.util.Map;
 
 @Component(
-        name = "siddhi-data-provider",
         service = DataProvider.class,
         immediate = true
 )

--- a/pom.xml
+++ b/pom.xml
@@ -1563,7 +1563,7 @@
 
         <!--Dashboard-->
         <carbon.uiserver.version>0.19.5</carbon.uiserver.version>
-        <carbon.uiserver.version.range>[0.19.5, 1.0.0]</carbon.uiserver.version.range>
+        <carbon.uiserver.version.range>[0.19.3, 1.0.0]</carbon.uiserver.version.range>
 
         <!-- Maven plugins -->
         <!--Bundle Plugin - Overridden from parent due to a bug in latest version related to capability providers-->

--- a/pom.xml
+++ b/pom.xml
@@ -1562,8 +1562,8 @@
         <mavan.findbugsplugin.exclude.file>findbugs-exclude.xml</mavan.findbugsplugin.exclude.file>
 
         <!--Dashboard-->
-        <carbon.uiserver.version>0.19.3</carbon.uiserver.version>
-        <carbon.uiserver.version.range>[0.19.2, 1.0.0]</carbon.uiserver.version.range>
+        <carbon.uiserver.version>0.19.5</carbon.uiserver.version>
+        <carbon.uiserver.version.range>[0.19.5, 1.0.0]</carbon.uiserver.version.range>
 
         <!-- Maven plugins -->
         <!--Bundle Plugin - Overridden from parent due to a bug in latest version related to capability providers-->


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/product-sp/issues/544

## Goals
- Remove the [hard-coded `/portal` context path](https://github.com/wso2/carbon-analytics/blob/v2.0.315/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/DataProviderAPI.java#L55) from `DataProviderAPI` class.

## Approach
- `DataProviderAPI` is no longer an OSGi component.
- Instead `DashboardRestApiProvider` which implements the [`RestApiProvider`](https://github.com/wso2/carbon-ui-server/blob/v0.19.5/components/org.wso2.carbon.uiserver/src/main/java/org/wso2/carbon/uiserver/spi/RestApiProvider.java) from carbon-ui-server provides the `DataProviderAPI` as a Microservice that needs to be deployed when deploying the **portal** webap.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
