### PR TITLE
1.3.x

### DIFF
--- a/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/AnalyticsDataServiceImpl.java
+++ b/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/AnalyticsDataServiceImpl.java
@@ -161,6 +161,7 @@ public class AnalyticsDataServiceImpl implements AnalyticsDataService {
             indexerInfo.setTaxonomyWriterLRUCacheSize(config.getTaxonomyWriterCacheConfiguration().getCacheSize());
         }
         indexerInfo.setIndexFacetConfig(config.getAnalyticsFacetConfiguration());
+        indexerInfo.setLowercaseExpandedTerms(config.getLowercaseExpandedTerms());
         this.indexer = new AnalyticsDataIndexer(indexerInfo);
         AnalyticsServiceHolder.setAnalyticsDataService(this);
         AnalyticsClusterManager acm = AnalyticsServiceHolder.getAnalyticsClusterManager();

--- a/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/AnalyticsQueryParser.java
+++ b/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/AnalyticsQueryParser.java
@@ -46,7 +46,14 @@ public class AnalyticsQueryParser extends QueryParser {
         super(null, analyzer);
         this.indices = indices;
     }
-    
+
+    public AnalyticsQueryParser(Analyzer analyzer, Map<String, ColumnDefinition> indices,
+                                boolean lowercaseExpandedTerms) {
+        super(null, analyzer);
+        this.indices = indices;
+        setLowercaseExpandedTerms(lowercaseExpandedTerms);
+    }
+
     @Override
     public Query getRangeQuery(String field, String part1, String part2, boolean si, boolean ei) throws ParseException {
         AnalyticsSchema.ColumnType type = null;

--- a/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/Constants.java
+++ b/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/Constants.java
@@ -81,6 +81,7 @@ public class Constants {
                     "index_data" + File.separator;
 
     public static final String INDEX_STORE_DIR_PREFIX = "shard";
+    public static final boolean DEFAULT_LOWERCASE_EXPANDED_TERMS = true;
 
     public static final String LOCAL_SHARD_ALLOCATION_CONFIG_LOCATION =
             getDataDirPath(AnalyticsDataSourceConstants.CARBON_HOME_VAR) + File.separator +

--- a/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/config/AnalyticsDataServiceConfiguration.java
+++ b/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/config/AnalyticsDataServiceConfiguration.java
@@ -58,6 +58,7 @@ public class AnalyticsDataServiceConfiguration {
     private int maxIndexerCommunicatorBufferSize = Constants.DEFAULT_MAX_INDEXER_COMMUNICATOR_BUFFER_SIZE;
 
     private int queueCleanupThreshold = Constants.DEFAULT_INDEXING_QUEUE_CLEANUP_THRESHOLD;
+    private boolean lowercaseExpandedTerms = Constants.DEFAULT_LOWERCASE_EXPANDED_TERMS;
 
     @XmlElement (name = "analytics-record-store", nillable = false)
     public AnalyticsRecordStoreConfiguration[] getAnalyticsRecordStoreConfigurations() {
@@ -194,6 +195,15 @@ public class AnalyticsDataServiceConfiguration {
 
     public void setStaticQuorumConfiguration(StaticQuorumConfiguration staticQuorumConfiguration) {
         this.staticQuorumConfiguration = staticQuorumConfiguration;
+    }
+
+    @XmlElement( name = "lowercaseExpandedTerms", defaultValue = "" + Constants.DEFAULT_LOWERCASE_EXPANDED_TERMS)
+    public boolean getLowercaseExpandedTerms() {
+        return lowercaseExpandedTerms;
+    }
+
+    public void setLowercaseExpandedTerms(boolean lowercaseExpandedTerms) {
+        this.lowercaseExpandedTerms = lowercaseExpandedTerms;
     }
 
 }

--- a/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/indexing/AnalyticsDataIndexer.java
+++ b/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/indexing/AnalyticsDataIndexer.java
@@ -492,7 +492,8 @@ public class AnalyticsDataIndexer {
             throws org.apache.lucene.queryparser.classic.ParseException, AnalyticsIndexException {
         Analyzer analyzer = getPerFieldAnalyzerWrapper(indices);
         String validatedQuery = getValidatedLuceneQuery(query);
-        return new AnalyticsQueryParser(analyzer, indices).parse(validatedQuery);
+        return new AnalyticsQueryParser(analyzer, indices,
+                indexerInfo.isLowercaseExpandedTerms()).parse(validatedQuery);
     }
 
     private String getValidatedLuceneQuery(String query) {
@@ -679,7 +680,8 @@ public class AnalyticsDataIndexer {
             } else {
                 validatedQuery = query;
             }
-            Query indexQuery = new AnalyticsQueryParser(analyzer, indices).parse(validatedQuery);
+            Query indexQuery = new AnalyticsQueryParser(analyzer, indices,
+                    indexerInfo.isLowercaseExpandedTerms()).parse(validatedQuery);
             TotalHitCountCollector collector = new TotalHitCountCollector();
             searcher.search(indexQuery, collector);
             int result = collector.getTotalHits();
@@ -947,7 +949,8 @@ public class AnalyticsDataIndexer {
             Query queryObj = new MatchAllDocsQuery();
             if (drillDownRequest.getQuery() != null && !drillDownRequest.getQuery().isEmpty()) {
                 Analyzer analyzer = getPerFieldAnalyzerWrapper(indices);
-                queryObj = (new AnalyticsQueryParser(analyzer, indices)).parse(drillDownRequest.getQuery());
+                queryObj = (new AnalyticsQueryParser(analyzer, indices,
+                        indexerInfo.isLowercaseExpandedTerms()).parse(drillDownRequest.getQuery()));
             }
             DrillDownQuery drillDownQuery = new DrillDownQuery(config, queryObj);
             String[] path = drillDownRequest.getPath();

--- a/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/indexing/AnalyticsIndexerInfo.java
+++ b/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/indexing/AnalyticsIndexerInfo.java
@@ -65,6 +65,7 @@ public class AnalyticsIndexerInfo {
     private String taxonomyWriterLRUCacheType;
 
     private int taxonomyWriterLRUCacheSize;
+    private boolean lowercaseExpandedTerms;
 
 
     public Analyzer getLuceneAnalyzer() {
@@ -217,5 +218,13 @@ public class AnalyticsIndexerInfo {
 
     public AnalyticsIndexFacetConfig getIndexFacetConfig() {
         return indexFacetConfig;
+    }
+
+    public void setLowercaseExpandedTerms(boolean lowercaseExpandedTerms) {
+        this.lowercaseExpandedTerms = lowercaseExpandedTerms;
+    }
+
+    public boolean isLowercaseExpandedTerms() {
+        return lowercaseExpandedTerms;
     }
 }

--- a/components/analytics-core/org.wso2.carbon.analytics.datasource.core.test/src/main/java/org/wso2/carbon/analytics/datasource/core/AnalyticsDataServiceTest.java
+++ b/components/analytics-core/org.wso2.carbon.analytics.datasource.core.test/src/main/java/org/wso2/carbon/analytics/datasource/core/AnalyticsDataServiceTest.java
@@ -503,7 +503,7 @@ public class AnalyticsDataServiceTest implements GroupEventListener {
         columns.add(new ColumnDefinitionExt("STR1", ColumnType.STRING, true, false));
         this.service.createTable(tenantId, tableName);
         this.service.setTableSchema(tenantId, tableName, new AnalyticsSchema(columns, null));
-        Assert.assertEquals(this.service.search(tenantId, tableName, "STR1:S*", 0, 150).size(), 0);
+        Assert.assertEquals(this.service.search(tenantId, tableName, "_STR1:S*", 0, 150).size(), 0);
         List<Record> records = this.generateIndexRecords(tenantId, tableName, 98, 0);
         this.service.put(records);
         List<String> ids = new ArrayList<>();
@@ -513,7 +513,7 @@ public class AnalyticsDataServiceTest implements GroupEventListener {
         ids.add(records.get(97).getId());
         Assert.assertEquals(AnalyticsDataServiceUtils.listRecords(this.service, this.service.get(tenantId, tableName, 2, null, ids)).size(), 4);
         this.service.waitForIndexing(DEFAULT_WAIT_TIME);
-        List<SearchResultEntry> result = this.service.search(tenantId, tableName, "STR1:S*", 0, 150);
+        List<SearchResultEntry> result = this.service.search(tenantId, tableName, "_STR1:S*", 0, 150);
         Assert.assertEquals(result.size(), 98);
         this.service.delete(tenantId, tableName, ids);
         Assert.assertEquals(AnalyticsDataServiceUtils.listRecords(this.service, this.service.get(
@@ -521,7 +521,7 @@ public class AnalyticsDataServiceTest implements GroupEventListener {
         Assert.assertEquals(AnalyticsDataServiceUtils.listRecords(this.service, this.service.get(
                 tenantId, tableName, 1, null, Long.MIN_VALUE, Long.MAX_VALUE, 0, -1)).size(), 94);
         this.service.waitForIndexing(DEFAULT_WAIT_TIME);
-        result = this.service.search(tenantId, tableName, "STR1:S*", 0, 150);
+        result = this.service.search(tenantId, tableName, "_STR1:S*", 0, 150);
         Assert.assertEquals(result.size(), 94);
         Assert.assertEquals(AnalyticsDataServiceUtils.listRecords(this.service, this.service.get(tenantId, tableName, 3, null, ids)).size(), 0);
         this.cleanupTable(tenantId, tableName);
@@ -1283,6 +1283,25 @@ public class AnalyticsDataServiceTest implements GroupEventListener {
         drillDownRequest.addCategoryPath("location2", path);
         List<SearchResultEntry> results = this.service.drillDownSearch(tenantId, drillDownRequest);
         Assert.assertEquals(1, results.size());
+        this.cleanupTable(tenantId, tableName);
+    }
+
+    @Test (dependsOnMethods = "testFacetSplitterForField")
+    public void testUppercaseWildcardQueries() throws AnalyticsException {
+        int tenantId = 4;
+        String tableName = "Books";
+        this.cleanupTable(tenantId, tableName);
+        List<ColumnDefinition> columns = new ArrayList<>();
+        columns.add(new ColumnDefinitionExt("STR1", ColumnType.STRING, true, false));
+        this.service.createTable(tenantId, tableName);
+        this.service.setTableSchema(tenantId, tableName, new AnalyticsSchema(columns, null));
+        List<Record> records = this.generateIndexRecords(tenantId, tableName, 100, 0);
+        this.service.put(records);
+        this.service.waitForIndexing(DEFAULT_WAIT_TIME);
+        List<SearchResultEntry> result = this.service.search(tenantId, tableName, "_STR1:S*", 0, 150);
+        Assert.assertEquals(result.size(), 100);
+        int count = this.service.searchCount(tenantId, tableName, "_STR1:STR*");
+        Assert.assertEquals(count, 100);
         this.cleanupTable(tenantId, tableName);
     }
 

--- a/components/analytics-data-connectors/org.wso2.carbon.analytics.datasource.rdbms/src/test/resources/conf1/analytics/analytics-config.xml
+++ b/components/analytics-data-connectors/org.wso2.carbon.analytics.datasource.rdbms/src/test/resources/conf1/analytics/analytics-config.xml
@@ -74,4 +74,7 @@
          to do the indexing operations of the local shards. When this value is increased, the parallel I/O operations being done on the
          system grows larger. So a system which can handle parallel I/O operation could increase this, e.g. SSDs -->
     <indexWorkerCount>8</indexWorkerCount>
+    <!-- Whether terms of wildcard, prefix, fuzzy and range lucene queries are to be automatically lower-cased or
+    not. By default this will be true and property can be used to override that behavior -->
+    <lowercaseExpandedTerms>false</lowercaseExpandedTerms>
 </analytics-dataservice-configuration>

--- a/components/analytics-data-connectors/org.wso2.carbon.analytics.datasource.rdbms/src/test/resources/conf3/analytics/analytics-config.xml
+++ b/components/analytics-data-connectors/org.wso2.carbon.analytics.datasource.rdbms/src/test/resources/conf3/analytics/analytics-config.xml
@@ -51,4 +51,7 @@
     <!-- The number of index shards, should be equal or higher to the number of indexing nodes that is going to be working,
          ideal count being 'number of indexing nodes * CPU cores' -->
     <shardCount>6</shardCount>
+    <!-- Whether terms of wildcard, prefix, fuzzy and range lucene queries are to be automatically lower-cased or
+    not. By default this will be true and property can be used to override that behavior -->
+    <lowercaseExpandedTerms>false</lowercaseExpandedTerms>
 </analytics-dataservice-configuration>

--- a/components/analytics-data-connectors/org.wso2.carbon.analytics.datasource.rdbms/src/test/resources/conf4/analytics/analytics-config.xml
+++ b/components/analytics-data-connectors/org.wso2.carbon.analytics.datasource.rdbms/src/test/resources/conf4/analytics/analytics-config.xml
@@ -50,4 +50,7 @@
     <!-- The number of index shards, should be equal or higher to the number of indexing nodes that is going to be working,
          ideal count being 'number of indexing nodes * CPU cores' -->
     <shardCount>6</shardCount>
+    <!-- Whether terms of wildcard, prefix, fuzzy and range lucene queries are to be automatically lower-cased or
+    not. By default this will be true and property can be used to override that behavior -->
+    <lowercaseExpandedTerms>false</lowercaseExpandedTerms>
 </analytics-dataservice-configuration>

--- a/components/analytics-data-connectors/org.wso2.carbon.analytics.datasource.rdbms/src/test/resources/conf5/analytics/analytics-config.xml
+++ b/components/analytics-data-connectors/org.wso2.carbon.analytics.datasource.rdbms/src/test/resources/conf5/analytics/analytics-config.xml
@@ -50,4 +50,7 @@
    <!-- The number of index shards, should be equal or higher to the number of indexing nodes that is going to be working,
         ideal count being 'number of indexing nodes * CPU cores' -->
    <shardCount>6</shardCount>
+    <!-- Whether terms of wildcard, prefix, fuzzy and range lucene queries are to be automatically lower-cased or
+    not. By default this will be true and property can be used to override that behavior -->
+    <lowercaseExpandedTerms>false</lowercaseExpandedTerms>
 </analytics-dataservice-configuration>

--- a/components/analytics-data-connectors/org.wso2.carbon.analytics.datasource.rdbms/src/test/resources/conf6/analytics/analytics-config.xml
+++ b/components/analytics-data-connectors/org.wso2.carbon.analytics.datasource.rdbms/src/test/resources/conf6/analytics/analytics-config.xml
@@ -50,4 +50,7 @@
    <!-- The number of index shards, should be equal or higher to the number of indexing nodes that is going to be working,
         ideal count being 'number of indexing nodes * CPU cores' -->
    <shardCount>6</shardCount>
+    <!-- Whether terms of wildcard, prefix, fuzzy and range lucene queries are to be automatically lower-cased or
+    not. By default this will be true and property can be used to override that behavior -->
+    <lowercaseExpandedTerms>false</lowercaseExpandedTerms>
 </analytics-dataservice-configuration>

--- a/components/analytics-data-connectors/org.wso2.carbon.analytics.datasource.rdbms/src/test/resources/conf7/analytics/analytics-config.xml
+++ b/components/analytics-data-connectors/org.wso2.carbon.analytics.datasource.rdbms/src/test/resources/conf7/analytics/analytics-config.xml
@@ -50,4 +50,7 @@
    <!-- The number of index shards, should be equal or higher to the number of indexing nodes that is going to be working,
         ideal count being 'number of indexing nodes * CPU cores' -->
    <shardCount>6</shardCount>
+    <!-- Whether terms of wildcard, prefix, fuzzy and range lucene queries are to be automatically lower-cased or
+    not. By default this will be true and property can be used to override that behavior -->
+    <lowercaseExpandedTerms>false</lowercaseExpandedTerms>
 </analytics-dataservice-configuration>

--- a/components/analytics-data-connectors/org.wso2.carbon.analytics.datasource.rdbms/src/test/resources/conf8/analytics/analytics-config.xml
+++ b/components/analytics-data-connectors/org.wso2.carbon.analytics.datasource.rdbms/src/test/resources/conf8/analytics/analytics-config.xml
@@ -74,4 +74,7 @@
          to do the indexing operations of the local shards. When this value is increased, the parallel I/O operations being done on the
          system grows larger. So a system which can handle parallel I/O operation could increase this, e.g. SSDs -->
     <indexWorkerCount>8</indexWorkerCount>
+    <!-- Whether terms of wildcard, prefix, fuzzy and range lucene queries are to be automatically lower-cased or
+    not. By default this will be true and property can be used to override that behavior -->
+    <lowercaseExpandedTerms>false</lowercaseExpandedTerms>
 </analytics-dataservice-configuration>


### PR DESCRIPTION
## Purpose
Resolves #1221 

## Goals
This PR provide support to have Lucene queries with with upper-case letters and wild cards(_STR1:S*). 

## Approach
This PR overrides the default behavior of Lucene which normalize queries and converts to lower-case. To utilize the functionality users will have to add a configuration to analytics-config.xml

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JK 1.8.0
 