### PR TITLE
 Add missing TestNG dependency and test suit file

### DIFF
--- a/components/org.wso2.carbon.sp.solutions/org.wso2.carbon.sp.solutions.message.tracer/components/open-tracer-client/org.wso2.sp.open.tracer.client/pom.xml
+++ b/components/org.wso2.carbon.sp.solutions/org.wso2.carbon.sp.solutions.message.tracer/components/open-tracer-client/org.wso2.sp.open.tracer.client/pom.xml
@@ -49,6 +49,11 @@
             <groupId>org.wso2.carbon.analytics-common</groupId>
             <artifactId>org.wso2.carbon.databridge.agent</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/org.wso2.carbon.sp.solutions/org.wso2.carbon.sp.solutions.message.tracer/components/open-tracer-client/org.wso2.sp.open.tracer.client/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.sp.solutions/org.wso2.carbon.sp.solutions.message.tracer/components/open-tracer-client/org.wso2.sp.open.tracer.client/src/test/resources/testng.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="wso2-test-suite">
+
+</suite>


### PR DESCRIPTION
## Purpose
> Add missing TestNG dependency and test suit file, as test framework validate when the Jenkin building the repo component.