### PR TITLE
Change material-ui-next version of Status Dashboard web component

### DIFF
--- a/components/org.wso2.carbon.status.dashboard.web/package.json
+++ b/components/org.wso2.carbon.status.dashboard.web/package.json
@@ -29,7 +29,7 @@
     "dagre-d3": "^0.6.1",
     "html-loader": "^0.5.0",
     "material-ui": "^0.19.4",
-    "material-ui-next": "^1.0.0-beta.42",
+    "material-ui-next": "1.0.0-beta.42",
     "material-ui-pagination": "^1.1.6",
     "prop-types": "^15.5.10",
     "qs": "^6.5.1",


### PR DESCRIPTION
## Purpose
> Removing prefix character of material-ui-next version in `package.json`

## Goals
> Avoid build failures with Node 6.10.0 & NPM 3.10.10

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
> #1232 

## Test environment
> Node 6.10.0, NPM 3.10.10