### PR TITLE
Add fix to show host machine ip when editor starts up

### DIFF
--- a/components/org.wso2.carbon.business.rules.templates.editor.core/src/main/java/org/wso2/carbon/business/rules/templates/editor/core/internal/StartupComponent.java
+++ b/components/org.wso2.carbon.business.rules.templates.editor.core/src/main/java/org/wso2/carbon/business/rules/templates/editor/core/internal/StartupComponent.java
@@ -55,7 +55,15 @@ public class StartupComponent {
     protected void setMicroservicesServer(MicroservicesServer microservicesServer) {
         microservicesServer.getListenerConfigurations().entrySet().stream().forEach(entry -> {
             if (("http").equals(entry.getValue().getScheme())) {
-                String startingURL = entry.getValue().getScheme() + "://localhost:" + entry.getValue()
+                String hostname;
+                try {
+                    hostname = HostAddressFinder.findAddress(entry.getValue().getHost());
+                } catch (SocketException e) {
+                    hostname = entry.getValue().getHost();
+                    logger.error("Error in finding address for provided hostname " + hostname + "." +
+                            e.getMessage(), e);
+                }
+                String startingURL = entry.getValue().getScheme() + "://" + hostname + ":" + entry.getValue()
                         .getPort() + "/template-editor";
                 logger.info("Template Editor Started on : " + startingURL);
             }

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/StartupComponent.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/StartupComponent.java
@@ -27,7 +27,10 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.wso2.carbon.siddhi.editor.core.util.HostAddressFinder;
 import org.wso2.msf4j.MicroservicesServer;
+
+import java.net.SocketException;
 
 /**
  * Startup component of Siddhi Editor.
@@ -57,7 +60,15 @@ public class StartupComponent {
     protected void setMicroservicesServer(MicroservicesServer microservicesServer) {
         microservicesServer.getListenerConfigurations().entrySet().stream().forEach(entry -> {
             if (("http").equals(entry.getValue().getScheme())) {
-                String startingURL = entry.getValue().getScheme() + "://localhost:" + entry.getValue()
+                String hostname;
+                try {
+                    hostname = HostAddressFinder.findAddress(entry.getValue().getHost());
+                } catch (SocketException e) {
+                    hostname = entry.getValue().getHost();
+                    logger.error("Error in finding address for provided hostname " + hostname + "." +
+                            e.getMessage(), e);
+                }
+                String startingURL = entry.getValue().getScheme() + "://" + hostname + ":" + entry.getValue()
                         .getPort() + "/editor";
                 logger.info("Editor Started on : " + startingURL);
             }


### PR DESCRIPTION
## Purpose
Enable host machine Ip to be visible on startup log


## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes