### PR TITLE
Fix add current event as the default event type

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/codegenerator/generators/query/subelements/QueryOutputCodeGenerator.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/codegenerator/generators/query/subelements/QueryOutputCodeGenerator.java
@@ -91,8 +91,7 @@ public class QueryOutputCodeGenerator {
         if (insertOutput.getEventType() != null && !insertOutput.getEventType().isEmpty()) {
             switch (insertOutput.getEventType().toUpperCase()) {
                 case CodeGeneratorConstants.CURRENT_EVENTS:
-                    insertOutputStringBuilder.append(SiddhiCodeBuilderConstants.CURRENT_EVENTS)
-                            .append(SiddhiCodeBuilderConstants.SPACE);
+                    insertOutputStringBuilder.append(SiddhiCodeBuilderConstants.SPACE);
                     break;
                 case CodeGeneratorConstants.EXPIRED_EVENTS:
                     insertOutputStringBuilder.append(SiddhiCodeBuilderConstants.EXPIRED_EVENTS)

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/join-query-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/join-query-form.js
@@ -566,7 +566,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOutputInsert'
                                 title: "For",
                                 type: "string",
                                 enum: ['current events', 'expired events', 'all events'],
-                                default: 'all events'
+                                default: 'current events'
                             }
                         }
                     };

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/pattern-query-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/pattern-query-form.js
@@ -376,7 +376,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOutputInsert'
                                 title: "For",
                                 type: "string",
                                 enum: ['current events', 'expired events', 'all events'],
-                                default: 'all events'
+                                default: 'current events'
                             }
                         }
                     };

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/sequence-query-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/sequence-query-form.js
@@ -373,7 +373,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOutputInsert'
                                 title: "For",
                                 type: "string",
                                 enum: ['current events', 'expired events', 'all events'],
-                                default: 'all events'
+                                default: 'current events'
                             }
                         }
                     };

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/window-filter-projection-query-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/window-filter-projection-query-form.js
@@ -56,7 +56,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOutputInsert'
         WindowFilterProjectionQueryForm.prototype.generatePropertiesForm = function (element, formConsole,
                                                                                      formContainer) {
             var self = this;
-            var propertyDiv = $('<div id="property-header"><h3>Query Configuration</h3></div>' +
+            var propertyDiv = $('<div id="property-header"><h3>Query Configuration </h3></div>' +
                 '<div class="define-windowFilterProjection-query"></div>');
             formContainer.append(propertyDiv);
             self.designViewContainer.addClass('disableContainer');
@@ -672,7 +672,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOutputInsert'
                                 title: "For",
                                 type: "string",
                                 enum: ['current events', 'expired events', 'all events'],
-                                default: 'all events'
+                                default: 'current events'
                             }
                         }
                     };


### PR DESCRIPTION
## Purpose
> Currently, all events are selected as the default event type in query forms.
>In the design view if the "current events" is selected while generating the code view the "current events" word need not be added as it is the default event.

## Goals
> To make current events as the default event type.
> If the event type selected is "current event", not to append the SiddhiCodeBuilderConstants.CURRENT_EVENTS to the source code query 

##Issues
> Issues: https://github.com/wso2/product-sp/issues/716