### PR TITLE
Fix login page refresh on first keystroke

### DIFF
--- a/components/org.wso2.carbon.business.rules.web/src/components/auth/Login.jsx
+++ b/components/org.wso2.carbon.business.rules.web/src/components/auth/Login.jsx
@@ -57,7 +57,7 @@ export default class Login extends Component {
             password: '',
             authenticated: false,
             rememberMe: false,
-            referrer: appContext,
+            referrer: '/',
         };
         this.authenticate = this.authenticate.bind(this);
     }

--- a/components/org.wso2.carbon.business.rules.web/src/components/auth/Logout.jsx
+++ b/components/org.wso2.carbon.business.rules.web/src/components/auth/Logout.jsx
@@ -31,10 +31,22 @@ const appContext = window.contextPath;
  * Logout Component
  */
 export default class Logout extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            redirectToLogin: false,
+        }
+    }
+
+    componentDidMount() {
+        AuthManager.logout()
+            .then(() => this.setState({ redirectToLogin: true }));
+    }
+
     render() {
-        AuthManager.logout();
-        return (
-            <Redirect to={{ pathname: `${appContext}/login` }} />
-        );
+        if (this.state.redirectToLogin) {
+            return <Redirect to={{ pathname: '/login' }} />;
+        }
+        return null;
     }
 }


### PR DESCRIPTION
## Purpose
> Fixing the problem of refreshing the login page on the first keystroke, when the login page was loaded after a log out.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes