### PR TITLE
Fix monitoring app crash after receiving a incorrectly decoded message

### DIFF
--- a/components/org.wso2.carbon.status.dashboard.core/src/main/java/org/wso2/carbon/status/dashboard/core/impl/MonitoringApiServiceImpl.java
+++ b/components/org.wso2.carbon.status.dashboard.core/src/main/java/org/wso2/carbon/status/dashboard/core/impl/MonitoringApiServiceImpl.java
@@ -58,6 +58,7 @@ import org.wso2.carbon.status.dashboard.core.dbhandler.StatusDashboardMetricsDBH
 import org.wso2.carbon.status.dashboard.core.exception.RDBMSTableException;
 import org.wso2.carbon.status.dashboard.core.exception.StatusDashboardRuntimeException;
 import org.wso2.carbon.status.dashboard.core.impl.utils.Constants;
+import org.wso2.carbon.status.dashboard.core.impl.utils.MonitoringApiUtil;
 import org.wso2.carbon.status.dashboard.core.internal.ApiResponseMessageWithCode;
 import org.wso2.carbon.status.dashboard.core.internal.MonitoringDataHolder;
 import org.wso2.carbon.status.dashboard.core.internal.WorkerStateHolder;
@@ -890,7 +891,7 @@ public class MonitoringApiServiceImpl extends MonitoringApiService {
     }
 
     /**
-     * This method return the both siddi apptext view and flow chart.PS: Currently implemetented till text view.
+     * This method return the both siddi apptext view
      *
      * @param id      workerid of the siddhi app
      * @param appName siddhiapp name
@@ -918,7 +919,8 @@ public class MonitoringApiServiceImpl extends MonitoringApiService {
                                         "Requested Response is null"));
                         return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(jsonString).build();
                     } else {
-                        String responseAppBody = siddhiAppResponce.body().toString();
+                        String responseAppBody = MonitoringApiUtil
+                                .processResponseBody(siddhiAppResponce.body());
                         if (siddhiAppResponce.status() == 200) {
                             return Response.ok().entity(responseAppBody).build();
                         } else if (siddhiAppResponce.status() == 401) {
@@ -933,6 +935,11 @@ public class MonitoringApiServiceImpl extends MonitoringApiService {
                             toJson(new ApiResponseMessageWithCode(ApiResponseMessageWithCode.SERVER_CONNECTION_ERROR,
                                     e.getMessage()));
                     return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(jsonString).build();
+                } catch (IOException e) {
+                    logger.error("Unable to decode siddhi app '" + appName + "'.", e);
+                    return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                            .entity("Unable to decode siddhi app. Please try again.")
+                            .build();
                 }
             }
             logger.error("Inproper format of worker ID:" + id);

--- a/components/org.wso2.carbon.status.dashboard.core/src/main/java/org/wso2/carbon/status/dashboard/core/impl/utils/MonitoringApiUtil.java
+++ b/components/org.wso2.carbon.status.dashboard.core/src/main/java/org/wso2/carbon/status/dashboard/core/impl/utils/MonitoringApiUtil.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.status.dashboard.core.impl.utils;
+
+import feign.Response;
+import okio.Buffer;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.stream.Collectors;
+
+/**
+ * Util class for Monitoring APIs.
+ */
+public class MonitoringApiUtil {
+
+    public static String processResponseBody(Object responseBody) throws IOException {
+        if (responseBody instanceof Response.Body) {
+            try (BufferedReader br = new BufferedReader(
+                    new InputStreamReader(((Response.Body) responseBody).asInputStream(), "UTF-8"))) {
+                return br.lines().collect(Collectors.joining());
+            }
+        }
+        return responseBody.toString();
+    }
+}

--- a/components/org.wso2.carbon.status.dashboard.web/src/siddhi-app/AppSpecific.jsx
+++ b/components/org.wso2.carbon.status.dashboard.web/src/siddhi-app/AppSpecific.jsx
@@ -230,7 +230,25 @@ export default class WorkerSpecific extends React.Component {
                             totalMem: response.data[0].memory.data
                         });
                     });
-            });
+            }).catch((error) => {
+            let message;
+            if (error.response !== null) {
+                if (error.response.status === 500) {
+                    message = "Authentication fail. Please login again.";
+                    this.setState({
+                        appText: "Unable to fetch Siddhi App!",
+                        latency: [],
+                        throughputAll: [],
+                        totalMem: []
+                    })
+                } else {
+                    message = "Unable to fetch Siddhi App! : " + error.response.data;
+                }
+                this.setState({
+                    message: message
+                })
+            }
+        });
     }
 
     renderLatencyChart() {


### PR DESCRIPTION
## Purpose
$subject. Fixes https://github.com/wso2/product-sp/issues/747

## Goals
Decode the siddhi app response properly if the response body is Feign.Response.Body object,

## Approach
f273a26

## Documentation
N/A

## Automation tests
 - Unit tests -  Passes All
 - Integration tests - Passes All

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes