### PR TITLE
 Improve editor by adding Siddhiapp description into the design view

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/beans/configs/SiddhiAppConfig.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/beans/configs/SiddhiAppConfig.java
@@ -44,6 +44,7 @@ import java.util.Set;
 public class SiddhiAppConfig {
     private int finalElementCount = 0;
 
+    private String siddhiAppDescription ="";
     private String siddhiAppName = "";
     private List<String> appAnnotationList = new ArrayList<>();
     private List<SourceSinkConfig> sourceList = new ArrayList<>();
@@ -203,6 +204,10 @@ public class SiddhiAppConfig {
     public void setAppAnnotationList(List<String> appAnnotationList) {
         this.appAnnotationList = appAnnotationList;
     }
+
+    public void setSiddhiAppDescription(String siddhiAppDescription) { this.siddhiAppDescription = siddhiAppDescription; }
+
+    public String getSiddhiAppDescription() { return siddhiAppDescription; }
 
     public void setSiddhiAppName(String siddhiAppName) {
         this.siddhiAppName = siddhiAppName;

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/beans/configs/SiddhiAppConfig.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/beans/configs/SiddhiAppConfig.java
@@ -44,7 +44,7 @@ import java.util.Set;
 public class SiddhiAppConfig {
     private int finalElementCount = 0;
 
-    private String siddhiAppDescription ="";
+    private String siddhiAppDescription = "";
     private String siddhiAppName = "";
     private List<String> appAnnotationList = new ArrayList<>();
     private List<SourceSinkConfig> sourceList = new ArrayList<>();
@@ -70,7 +70,8 @@ public class SiddhiAppConfig {
 
     /**
      * Returns Id for the next element id, after incrementing the final element count
-     * @return      Id for the element
+     *
+     * @return Id for the element
      */
     private String generateNextElementId() {
         return String.valueOf(++finalElementCount);
@@ -78,9 +79,10 @@ public class SiddhiAppConfig {
 
     /**
      * Returns PartitionConnector id, with the given partition id and connector id
-     * @param partitionId       Id of the PartitionConfig
-     * @param connectorId       Id of the PartitionConnector, within the Partition
-     * @return                  PartitionConnector id
+     *
+     * @param partitionId Id of the PartitionConfig
+     * @param connectorId Id of the PartitionConnector, within the Partition
+     * @return PartitionConnector id
      */
     private String generatePartitionConnectorId(String partitionId, String connectorId) {
         return partitionId + "_pc" + connectorId;
@@ -88,9 +90,10 @@ public class SiddhiAppConfig {
 
     /**
      * Adds a given generic type Siddhi ElementConfig, to the given list of the same generic type
-     * @param elementList       List to which, the given element config should be added
-     * @param elementConfig     Siddhi ElementConfig object
-     * @param <T>               Generic type of the Siddhi ElementConfig object, and each membe of the list
+     *
+     * @param elementList   List to which, the given element config should be added
+     * @param elementConfig Siddhi ElementConfig object
+     * @param <T>           Generic type of the Siddhi ElementConfig object, and each membe of the list
      */
     private <T> void addElement(List<T> elementList, T elementConfig) {
         ((SiddhiElementConfig) elementConfig).setId(generateNextElementId());
@@ -101,7 +104,8 @@ public class SiddhiAppConfig {
     /**
      * Adds the given list of ElementCodeSegment objects representing code segments of Siddhi elements,
      * to the existing list
-     * @param elementCodeSegments       List of ElementCodeSegment objects
+     *
+     * @param elementCodeSegments List of ElementCodeSegment objects
      */
     public void addElementCodeSegments(Set<ElementCodeSegment> elementCodeSegments) {
         this.elementCodeSegments.addAll(elementCodeSegments);
@@ -109,7 +113,8 @@ public class SiddhiAppConfig {
 
     /**
      * Adds the code segment of the given SiddhiElementConfig object, to the existing list of code segments
-     * @param siddhiElementConfig       SiddhiElementConfig object
+     *
+     * @param siddhiElementConfig SiddhiElementConfig object
      */
     private void addElementCodeSegment(SiddhiElementConfig siddhiElementConfig) {
         ElementCodeSegment elementCodeSegment =
@@ -123,8 +128,9 @@ public class SiddhiAppConfig {
 
     /**
      * Adds a given QueryConfig object to its specific query list, denoted by the given QueryInputType
-     * @param queryListType     Key with which, the specific query list is denoted
-     * @param queryConfig       QueryConfig object
+     *
+     * @param queryListType Key with which, the specific query list is denoted
+     * @param queryConfig   QueryConfig object
      */
     public void addQuery(QueryListType queryListType, QueryConfig queryConfig) {
         queryConfig.setId(generateNextElementId());
@@ -134,7 +140,8 @@ public class SiddhiAppConfig {
 
     /**
      * Adds a given PartitionConfig object to the partitionList
-     * @param partitionConfig       PartitionConfig object
+     *
+     * @param partitionConfig PartitionConfig object
      */
     public void addPartition(PartitionConfig partitionConfig) {
         partitionConfig.setId(generateNextElementId());

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/codegenerator/CodeGenerator.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/codegenerator/CodeGenerator.java
@@ -85,7 +85,6 @@ public class CodeGenerator {
                 siddhiApp.getTriggerList(), siddhiApp.getAggregationList(), siddhiApp.getPartitionList());
 
         return generateAppName(siddhiApp.getSiddhiAppName()) +
-                //mine
                 generateAppDescription(siddhiApp.getSiddhiAppDescription()) +
                 SubElementCodeGenerator.generateAnnotations(siddhiApp.getAppAnnotationList()) +
                 generateStreams(streamsToBeGenerated, siddhiApp.getSourceList(), siddhiApp.getSinkList()) +

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/codegenerator/CodeGenerator.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/codegenerator/CodeGenerator.java
@@ -85,6 +85,8 @@ public class CodeGenerator {
                 siddhiApp.getTriggerList(), siddhiApp.getAggregationList(), siddhiApp.getPartitionList());
 
         return generateAppName(siddhiApp.getSiddhiAppName()) +
+                //mine
+                generateAppDescription(siddhiApp.getSiddhiAppDescription()) +
                 SubElementCodeGenerator.generateAnnotations(siddhiApp.getAppAnnotationList()) +
                 generateStreams(streamsToBeGenerated, siddhiApp.getSourceList(), siddhiApp.getSinkList()) +
                 generateTables(siddhiApp.getTableList()) +
@@ -116,6 +118,32 @@ public class CodeGenerator {
 
         return appNameStringBuilder.toString();
     }
+
+    //mine
+
+    /**
+     * Generate's the Siddhi code representation of a Siddhi app's app description
+     *
+     * @param appDescription The Siddhi app's app description
+     * @return The Siddhi code representation of a Siddhi app description annotation
+     */
+    private String generateAppDescription(String appDescription) {
+        StringBuilder appDescriptionStringBuilder = new StringBuilder();
+
+        if (appDescription != null && !appDescription.isEmpty()) {
+            appDescriptionStringBuilder.append(SiddhiCodeBuilderConstants.APP_DESCRIPTION_ANNOTATION)
+                    .append(appDescription)
+                    .append(SiddhiCodeBuilderConstants.SINGLE_QUOTE)
+                    .append(SiddhiCodeBuilderConstants.CLOSE_BRACKET);
+        } else {
+            appDescriptionStringBuilder.append(SiddhiCodeBuilderConstants.DEFAULT_APP_DESCRIPTION_ANNOTATION);
+        }
+
+        return appDescriptionStringBuilder.toString();
+    }
+
+
+
 
     /**
      * Generate's the Siddhi code representation of a Siddhi app's stream definitions

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/codegenerator/CodeGenerator.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/codegenerator/CodeGenerator.java
@@ -119,8 +119,6 @@ public class CodeGenerator {
         return appNameStringBuilder.toString();
     }
 
-    //mine
-
     /**
      * Generate's the Siddhi code representation of a Siddhi app's app description
      *
@@ -141,9 +139,6 @@ public class CodeGenerator {
 
         return appDescriptionStringBuilder.toString();
     }
-
-
-
 
     /**
      * Generate's the Siddhi code representation of a Siddhi app's stream definitions

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/constants/SiddhiCodeBuilderConstants.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/constants/SiddhiCodeBuilderConstants.java
@@ -67,8 +67,8 @@ public class SiddhiCodeBuilderConstants {
     public static final String PAYLOAD_ANNOTATION = "@payload(";
     public static final String DEFAULT_APP_NAME_ANNOTATION = APP_NAME_ANNOTATION + "SiddhiApp" +
             SINGLE_QUOTE + CLOSE_BRACKET;
-    public static final String DEFAULT_APP_DESCRIPTION_ANNOTATION = APP_DESCRIPTION_ANNOTATION + "Description of the plan" +
-            SINGLE_QUOTE + CLOSE_BRACKET;
+    public static final String DEFAULT_APP_DESCRIPTION_ANNOTATION = APP_DESCRIPTION_ANNOTATION +
+            "Description of the plan" + SINGLE_QUOTE + CLOSE_BRACKET;
     // Join Strings
     public static final String JOIN = "join";
     public static final String LEFT_OUTER_JOIN = "left outer join";

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/constants/SiddhiCodeBuilderConstants.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/constants/SiddhiCodeBuilderConstants.java
@@ -57,6 +57,8 @@ public class SiddhiCodeBuilderConstants {
     public static final String ALL_EVENTS = "all events";
     // Annotation Strings
     public static final String APP_NAME_ANNOTATION = "@App:name('";
+    public static final String APP_DESCRIPTION_ANNOTATION = "@App:description('";
+
     public static final String SOURCE_ANNOTATION = "@source(type='";
     public static final String SINK_ANNOTATION = "@sink(type='";
     public static final String STORE_ANNOTATION = "@store(type='";
@@ -64,6 +66,8 @@ public class SiddhiCodeBuilderConstants {
     public static final String ATTRIBUTES_ANNOTATION = "@attributes(";
     public static final String PAYLOAD_ANNOTATION = "@payload(";
     public static final String DEFAULT_APP_NAME_ANNOTATION = APP_NAME_ANNOTATION + "SiddhiApp" +
+            SINGLE_QUOTE + CLOSE_BRACKET;
+    public static final String DEFAULT_APP_DESCRIPTION_ANNOTATION = APP_DESCRIPTION_ANNOTATION + "Description of the plan" +
             SINGLE_QUOTE + CLOSE_BRACKET;
     // Join Strings
     public static final String JOIN = "join";

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/designgenerator/builders/EventFlowBuilder.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/designgenerator/builders/EventFlowBuilder.java
@@ -93,18 +93,27 @@ public class EventFlowBuilder {
      */
     public EventFlowBuilder loadAppAnnotations() {
         String siddhiAppName = "";
+        String siddhiAppDescription = "";
         List<String> appAnnotations = new ArrayList<>();
         AnnotationConfigGenerator annotationConfigGenerator = new AnnotationConfigGenerator();
         for (Annotation annotation : siddhiApp.getAnnotations()) {
             if (annotation.getName().equalsIgnoreCase("NAME")) {
                 siddhiAppName = annotation.getElements().get(0).getValue();
                 annotationConfigGenerator.preserveCodeSegment(annotation);
-            } else {
+            }
+
+            else if (annotation.getName().equalsIgnoreCase("DESCRIPTION")){
+                siddhiAppDescription = annotation.getElements().get(0).getValue();
+                annotationConfigGenerator.preserveCodeSegment(annotation);
+            }
+
+            else {
                 appAnnotations.add(
                         "@App:" + annotationConfigGenerator.generateAnnotationConfig(annotation).split("@")[1]);
             }
         }
         siddhiAppConfig.setSiddhiAppName(siddhiAppName);
+        siddhiAppConfig.setSiddhiAppDescription(siddhiAppDescription);
         siddhiAppConfig.setAppAnnotationList(appAnnotations);
         siddhiAppConfig.addElementCodeSegments(annotationConfigGenerator.getPreservedCodeSegments());
         return this;

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/designgenerator/builders/EventFlowBuilder.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/designgenerator/builders/EventFlowBuilder.java
@@ -81,7 +81,8 @@ public class EventFlowBuilder {
 
     /**
      * Creates an EventFlow object with loaded elements
-     * @return      EventFlow object
+     *
+     * @return EventFlow object
      */
     public EventFlow create() {
         return new EventFlow(siddhiAppConfig, edges);
@@ -89,7 +90,8 @@ public class EventFlowBuilder {
 
     /**
      * Loads App level Annotations from the Siddhi app
-     * @return      A reference to this object
+     *
+     * @return A reference to this object
      */
     public EventFlowBuilder loadAppAnnotations() {
         String siddhiAppName = "";
@@ -100,14 +102,10 @@ public class EventFlowBuilder {
             if (annotation.getName().equalsIgnoreCase("NAME")) {
                 siddhiAppName = annotation.getElements().get(0).getValue();
                 annotationConfigGenerator.preserveCodeSegment(annotation);
-            }
-
-            else if (annotation.getName().equalsIgnoreCase("DESCRIPTION")){
+            } else if (annotation.getName().equalsIgnoreCase("DESCRIPTION")) {
                 siddhiAppDescription = annotation.getElements().get(0).getValue();
                 annotationConfigGenerator.preserveCodeSegment(annotation);
-            }
-
-            else {
+            } else {
                 appAnnotations.add(
                         "@App:" + annotationConfigGenerator.generateAnnotationConfig(annotation).split("@")[1]);
             }
@@ -121,8 +119,9 @@ public class EventFlowBuilder {
 
     /**
      * Loads Triggers from the SiddhiApp
-     * @return                                  A reference to this object
-     * @throws DesignGenerationException        Error while loading elements
+     *
+     * @return A reference to this object
+     * @throws DesignGenerationException Error while loading elements
      */
     public EventFlowBuilder loadTriggers() throws DesignGenerationException {
         TriggerConfigGenerator triggerConfigGenerator =
@@ -136,9 +135,10 @@ public class EventFlowBuilder {
 
     /**
      * Returns the availability of a Trigger with the given name, in the given Siddhi app
-     * @param streamName    Name of the Stream
-     * @param siddhiApp     Siddhi app in which, availability of Trigger is searched
-     * @return              Availability of Trigger with the given name, in given Siddhi app
+     *
+     * @param streamName Name of the Stream
+     * @param siddhiApp  Siddhi app in which, availability of Trigger is searched
+     * @return Availability of Trigger with the given name, in given Siddhi app
      */
     private boolean isTriggerDefined(String streamName, SiddhiApp siddhiApp) {
         return (siddhiApp.getTriggerDefinitionMap().size() != 0 &&
@@ -147,7 +147,8 @@ public class EventFlowBuilder {
 
     /**
      * Loads Streams from the SiddhiAppRuntime
-     * @return      A reference to this object
+     *
+     * @return A reference to this object
      */
     public EventFlowBuilder loadStreams() {
         StreamDefinitionConfigGenerator streamDefinitionConfigGenerator = new StreamDefinitionConfigGenerator();
@@ -165,7 +166,8 @@ public class EventFlowBuilder {
 
     /**
      * Loads Sources from the SiddhiAppRuntime
-     * @return      A reference to this object
+     *
+     * @return A reference to this object
      */
     public EventFlowBuilder loadSources() throws DesignGenerationException {
         SourceSinkConfigsGenerator sourceConfigsGenerator = new SourceSinkConfigsGenerator();
@@ -180,7 +182,8 @@ public class EventFlowBuilder {
 
     /**
      * Loads Sinks from the SiddhiAppRuntime
-     * @return      A reference to this object
+     *
+     * @return A reference to this object
      */
     public EventFlowBuilder loadSinks() throws DesignGenerationException {
         SourceSinkConfigsGenerator sinkConfigsGenerator = new SourceSinkConfigsGenerator();
@@ -195,8 +198,9 @@ public class EventFlowBuilder {
 
     /**
      * Loads Tables from the Siddhi App
-     * @return                                  A reference to this object
-     * @throws DesignGenerationException        Error while loading elements
+     *
+     * @return A reference to this object
+     * @throws DesignGenerationException Error while loading elements
      */
     public EventFlowBuilder loadTables() throws DesignGenerationException {
         TableConfigGenerator tableConfigGenerator = new TableConfigGenerator();
@@ -209,8 +213,9 @@ public class EventFlowBuilder {
 
     /**
      * Loads Defined Windows from the SiddhiAppRuntime
-     * @return                                  A reference to this object
-     * @throws DesignGenerationException        Error while loading elements
+     *
+     * @return A reference to this object
+     * @throws DesignGenerationException Error while loading elements
      */
     public EventFlowBuilder loadWindows() throws DesignGenerationException {
         WindowConfigGenerator windowConfigGenerator = new WindowConfigGenerator(siddhiAppString);
@@ -223,8 +228,9 @@ public class EventFlowBuilder {
 
     /**
      * Loads Aggregations from the SiddhiApp
-     * @return                                  A reference to this object
-     * @throws DesignGenerationException        Error while loading elements
+     *
+     * @return A reference to this object
+     * @throws DesignGenerationException Error while loading elements
      */
     public EventFlowBuilder loadAggregations() throws DesignGenerationException {
         AggregationConfigGenerator aggregationConfigGenerator = new AggregationConfigGenerator(siddhiAppString);
@@ -237,7 +243,8 @@ public class EventFlowBuilder {
 
     /**
      * Loads Functions from the siddhi app
-     * @return      A reference to this object
+     *
+     * @return A reference to this object
      */
     public EventFlowBuilder loadFunctions() {
         FunctionConfigGenerator functionConfigGenerator = new FunctionConfigGenerator();
@@ -250,8 +257,9 @@ public class EventFlowBuilder {
 
     /**
      * Loads Execution Elements from the Siddhi App
-     * @return                                  A reference to this object
-     * @throws DesignGenerationException        Error while loading elements
+     *
+     * @return A reference to this object
+     * @throws DesignGenerationException Error while loading elements
      */
     public EventFlowBuilder loadExecutionElements() throws DesignGenerationException {
         Map<String, Map<String, AbstractDefinition>> partitionedInnerStreamDefinitions =
@@ -283,8 +291,9 @@ public class EventFlowBuilder {
 
     /**
      * Loads generated Edges that represent connections between SiddhiElementConfigs, into SiddhiAppConfig object
-     * @return                                  A reference to this object
-     * @throws DesignGenerationException        Error while loading edges
+     *
+     * @return A reference to this object
+     * @throws DesignGenerationException Error while loading edges
      */
     public EventFlowBuilder loadEdges() throws DesignGenerationException {
         EdgesGenerator edgesGenerator = new EdgesGenerator(siddhiAppConfig);
@@ -294,8 +303,9 @@ public class EventFlowBuilder {
 
     /**
      * Loads Comments, that were preserved by each Siddhi Element Config generator
-     * @return                                  A reference to this object
-     * @throws DesignGenerationException        Error while generating Comment Code Segments
+     *
+     * @return A reference to this object
+     * @throws DesignGenerationException Error while generating Comment Code Segments
      */
     public EventFlowBuilder loadComments() throws DesignGenerationException {
         OuterScopeCommentsPreserver outerScopeCommentsPreserver =

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/css/design-view.css
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/css/design-view.css
@@ -235,7 +235,7 @@
     margin-right: 5px;
 }
 
-input {
+input{
 . form-control input-md;
     font-family: inherit;
     font-size: inherit;
@@ -445,7 +445,7 @@ h3,
 
 .app-annotations-button {
     position: fixed;
-    top: 70px;
+    top: 79px;
     right: 15px;
     font-size: 20px;
     color: #757575;
@@ -460,6 +460,14 @@ h3,
     position: fixed;
     right: 60px;
     top: 77px;
+    opacity: 1 !important;
+    font-size: 16px;
+}
+
+#siddhi-app-desc-node{
+    position: fixed;
+    right: 60px;
+    top: 97px;
     opacity: 1 !important;
     font-size: 14px;
 }
@@ -590,6 +598,8 @@ a.list-group-item, button.list-group-item {
 {
     display: none;
 }
+
+#
 
 .error-element {
     border: 1px solid #FF0000;

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/configuration-data/app-data.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/configuration-data/app-data.js
@@ -29,6 +29,8 @@ define(['require', 'elementUtils', 'lodash'],
             // initiates the collections
             if (options !== undefined) {
                 this.siddhiAppName = options.siddhiAppName;
+                this.siddhiAppDescription = options.siddhiAppDescription;
+
                 // Following lists hold references for comments in the code view. These lists are passed to the backend
                 // when generating the code from design. Front end does not use them.
                 this.elementCodeSegments = options.elementCodeSegments;
@@ -198,6 +200,10 @@ define(['require', 'elementUtils', 'lodash'],
             return this.siddhiAppName;
         };
 
+         AppData.prototype.getSiddhiAppDescription = function () {
+                    return this.siddhiAppDescription;
+         };
+
         AppData.prototype.getStream = function (streamId) {
             var returnedElement = ElementUtils.prototype.getElement(this.streamList, streamId);
             if (!returnedElement) {
@@ -335,6 +341,10 @@ define(['require', 'elementUtils', 'lodash'],
         AppData.prototype.setSiddhiAppName = function (siddhiAppName) {
             this.siddhiAppName = siddhiAppName;
         };
+
+        AppData.prototype.setSiddhiAppDescription = function (siddhiAppDescription) {
+                    this.siddhiAppDescription = siddhiAppDescription;
+         };
 
         AppData.prototype.setAppAnnotationList = function (appAnnotationList) {
             this.appAnnotationList = appAnnotationList;

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/configuration-data/configuration-data.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/configuration-data/configuration-data.js
@@ -51,7 +51,6 @@ define(['require', 'elementUtils'],
         ConfigurationData.prototype.getEdge = function (edgeId) {
             return ElementUtils.prototype.getElement(this.edgeList, edgeId);
         };
-
         ConfigurationData.prototype.getEdgeList = function () {
             return this.edgeList;
         };

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/design-grid.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/design-grid.js
@@ -98,15 +98,13 @@ define(['require', 'log', 'jquery', 'backbone', 'lodash', 'designViewUtils', 'dr
                 self.dropElements.formBuilder.DefineFormForAppAnnotations(this);
             });
 
-            // add a text field to display the siddhi app name
+            // add text fields to display the siddhi app name and description
             var siddhiAppNameNodeId = self.currentTabId + '-siddhiAppNameId';
             var siddhiAppName = self.configurationData.getSiddhiAppConfig().getSiddhiAppName();
             var siddhiAppNameNode = $("<div id='" + siddhiAppNameNodeId + "' " +
                 "class='siddhi-app-name-node'>" + siddhiAppName + "</div>");
             var siddhiAppDescription = self.configurationData.getSiddhiAppConfig().getSiddhiAppDescription();
             var siddhiAppDescriptionNode = $("<div id='siddhi-app-desc-node'>"+siddhiAppDescription +"</div>");
-
-
             self.canvas.append(siddhiAppNameNode,siddhiAppDescriptionNode);
 
             /**

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/design-grid.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/design-grid.js
@@ -103,7 +103,11 @@ define(['require', 'log', 'jquery', 'backbone', 'lodash', 'designViewUtils', 'dr
             var siddhiAppName = self.configurationData.getSiddhiAppConfig().getSiddhiAppName();
             var siddhiAppNameNode = $("<div id='" + siddhiAppNameNodeId + "' " +
                 "class='siddhi-app-name-node'>" + siddhiAppName + "</div>");
-            self.canvas.append(siddhiAppNameNode);
+            var siddhiAppDescription = self.configurationData.getSiddhiAppConfig().getSiddhiAppDescription();
+            var siddhiAppDescriptionNode = $("<div id='siddhi-app-desc-node'>"+siddhiAppDescription +"</div>");
+
+
+            self.canvas.append(siddhiAppNameNode,siddhiAppDescriptionNode);
 
             /**
              * @description jsPlumb function opened

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/design-view.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/design-view.js
@@ -164,7 +164,8 @@ define(['require', 'log', 'lodash', 'jquery', 'tool_palette/tool-palette', 'desi
                 var defaultResponse = {
                     "siddhiAppConfig": {
                         "siddhiAppName": match[1],
-                        "appAnnotationList": ['@App:description("' + match[2] + '")'],
+                        "siddhiAppDescription": match[2],
+                        "appAnnotationList": [],
                         "streamList": [],
                         "tableList": [],
                         "windowList": [],

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/app-annotation-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/app-annotation-form.js
@@ -52,15 +52,17 @@ define(['require', 'log', 'jquery', 'lodash'],
 
             var siddhiAppConfig = self.configurationData.getSiddhiAppConfig();
             var siddhiAppName = siddhiAppConfig.getSiddhiAppName();
+            var siddhiAppDescription = siddhiAppConfig.getSiddhiAppDescription();
             var savedAppAnnotations = siddhiAppConfig.getAppAnnotationList();
             var annotations = [];
             _.forEach(savedAppAnnotations, function (savedAnnotation) {
-                annotations.push({annotation: savedAnnotation});
+                annotations.push({annotation:savedAnnotation});
             });
 
             var fillWith = {
                 siddhiApp: {
-                    name: siddhiAppName
+                    name: siddhiAppName,
+                    description: siddhiAppDescription
                 },
                 annotations: annotations
             };
@@ -84,6 +86,13 @@ define(['require', 'log', 'jquery', 'lodash'],
                                     title: "Name",
                                     type: "string",
                                     minLength: 1
+                                },
+                                description: {
+                                    required: true,
+                                    title: "Description",
+                                    type: "string",
+                                    minLength: 1
+
                                 }
                             }
                         },
@@ -130,6 +139,7 @@ define(['require', 'log', 'jquery', 'lodash'],
                 var config = editor.getValue();
 
                 siddhiAppConfig.setSiddhiAppName(config.siddhiApp.name);
+                siddhiAppConfig.setSiddhiAppDescription(config.siddhiApp.description);
                 siddhiAppConfig.clearAppAnnotationList();
                 _.forEach(config.annotations, function (annotation) {
                     siddhiAppConfig.addAppAnnotation(annotation.annotation);
@@ -138,6 +148,10 @@ define(['require', 'log', 'jquery', 'lodash'],
                 // update the siddhi app name displayed on the canvas
                 var siddhiAppNameNode = $('#' + self.currentTabId + '-siddhiAppNameId');
                 siddhiAppNameNode.html(config.siddhiApp.name);
+
+                //update the siddhi app desc displayed on the canvas
+                var siddhiAppDescriptionNode = $('#siddhi-app-desc-node');
+                siddhiAppDescriptionNode.html(config.siddhiApp.description);
 
                 // design view container and toggle view button are enabled
                 self.designViewContainer.removeClass('disableContainer');

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/initialise-data.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/initialise-data.js
@@ -55,6 +55,9 @@ define(['require', 'log', 'lodash', 'jquery', 'configurationData', 'appData', 'p
 
             // set the app name
             self.appData.setSiddhiAppName(configurationJSON.siddhiAppConfig.siddhiAppName);
+            // set the app desc
+            self.appData.setSiddhiAppDescription(configurationJSON.siddhiAppConfig.siddhiAppDescription);
+
             // add app annotations
             self.appData.setAppAnnotationList(configurationJSON.siddhiAppConfig.appAnnotationList);
             // add definitions to the data storing structure


### PR DESCRIPTION
## Purpose
> In the editor's design view the description of the app wasn't visible
> In the app annotation form there was no separate field for the user to edit the app description as the 
   app's name

## Goals
> Include a separate div to display the app description, just below the app name
> Have a separate input field in the annotation-form with the label "Description", so that the user can enter the description and when it is switched to the source view the description annotation is added

## Approach
> 
![img_20180808_140749](https://user-images.githubusercontent.com/32606884/43826332-b59aaf16-9b14-11e8-9fd8-31b34cf45940.png)
![img_20180808_140703](https://user-images.githubusercontent.com/32606884/43826352-bfd15624-9b14-11e8-9822-2588f6422032.png)
