### PR TITLE
Fixing - BufferOverflowException when a large record is persisted.

### DIFF
--- a/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/config/AnalyticsDataServiceConfiguration.java
+++ b/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/config/AnalyticsDataServiceConfiguration.java
@@ -59,6 +59,7 @@ public class AnalyticsDataServiceConfiguration {
 
     private int queueCleanupThreshold = Constants.DEFAULT_INDEXING_QUEUE_CLEANUP_THRESHOLD;
     private boolean lowercaseExpandedTerms = Constants.DEFAULT_LOWERCASE_EXPANDED_TERMS;
+    private int localIndexDataQueuePageSize;
 
     @XmlElement (name = "analytics-record-store", nillable = false)
     public AnalyticsRecordStoreConfiguration[] getAnalyticsRecordStoreConfigurations() {
@@ -206,4 +207,12 @@ public class AnalyticsDataServiceConfiguration {
         this.lowercaseExpandedTerms = lowercaseExpandedTerms;
     }
 
+    @XmlElement( name = "localIndexDataQueuePageSize")
+    public int getLocalIndexDataQueuePageSize() {
+        return localIndexDataQueuePageSize;
+    }
+
+    public void setLocalIndexDataQueuePageSize(int localIndexDataQueuePageSize) {
+        this.localIndexDataQueuePageSize = localIndexDataQueuePageSize;
+    }
 }

--- a/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/indexing/LocalIndexDataStore.java
+++ b/components/analytics-core/org.wso2.carbon.analytics.dataservice.core/src/main/java/org/wso2/carbon/analytics/dataservice/core/indexing/LocalIndexDataStore.java
@@ -23,6 +23,7 @@ import com.leansoft.bigqueue.IBigQueue;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.analytics.dataservice.commons.exception.AnalyticsInterruptException;
+import org.wso2.carbon.analytics.dataservice.core.AnalyticsServiceHolder;
 import org.wso2.carbon.analytics.dataservice.core.Constants;
 import org.wso2.carbon.analytics.datasource.commons.Record;
 import org.wso2.carbon.analytics.datasource.commons.exception.AnalyticsException;
@@ -213,6 +214,11 @@ public class LocalIndexDataStore {
             String path = Constants.DEFAULT_LOCAL_INDEX_STAGING_LOCATION;
             path = GenericUtils.resolveLocation(path);
             try {
+                int pageSize = AnalyticsServiceHolder.getAnalyticsDataServiceConfiguration().
+                        getLocalIndexDataQueuePageSize();
+                if (pageSize != 0) {
+                    return new BigQueueImpl(path, queueId, pageSize);
+                }
                 return new BigQueueImpl(path, queueId);
             } catch (IOException e) {
                 throw new AnalyticsException("Error in creating queue: " + e.getMessage(), e);


### PR DESCRIPTION
This PR contains 2 fixes:

1. Remove non-indexable fields from indexQueue. Thanks @gimantha for providing this fix.
2. Introducing a new configuration to set page size (in bytes) of the local index data queue. To configure this, add following entry to <DAS_HOME>/repository/conf/analytics/analytics-config.xml file:
`<localIndexDataQueuePageSize>PAGE_SIZE_IN_BYTES_HERE</localIndexDataQueuePageSize>`

Example:
`<localIndexDataQueuePageSize>268435456</localIndexDataQueuePageSize>`

This configuration is optional. If not set, page size will default to 134217728 bytes.

## Purpose
Resolves https://github.com/wso2/carbon-analytics/issues/1354