### PR TITLE
Deploy a business rule on all the available workers if it's not configured in deployment.yaml

### DIFF
--- a/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/services/TemplateManagerService.java
+++ b/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/services/TemplateManagerService.java
@@ -46,6 +46,7 @@ import org.wso2.carbon.business.rules.core.util.TemplateManagerHelper;
 import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -1398,7 +1399,11 @@ public class TemplateManagerService implements BusinessRulesService {
             String node = object.toString();
             Object templates = nodes.get(node);
             if (templates instanceof List) {
-                for (Object uuid : (List) templates) {
+                List templateList = (List) templates;
+                if (!templateList.contains(ruleTemplateUUID.toString())) {
+                    return new ArrayList<String>(nodes.keySet());
+                }
+                for (Object uuid : templateList) {
                     if (ruleTemplateUUID.equals(uuid.toString())) {
                         nodeList.add(node);
                         break;

--- a/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/services/TemplateManagerService.java
+++ b/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/services/TemplateManagerService.java
@@ -1402,11 +1402,12 @@ public class TemplateManagerService implements BusinessRulesService {
                 List templateList = (List) templates;
                 if (!templateList.contains(ruleTemplateUUID.toString())) {
                     return new ArrayList<String>(nodes.keySet());
-                }
-                for (Object uuid : templateList) {
-                    if (ruleTemplateUUID.equals(uuid.toString())) {
-                        nodeList.add(node);
-                        break;
+                } else {
+                    for (Object uuid : templateList) {
+                        if (ruleTemplateUUID.equals(uuid.toString())) {
+                            nodeList.add(node);
+                            break;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Purpose
> Deploy a business rule on all the available workers if it's not configured in deployment.yaml

## Goals
> Currently all the rule templates should be configured in deployment.yaml in order to deploy their instances. This PR is to allow deploying them on all the workers by default.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
