### PR TITLE
Fix event callbacks not getting triggered in data providers when table has no data

### DIFF
--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/AbstractDataProvider.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/AbstractDataProvider.java
@@ -70,6 +70,7 @@ public abstract class AbstractDataProvider implements DataProvider {
     @Override
     public void start() {
         dataPublishingExecutorService.scheduleAtFixedRate(() -> {
+
             publish(this.topic, this.sessionId);
         }, 0, publishingInterval, TimeUnit.SECONDS);
         if (isPurgingEnable) {
@@ -80,13 +81,11 @@ public abstract class AbstractDataProvider implements DataProvider {
     }
 
     public void publishToEndPoint(ArrayList<Object[]> data, String sessionId, String topic) {
-        if (data.size() > 0) {
-            DataModel dataModel = new DataModel(getMetadata(), data.toArray(new Object[0][0]), -1, topic);
-            try {
-                DataProviderEndPoint.sendText(sessionId, new Gson().toJson(dataModel));
-            } catch (IOException e) {
-                LOGGER.error("Failed to deliver message to client " + e.getMessage(), e);
-            }
+        DataModel dataModel = new DataModel(getMetadata(), data.toArray(new Object[0][0]), -1, topic);
+        try {
+            DataProviderEndPoint.sendText(sessionId, new Gson().toJson(dataModel));
+        } catch (IOException e) {
+            LOGGER.error("Failed to deliver message to client " + e.getMessage(), e);
         }
     }
 

--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/rdbms/RDBMSStreamingDataProvider.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/rdbms/RDBMSStreamingDataProvider.java
@@ -88,7 +88,7 @@ public class RDBMSStreamingDataProvider extends AbstractRDBMSDataProvider {
                         }
                         data.add(rowData);
                     }
-                    if (!data.isEmpty()) {
+                    if (!data.isEmpty() || lastRecordValue == 0) {
                         publishToEndPoint(data, sessionId, topic);
                     }
                 } catch (SQLException e) {

--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/siddhi/SiddhiProvider.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/siddhi/SiddhiProvider.java
@@ -122,8 +122,10 @@ public class SiddhiProvider extends AbstractDataProvider {
         Event[] events = siddhiAppRuntime.query(siddhiDataProviderConfig.getQueryData().getAsJsonObject().get
                 (QUERY).getAsString());
         ArrayList<Object[]> data = new ArrayList<>();
-        for (Event event : events) {
-            data.add(event.getData());
+        if (events != null) {
+            for (Event event : events) {
+                data.add(event.getData());
+            }
         }
         publishToEndPoint(data, sessionId, topic);
     }


### PR DESCRIPTION
## Purpose
Resolves #1400 

## Goals
Update will be identified by the lastRecordValue field. If the lastRecordValue has a non zero value then the table already has data. 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes