### PR TITLE
Improve editor by adding an input field for query name in design-view

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/beans/configs/siddhielements/query/QueryConfig.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/beans/configs/siddhielements/query/QueryConfig.java
@@ -30,7 +30,6 @@ import java.util.Map;
  * Represents a Siddhi Query
  */
 public class QueryConfig extends SiddhiElementConfig {
-
     private String queryName;
     private QueryInputConfig queryInput;
     private AttributesSelectionConfig select;

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/beans/configs/siddhielements/query/QueryConfig.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/beans/configs/siddhielements/query/QueryConfig.java
@@ -30,6 +30,8 @@ import java.util.Map;
  * Represents a Siddhi Query
  */
 public class QueryConfig extends SiddhiElementConfig {
+
+    private String queryName;
     private QueryInputConfig queryInput;
     private AttributesSelectionConfig select;
     private List<String> groupBy;
@@ -41,6 +43,10 @@ public class QueryConfig extends SiddhiElementConfig {
     private List<String> annotationList;
     private String partitionId;
     private Map<String, String> connectorsAndStreams;
+
+    public String getQueryName() { return queryName; }
+
+    public void setQueryName(String queryName) { this.queryName = queryName; }
 
     public QueryInputConfig getQueryInput() {
         return queryInput;

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/codegenerator/generators/SubElementCodeGenerator.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/codegenerator/generators/SubElementCodeGenerator.java
@@ -54,6 +54,23 @@ public class SubElementCodeGenerator {
     }
 
     /**
+     * Generate's the Siddhi code representation of the query's name
+     *
+     * @param queryName The Siddhi query's name
+     * @return The Siddhi code representation of a Siddhi query name annotation
+     */
+    public static String generateQueryName(String queryName) {
+        StringBuilder queryNameStringBuilder = new StringBuilder();
+        if (queryName != null && !queryName.isEmpty()) {
+            queryNameStringBuilder.append(SiddhiCodeBuilderConstants.QUERY_NAME_ANNOTATION)
+                    .append(queryName)
+                    .append(SiddhiCodeBuilderConstants.SINGLE_QUOTE)
+                    .append(SiddhiCodeBuilderConstants.CLOSE_BRACKET);
+        }
+        return queryNameStringBuilder.toString();
+    }
+
+    /**
      * Generate's the Siddhi code representation of a AttributeConfig list
      *
      * @param attributes The AttributeConfig list

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/codegenerator/generators/query/QueryCodeGenerator.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/codegenerator/generators/query/QueryCodeGenerator.java
@@ -25,7 +25,6 @@ import org.wso2.carbon.siddhi.editor.core.util.designview.codegenerator.generato
 import org.wso2.carbon.siddhi.editor.core.util.designview.codegenerator.generators.query.subelements.QuerySelectCodeGenerator;
 import org.wso2.carbon.siddhi.editor.core.util.designview.codegenerator.generators.query.subelements.QuerySubElementCodeGenerator;
 import org.wso2.carbon.siddhi.editor.core.util.designview.constants.SiddhiCodeBuilderConstants;
-import org.wso2.carbon.siddhi.editor.core.util.designview.designgenerator.generators.query.QueryConfigGenerator;
 import org.wso2.carbon.siddhi.editor.core.util.designview.exceptions.CodeGenerationException;
 import org.wso2.carbon.siddhi.editor.core.util.designview.utilities.CodeGeneratorUtils;
 

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/codegenerator/generators/query/QueryCodeGenerator.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/codegenerator/generators/query/QueryCodeGenerator.java
@@ -25,6 +25,7 @@ import org.wso2.carbon.siddhi.editor.core.util.designview.codegenerator.generato
 import org.wso2.carbon.siddhi.editor.core.util.designview.codegenerator.generators.query.subelements.QuerySelectCodeGenerator;
 import org.wso2.carbon.siddhi.editor.core.util.designview.codegenerator.generators.query.subelements.QuerySubElementCodeGenerator;
 import org.wso2.carbon.siddhi.editor.core.util.designview.constants.SiddhiCodeBuilderConstants;
+import org.wso2.carbon.siddhi.editor.core.util.designview.designgenerator.generators.query.QueryConfigGenerator;
 import org.wso2.carbon.siddhi.editor.core.util.designview.exceptions.CodeGenerationException;
 import org.wso2.carbon.siddhi.editor.core.util.designview.utilities.CodeGeneratorUtils;
 
@@ -46,6 +47,7 @@ public class QueryCodeGenerator {
         StringBuilder queryStringBuilder = new StringBuilder();
         queryStringBuilder.append(SubElementCodeGenerator.generateComment(query.getPreviousCommentSegment()))
                 .append(SubElementCodeGenerator.generateAnnotations(query.getAnnotationList()))
+                .append(SubElementCodeGenerator.generateQueryName(query.getQueryName()))
                 .append(QueryInputCodeGenerator.generateQueryInput(query.getQueryInput()))
                 .append(SiddhiCodeBuilderConstants.SPACE)
                 .append(QuerySelectCodeGenerator.generateQuerySelect(query.getSelect()));

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/constants/SiddhiCodeBuilderConstants.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/constants/SiddhiCodeBuilderConstants.java
@@ -59,6 +59,7 @@ public class SiddhiCodeBuilderConstants {
     public static final String APP_NAME_ANNOTATION = "@App:name('";
     public static final String APP_DESCRIPTION_ANNOTATION = "@App:description('";
 
+    public static final String QUERY_NAME_ANNOTATION = "@info(name='";
     public static final String SOURCE_ANNOTATION = "@source(type='";
     public static final String SINK_ANNOTATION = "@sink(type='";
     public static final String STORE_ANNOTATION = "@store(type='";

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/designgenerator/generators/AnnotationConfigGenerator.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/designgenerator/generators/AnnotationConfigGenerator.java
@@ -61,7 +61,8 @@ public class AnnotationConfigGenerator extends CodeSegmentsPreserver {
     public List<String> generateAnnotationConfigList(List<Annotation> annotations) {
         List<String> annotationList = new ArrayList<>();
         for (Annotation annotation : annotations) {
-            annotationList.add(generateAnnotationConfig(annotation));
+            if (!annotation.getName().equalsIgnoreCase("info"))
+                annotationList.add(generateAnnotationConfig(annotation));
         }
         return annotationList;
     }

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/designgenerator/generators/query/QueryConfigGenerator.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/designgenerator/generators/query/QueryConfigGenerator.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.siddhi.editor.core.util.designview.beans.configs.siddhiel
 import org.wso2.carbon.siddhi.editor.core.util.designview.beans.configs.siddhielements.query.input.patternsequence.PatternSequenceConfig;
 import org.wso2.carbon.siddhi.editor.core.util.designview.beans.configs.siddhielements.query.input.windowfilterprojection.WindowFilterProjectionConfig;
 import org.wso2.carbon.siddhi.editor.core.util.designview.beans.configs.siddhielements.query.output.QueryOutputConfig;
+import org.wso2.carbon.siddhi.editor.core.util.designview.constants.SiddhiCodeBuilderConstants;
 import org.wso2.carbon.siddhi.editor.core.util.designview.constants.query.QueryListType;
 import org.wso2.carbon.siddhi.editor.core.util.designview.designgenerator.generators.AttributesSelectionConfigGenerator;
 import org.wso2.carbon.siddhi.editor.core.util.designview.designgenerator.generators.AnnotationConfigGenerator;
@@ -35,6 +36,7 @@ import org.wso2.carbon.siddhi.editor.core.util.designview.designgenerator.genera
 import org.wso2.carbon.siddhi.editor.core.util.designview.exceptions.DesignGenerationException;
 import org.wso2.carbon.siddhi.editor.core.util.designview.utilities.ConfigBuildingUtilities;
 import org.wso2.siddhi.query.api.SiddhiApp;
+import org.wso2.siddhi.query.api.annotation.Annotation;
 import org.wso2.siddhi.query.api.execution.query.Query;
 import org.wso2.siddhi.query.api.execution.query.input.stream.InputStream;
 import org.wso2.siddhi.query.api.execution.query.output.ratelimit.OutputRate;
@@ -82,10 +84,23 @@ public class QueryConfigGenerator extends CodeSegmentsPreserver {
         queryConfig.setOutputRateLimit(generateOutputRateLimit(query.getOutputRate()));
         AnnotationConfigGenerator annotationConfigGenerator = new AnnotationConfigGenerator();
         queryConfig.setAnnotationList(annotationConfigGenerator.generateAnnotationConfigList(query.getAnnotations()));
-
+        queryConfig.setQueryName(generateQueryName(query.getAnnotations()));
         preserveCodeSegmentsOf(annotationConfigGenerator);
         preserveAndBindCodeSegment(query, queryConfig);
         return queryConfig;
+    }
+
+    /**
+     * Extracts the query name from the annotation list
+     * @param annotations           Query annotation list
+     * @return query name           name of the query
+     */
+    private String generateQueryName(List<Annotation> annotations) {
+        for (Annotation annotation : annotations) {
+            if (annotation.getName().equalsIgnoreCase("info"))
+                return annotation.getElement("name");
+        }
+        return "";
     }
 
     /**

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/designgenerator/generators/query/QueryConfigGenerator.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/designgenerator/generators/query/QueryConfigGenerator.java
@@ -26,7 +26,6 @@ import org.wso2.carbon.siddhi.editor.core.util.designview.beans.configs.siddhiel
 import org.wso2.carbon.siddhi.editor.core.util.designview.beans.configs.siddhielements.query.input.patternsequence.PatternSequenceConfig;
 import org.wso2.carbon.siddhi.editor.core.util.designview.beans.configs.siddhielements.query.input.windowfilterprojection.WindowFilterProjectionConfig;
 import org.wso2.carbon.siddhi.editor.core.util.designview.beans.configs.siddhielements.query.output.QueryOutputConfig;
-import org.wso2.carbon.siddhi.editor.core.util.designview.constants.SiddhiCodeBuilderConstants;
 import org.wso2.carbon.siddhi.editor.core.util.designview.constants.query.QueryListType;
 import org.wso2.carbon.siddhi.editor.core.util.designview.designgenerator.generators.AttributesSelectionConfigGenerator;
 import org.wso2.carbon.siddhi.editor.core.util.designview.designgenerator.generators.AnnotationConfigGenerator;

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/elements/queries/query.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/elements/queries/query.js
@@ -48,6 +48,7 @@ define(['require', 'elementUtils'],
                 annotationList: [annotation1, annotation2, ...]
             */
             if (options !== undefined) {
+                this.queryName = options.queryName;
                 this.id = options.id;
                 this.previousCommentSegment = options.previousCommentSegment;
                 this.queryInput = options.queryInput;
@@ -60,6 +61,14 @@ define(['require', 'elementUtils'],
             }
             this.orderBy = [];
             this.annotationList = [];
+        };
+
+        Query.prototype.addQueryName = function (queryName) {
+            this.queryName =  queryName ;
+        };
+
+        Query.prototype.getQueryName = function () {
+            return this.queryName;
         };
 
         Query.prototype.addAnnotation = function (annotation) {

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/join-query-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/join-query-form.js
@@ -111,6 +111,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOutputInsert'
                         joinType = "full outer";
                     }
                 }
+                var queryName = clickedElement.getQueryName();
                 var on = clickedElement.getQueryInput().getOn();
                 var within = clickedElement.getQueryInput().getWithin();
                 var per = clickedElement.getQueryInput().getPer();
@@ -573,6 +574,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOutputInsert'
                 }
 
                 formContainer.append('<div class="col-md-12 section-seperator frm-qry"><div class="col-md-4">' +
+                    '<div class="row"><div id="form-query-name"></div>'+
                     '<div class="row"><div id="form-query-annotation" class="col-md-12 section-seperator"></div></div>' +
                     '<div class="row"><div id="form-query-input" class="col-md-12"></div></div></div>' +
                     '<div id="form-query-select" class="col-md-4"></div>' +
@@ -613,6 +615,16 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOutputInsert'
                     no_additional_properties: true,
                     disable_array_delete_all_rows: true,
                     disable_array_delete_last_row: true
+                });
+
+                var editorQueryName = new JSONEditor($(formContainer).find('#form-query-name')[0], {
+                    schema: {
+                           required: true,
+                           title: "Name",
+                           type: "string"
+                    },
+                    startval: queryName,
+                    show_errors: "always"
                 });
 
                 var editorInput = new JSONEditor($(formContainer).find('#form-query-input')[0], {
@@ -1104,9 +1116,12 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOutputInsert'
                     }
 
                     var annotationConfig = editorAnnotation.getValue();
+                    var queryNameConfig = editorQueryName.getValue();
                     var inputConfig = editorInput.getValue();
                     var selectConfig = editorSelect.getValue();
                     var outputConfig = editorOutput.getValue();
+
+                    clickedElement.addQueryName(queryNameConfig);
 
                     // checks stream handlers related validations
                     function validateSourceStreamHandlers(joinConfiguration, joinSourceSide) {

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/pattern-query-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/pattern-query-form.js
@@ -83,6 +83,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOutputInsert'
                     annotations.push({annotation: savedAnnotation});
                 });
 
+                var queryName = clickedElement.getQueryName();
                 var inputStreamNames = clickedElement.getQueryInput().getConnectedElementNameList();
                 var savedConditionList = clickedElement.getQueryInput().getConditionList();
                 var logic = clickedElement.getQueryInput().getLogic();
@@ -384,6 +385,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOutputInsert'
 
                 formContainer.find('.define-pattern-query')
                     .append('<div class="col-md-12 section-seperator frm-qry"><div class="col-md-4">' +
+                    '<div class="row"><div id="form-query-name"></div>'+
                     '<div class="row"><div id="form-query-annotation" class="col-md-12 section-seperator"></div></div>' +
                     '<div class="row"><div id="form-query-input" class="col-md-12"></div></div></div>' +
                     '<div id="form-query-select" class="col-md-4"></div>' +
@@ -424,6 +426,16 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOutputInsert'
                     no_additional_properties: true,
                     disable_array_delete_all_rows: true,
                     disable_array_delete_last_row: true
+                });
+
+                 var editorQueryName = new JSONEditor($(formContainer).find('#form-query-name')[0], {
+                    schema: {
+                           required: true,
+                           title: "Name",
+                           type: "string"
+                    },
+                    startval: queryName,
+                    show_errors: "always"
                 });
 
                 var editorInput = new JSONEditor($(formContainer).find('#form-query-input')[0], {
@@ -964,6 +976,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOutputInsert'
                     self.configurationData.setIsDesignViewContentChanged(true);
 
                     var annotationConfig = editorAnnotation.getValue();
+                    var queryNameConfig = editorQueryName.getValue();
                     var inputConfig = editorInput.getValue();
                     var selectConfig = editorSelect.getValue();
                     var outputConfig = editorOutput.getValue();
@@ -972,6 +985,8 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOutputInsert'
                     _.forEach(annotationConfig.annotations, function (annotation) {
                         clickedElement.addAnnotation(annotation.annotation);
                     });
+
+                    clickedElement.addQueryName(queryNameConfig);
 
                     var queryInput = clickedElement.getQueryInput();
 

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/sequence-query-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/sequence-query-form.js
@@ -80,6 +80,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOutputInsert'
                     annotations.push({annotation: savedAnnotation});
                 });
 
+                var queryName = clickedElement.getQueryName();
                 var inputStreamNames = clickedElement.getQueryInput().getConnectedElementNameList();
                 var savedConditionList = clickedElement.getQueryInput().getConditionList();
                 var logic = clickedElement.getQueryInput().getLogic();
@@ -381,6 +382,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOutputInsert'
 
                 formContainer.find('.define-sequence-query')
                     .append('<div class="col-md-12 section-seperator frm-qry"><div class="col-md-4">' +
+                    '<div class="row"><div id="form-query-name"></div>'+
                     '<div class="row"><div id="form-query-annotation" class="col-md-12 section-seperator"></div></div>' +
                     '<div class="row"><div id="form-query-input" class="col-md-12"></div></div></div>' +
                     '<div id="form-query-select" class="col-md-4"></div>' +
@@ -421,6 +423,16 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOutputInsert'
                     no_additional_properties: true,
                     disable_array_delete_all_rows: true,
                     disable_array_delete_last_row: true
+                });
+
+                var editorQueryName = new JSONEditor($(formContainer).find('#form-query-name')[0], {
+                    schema: {
+                           required: true,
+                           title: "Name",
+                           type: "string"
+                     },
+                    startval: queryName,
+                    show_errors: "always"
                 });
 
                 var editorInput = new JSONEditor($(formContainer).find('#form-query-input')[0], {
@@ -956,6 +968,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOutputInsert'
                     self.configurationData.setIsDesignViewContentChanged(true);
 
                     var annotationConfig = editorAnnotation.getValue();
+                    var queryNameConfig = editorQueryName.getValue();
                     var inputConfig = editorInput.getValue();
                     var selectConfig = editorSelect.getValue();
                     var outputConfig = editorOutput.getValue();
@@ -966,6 +979,8 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOutputInsert'
                     });
 
                     var queryInput = clickedElement.getQueryInput();
