### PR TITLE
Changing revision separator to double-underscore.

### DIFF
--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/persistence/util/PersistenceConstants.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/persistence/util/PersistenceConstants.java
@@ -27,10 +27,9 @@ public class PersistenceConstants {
     public static final String STATE_PERSISTENCE_REVISIONS_TO_KEEP = "revisionsToKeep";
     public static final String STATE_PERSISTENCE_CONFIGS = "config";
     public static final String DEFAULT_FILE_PERSISTENCE_FOLDER = "siddhi-app-persistence";
-    public static final String REVISION_SEPARATOR = "_";
+    public static final String REVISION_SEPARATOR = "__";
     public static final String DEFAULT_DB_PERSISTENCE_DATASOURCE = "WSO2_CARBON_DB";
     public static final String DEFAULT_DB_PERSISTENCE_TABLE_NAME = "PERSISTENCE_TABLE";
-
     public static final String CREATE_TABLE = "CREATE_TABLE";
     public static final String INSERT_INTO_TABLE = "INSERT_INTO_TABLE";
     public static final String IS_TABLE_EXISTS = "IS_TABLE_EXISTS";


### PR DESCRIPTION
## Purpose
The default query IDs set by Siddhi takes the form query_1, query_2 etc. This breaks revision conversion.

## Related PRs
https://github.com/wso2/siddhi/pull/845
