### PR TITLE
Add lucene jar to classpath explicitly

### DIFF
--- a/features/analytics-core/org.wso2.carbon.analytics.core.server.feature/src/main/resources/bin/analytics-backup.sh
+++ b/features/analytics-core/org.wso2.carbon.analytics.core.server.feature/src/main/resources/bin/analytics-backup.sh
@@ -245,6 +245,7 @@ for t in "$CARBON_HOME"/repository/components/lib/*.jar
 do
     CARBON_CLASSPATH="$CARBON_CLASSPATH":$t
 done
+CARBON_CLASSPATH="$CARBON_CLASSPATH":$(find "$CARBON_HOME"/repository/components/plugins -name 'lucene_[0-9]*.*[0-9]*.*[0-9]*.*wso2v[0-9].jar')
 for t in "$CARBON_HOME"/repository/components/plugins/*.jar
 do
     CARBON_CLASSPATH="$CARBON_CLASSPATH":$t


### PR DESCRIPTION
## Purpose
> Fix lucene class loading issue when using analytics-backup tool

## Approach
> Explicitly add lucene_5.2.1.wso2v1.jar to classpath