+
+                    clickedElement.addQueryName(queryNameConfig);
 
                     queryInput.clearConditionList();
                     _.forEach(inputConfig.conditions, function (condition) {

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/window-filter-projection-query-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/window-filter-projection-query-form.js
@@ -133,6 +133,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOutputInsert'
                     annotations.push({annotation: savedAnnotation});
                 });
 
+                var queryName = clickedElement.getQueryName();
                 var inputElementName = clickedElement.getQueryInput().getFrom();
                 var savedGroupByAttributes = clickedElement.getGroupBy();
                 var having = clickedElement.getHaving();
@@ -680,7 +681,8 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOutputInsert'
 
                 formContainer.find('.define-windowFilterProjection-query')
                     .append('<div class="col-md-12 section-seperator frm-qry"><div class="col-md-4">' +
-                    '<div class="row"><div id="form-query-annotation" class="col-md-12 section-seperator"></div></div>' +
+                    '<div class="row"><div id="form-query-name"></div>'+
+                    '<div id="form-query-annotation" class="col-md-12 section-seperator"></div></div>' +
                     '<div class="row"><div id="form-query-input" class="col-md-12"></div></div></div>' +
                     '<div id="form-query-select" class="col-md-4"></div>' +
                     '<div id="form-query-output" class="col-md-4"></div></div>');
@@ -720,6 +722,16 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOutputInsert'
                     no_additional_properties: true,
                     disable_array_delete_all_rows: true,
                     disable_array_delete_last_row: true
+                });
+
+                var editorQueryName = new JSONEditor($(formContainer).find('#form-query-name')[0], {
+                schema: {
+                       required: true,
+                       title: "Name",
+                       type: "string"
+                },
+                startval: queryName,
+                show_errors: "always"
                 });
 
                 var editorInput = new JSONEditor($(formContainer).find('#form-query-input')[0], {
@@ -1123,6 +1135,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOutputInsert'
                     self.configurationData.setIsDesignViewContentChanged(true);
 
                     var annotationConfig = editorAnnotation.getValue();
+                    var queryNameConfig = editorQueryName.getValue();
                     var inputConfig = editorInput.getValue();
                     var selectConfig = editorSelect.getValue();
                     var outputConfig = editorOutput.getValue();
@@ -1131,6 +1144,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOutputInsert'
                     var numberOfFilters = 0;
                     var numberOfFunctions = 0;
                     clickedElement.getQueryInput().clearStreamHandlerList();
+                    clickedElement.addQueryName(queryNameConfig);
 
                     _.forEach(inputConfig.streamHandlerList, function (streamHandler) {
                         streamHandler = streamHandler.streamHandler;

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/initialise-data.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/initialise-data.js
@@ -261,6 +261,7 @@ define(['require', 'log', 'lodash', 'jquery', 'configurationData', 'appData', 'p
             _.forEach(windowFilterProjectionQueryList, function (windowFilterProjectionQuery) {
                 var queryObject = new Query(windowFilterProjectionQuery);
                 addAnnotationsForElement(windowFilterProjectionQuery, queryObject);
+                queryObject.addQueryName(windowFilterProjectionQuery.queryName);
 
                 // queryInput section in the query is compulsory. If that is not found there is a error in backend.
                 if (!windowFilterProjectionQuery.queryInput) {


### PR DESCRIPTION
## Purpose
> If the user wants to give a query name in the query form from the design view, the user has to write the whole annotation in the annotation input field.

## Goals
> An input field in the query form has been included so that the user can just type in the query name without having to type the annotation for the query name.

## Approach
![queryform](https://user-images.githubusercontent.com/32606884/44321415-8ed86a80-a465-11e8-8ce5-a986edaf305a.png)
