### PR TITLE
Add WebSocket Provider

### DIFF
--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/websocket/WebSocketProvider.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/websocket/WebSocketProvider.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.data.provider.websocket;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.carbon.data.provider.DataProvider;
+import org.wso2.carbon.data.provider.InputFieldTypes;
+import org.wso2.carbon.data.provider.ProviderConfig;
+import org.wso2.carbon.data.provider.bean.DataSetMetadata;
+import org.wso2.carbon.data.provider.exception.DataProviderException;
+import org.wso2.carbon.data.provider.websocket.bean.WebSocketChannel;
+import org.wso2.carbon.data.provider.websocket.endpoint.WebSocketProviderEndPoint;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component(
+        service = DataProvider.class,
+        immediate = true
+)
+public class WebSocketProvider implements DataProvider {
+    private static final Logger log = LoggerFactory.getLogger(WebSocketProvider.class);
+    private WebSocketChannel webSocketChannel;
+
+    @Override
+    public DataProvider init(String topic, String sessionId, JsonElement jsonElement) throws DataProviderException {
+        webSocketChannel = new Gson().fromJson(jsonElement, WebSocketChannel.class);
+        webSocketChannel.setSessionId(sessionId);
+        webSocketChannel.setTopic(topic);
+        return this;
+    }
+
+    @Override
+    public void start() {
+        WebSocketProviderEndPoint.subscribeToTopic(webSocketChannel.getSubscriberTopic(), webSocketChannel);
+    }
+
+    @Override
+    public void stop() {
+        WebSocketProviderEndPoint.unsubscribeFromTopic(webSocketChannel.getSubscriberTopic(), webSocketChannel.getSessionId());
+    }
+
+    @Override
+    public boolean configValidator(ProviderConfig providerConfig) throws DataProviderException {
+        // no validations required
+        return false;
+    }
+
+    @Override
+    public String providerName() {
+        return "WebSocketProvider";
+    }
+
+    @Override
+    public DataSetMetadata dataSetMetadata() {
+        // not applicable because web-socket will only provide a stream of data.
+        return null;
+    }
+
+    @Override
+    public String providerConfig() {
+        Map<String, String> renderingTypes = new HashMap<>();
+
+        renderingTypes.put("topic", InputFieldTypes.TEXT_FIELD);
+        renderingTypes.put("mapType", InputFieldTypes.TEXT_FIELD);
+
+        return new Gson().toJson(new Object[]{renderingTypes, new WebSocketChannel()});
+    }
+}

--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/websocket/WebSocketProvider.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/websocket/WebSocketProvider.java
@@ -80,10 +80,8 @@ public class WebSocketProvider implements DataProvider {
     @Override
     public String providerConfig() {
         Map<String, String> renderingTypes = new HashMap<>();
-
         renderingTypes.put("topic", InputFieldTypes.TEXT_FIELD);
         renderingTypes.put("mapType", InputFieldTypes.TEXT_FIELD);
-
         return new Gson().toJson(new Object[]{renderingTypes, new WebSocketChannel()});
     }
 }

--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/websocket/bean/WebSocketChannel.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/websocket/bean/WebSocketChannel.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.data.provider.websocket.bean;
+
+public class WebSocketChannel {
+    private String subscriberTopic;
+    private String sessionId;
+    private String mapType;
+    private String topic;
+
+    public String getMapType() {
+        return mapType;
+    }
+
+    public void setMapType(String mapType) {
+        this.mapType = mapType;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public void setSessionId(String sessionId) {
+        this.sessionId = sessionId;
+    }
+
+    public String getSubscriberTopic() {
+        return subscriberTopic;
+    }
+
+    public void setSubscriberTopic(String subscriberTopic) {
+        this.subscriberTopic = subscriberTopic;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+}

--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/websocket/endpoint/WebSocketProviderEndPoint.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/websocket/endpoint/WebSocketProviderEndPoint.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.data.provider.websocket.endpoint;
+
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.wso2.carbon.data.provider.endpoint.DataProviderEndPoint;
+import org.wso2.carbon.data.provider.websocket.bean.WebSocketChannel;
+import org.wso2.msf4j.websocket.WebSocketEndpoint;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import javax.websocket.*;
+import javax.websocket.server.PathParam;
+import javax.websocket.server.ServerEndpoint;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.*;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component(
+        service = WebSocketEndpoint.class,
+        immediate = true
+)
+@ServerEndpoint(value = "/websocket-provider/{topic}")
+public class WebSocketProviderEndPoint implements WebSocketEndpoint {
+    private static final Logger log = LoggerFactory.getLogger(WebSocketProviderEndPoint.class);
+    private static final Map<String, ArrayList<WebSocketChannel>> providerMap = new HashMap<>();
+
+
+    @OnOpen
+    public static void onOpen(Session session, @PathParam("topic") String topic) {
+        // Not required.
+    }
+
+    @OnMessage
+    public void onMessage(String message, @PathParam("topic") String topic) {
+        log.info(message);
+        if (providerMap.containsKey(topic)) {
+            providerMap.get(topic).forEach(channel -> {
+                try {
+                    DataProviderEndPoint
+                            .sendText(channel.getSessionId(),
+                                    formatString(message, channel.getMapType(), channel.getTopic()).toString());
+                } catch (IOException e) {
+                    log.info("Failed to send the message : " + e.getMessage(), e);
+                }
+            });
+        }
+    }
+
+    @OnClose
+    public void onClose(Session session) {
+        // Not applicable as disconnecting from the web-socket provider doesn't affect the subscribed clients of the
+        // data provider
+    }
+
+    @OnError
+    public void onError(Throwable throwable) {
+        log.error("Error found in method : " + throwable.getMessage(), throwable);
+    }
+
+    public static void subscribeToTopic(String topic, WebSocketChannel channel) {
+        if (providerMap.containsKey(topic)) {
+            providerMap.get(topic).add(channel);
+        } else {
+            providerMap.put(topic, new ArrayList<>());
+            providerMap.get(topic).add(channel);
+        }
+    }
+
+    public static void unsubscribeFromTopic(String topic, String sessionID) {
+        providerMap.get(topic).removeIf(channel -> channel.getSessionId().equals(sessionID));
+    }
+
+    private JsonElement formatString(String message, String mapping, String topic) {
+
+        JsonElement element = new Gson().fromJson("{}", JsonElement.class);
+        Pattern pattern = null;
+        Matcher matcher = null;
+
+        switch (mapping.toLowerCase()) {
+            case "text":
+                element = new Gson().fromJson(getJsonString(message, topic), JsonElement.class);
+                break;
+            case "json":
+                pattern = Pattern.compile("\\{\"event\":\\{(.*?)}}");
+                matcher = pattern.matcher(message);
+
+                if (matcher.find()) {
+                    element = new Gson().fromJson(getJsonString(matcher.group(1), topic), JsonElement.class);
+                }
+                break;
+            case "xml":
+                try {
+                    InputSource inputSource = new InputSource(new StringReader(message));
+                    DocumentBuilder documentBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+                    Document document = documentBuilder.parse(inputSource);
+
+                    XPathFactory xPathFactory = XPathFactory.newInstance();
+                    XPath xPath = xPathFactory.newXPath();
+                    XPathExpression expression = xPath.compile("//events/event/*");
+                    Object result = expression.evaluate(document, XPathConstants.NODESET);
+                    NodeList nodeList = (NodeList) result;
+
+                    StringBuilder stringBuilder = new StringBuilder();
+                    stringBuilder.append("{data:[[\"");
+
+                    for (int i = 0; i < nodeList.getLength(); i++) {
+                        Element el = (Element) nodeList.item(i);
+
+                        // seach for the Text children
+                        if (el.getFirstChild().getNodeType() == Node.TEXT_NODE)
+                            stringBuilder.append(el.getFirstChild().getNodeValue()).append("\",\"");
+                    }
+
+                    stringBuilder.setLength(stringBuilder.length() - 2);
+
+                    stringBuilder.append("]],topic:").append(topic).append("}");
+
+                    element = new Gson().fromJson(stringBuilder.toString(), JsonElement.class);
+
+                } catch (XPathExpressionException | ParserConfigurationException | SAXException | IOException e) {
+                    log.error("Error occurd when parsing xml." + e.getMessage(), e);
+                }
+                break;
+            default:
+                log.error("Invalid mapping provided for the data provider configuration.");
+        }
+
+        return element;
+    }
+
+
+    private String getJsonString(String value, String topic) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("{data:[[");
+        Arrays.stream(value.trim().split(","))
+                .forEach(keyValuePair -> builder.append(keyValuePair.split(":")[1]).append(","));
+        builder.deleteCharAt(builder.length() - 1).append("]],topic:").append(topic).append("}");
+
+        return builder.toString();
+    }
+}


### PR DESCRIPTION
## Purpose
Introduce a web socket provider to provide data for the dashboards etc.

## Goals
Introduce a data provider that utilizes web siddhi-io-websocket sink to provide data to the clients.

## Approach
- Create a web-socket server endpoint that accepts a topic as a path parameter siddhi websocket sinks(or any other websocket sink) can connect to.
- Register clients that request websocket data provider in that end point under the topics given in their data provider configuration.
- When a web socket sink publish a message to the endpoint with the topic parameter if there are clients registered to that topic those messages will be published to the clients via the data provider.

## Documentation
This Provider will create the following end points to web socket sinks to connect and publish to.
```
    wss://host:port/websocket-provider/{topic}
```
In order to initialize the Data provider and connect to the end point following json should be provided to the data-provider endpoint
```javascript
        {
            configs: {
                type: 'WebSocketProvider', // type of the data provider to initialize
                config: {
                    subscriberTopic: 'sampleStream', // topic the client subscribing to
                    mapType: 'json' // mapping used in the web socket sink
                }
            }
        }
```
Provider supports mappings of `text`, `json` and `xml`.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK v1.8.0_171