### PR TITLE
[Editor][Design View] Ignore query's 'info' annotation when generating Query config, rather than when generating Annotation config

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/designgenerator/generators/AnnotationConfigGenerator.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/designgenerator/generators/AnnotationConfigGenerator.java
@@ -61,8 +61,7 @@ public class AnnotationConfigGenerator extends CodeSegmentsPreserver {
     public List<String> generateAnnotationConfigList(List<Annotation> annotations) {
         List<String> annotationList = new ArrayList<>();
         for (Annotation annotation : annotations) {
-            if (!annotation.getName().equalsIgnoreCase("info"))
-                annotationList.add(generateAnnotationConfig(annotation));
+            annotationList.add(generateAnnotationConfig(annotation));
         }
         return annotationList;
     }

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/designgenerator/generators/query/QueryConfigGenerator.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/designgenerator/generators/query/QueryConfigGenerator.java
@@ -81,25 +81,10 @@ public class QueryConfigGenerator extends CodeSegmentsPreserver {
 
         queryConfig.setQueryOutput(generateOutput(query.getOutputStream()));
         queryConfig.setOutputRateLimit(generateOutputRateLimit(query.getOutputRate()));
-        AnnotationConfigGenerator annotationConfigGenerator = new AnnotationConfigGenerator();
-        queryConfig.setAnnotationList(annotationConfigGenerator.generateAnnotationConfigList(query.getAnnotations()));
+        queryConfig.setAnnotationList(generateAnnotationList(query.getAnnotations()));
         queryConfig.setQueryName(generateQueryName(query.getAnnotations()));
-        preserveCodeSegmentsOf(annotationConfigGenerator);
         preserveAndBindCodeSegment(query, queryConfig);
         return queryConfig;
-    }
-
-    /**
-     * Extracts the query name from the annotation list
-     * @param annotations           Query annotation list
-     * @return query name           name of the query
-     */
-    private String generateQueryName(List<Annotation> annotations) {
-        for (Annotation annotation : annotations) {
-            if (annotation.getName().equalsIgnoreCase("info"))
-                return annotation.getElement("name");
-        }
-        return "query";
     }
 
     /**
@@ -201,6 +186,39 @@ public class QueryConfigGenerator extends CodeSegmentsPreserver {
             return Long.parseLong(ConfigBuildingUtilities.getDefinition(limit, siddhiAppString));
         }
         return 0;
+    }
+
+    /**
+     * Generates a string list of Siddhi Annotations, from the given list of Siddhi Annotations.
+     * Ignores the 'info' annotation
+     * @param queryAnnotations      List of Siddhi Annotations of a query
+     * @return                      List of strings, each representing a Siddhi Query Annotation
+     */
+    private List<String> generateAnnotationList(List<Annotation> queryAnnotations) {
+        List<String> annotationList = new ArrayList<>();
+        AnnotationConfigGenerator annotationConfigGenerator = new AnnotationConfigGenerator();
+        for (Annotation queryAnnotation : queryAnnotations) {
+            if (!queryAnnotation.getName().equalsIgnoreCase("info")) {
+                annotationList.add(annotationConfigGenerator.generateAnnotationConfig(queryAnnotation));
+            }
+        }
+        preserveCodeSegmentsOf(annotationConfigGenerator);
+        return annotationList;
+    }
+
+    /**
+     * Extracts the query name from the annotation list
+     * @param annotations           Query annotation list
+     * @return query name           name of the query
+     */
+    private String generateQueryName(List<Annotation> annotations) {
+        for (Annotation annotation : annotations) {
+            if (annotation.getName().equalsIgnoreCase("info")) {
+                preserveCodeSegment(annotation);
+                return annotation.getElement("name");
+            }
+        }
+        return "query";
     }
 
     /**


### PR DESCRIPTION
## Purpose
> - After the introduction of capturing query's name from its `info` annotation - in PR https://github.com/wso2/carbon-analytics/pull/1391, the `info` annotation is ignored in the `AnnotationConfigGenerator`'s `generateAnnotationConfigList` method.
> - `AnnotationConfigGenerator` is not only used in Query config generation, but also used in all the elements that have Annotations. So, `info` annotation will be ignored for other elements too.
> - This PR ignores the `info` annotation only during Query config generation, i.e: within the `QueryConfigGenerator`. Query name is seperately captured here as well.
> **_The same approach is followed in ignoring app name & app description annotations of a SIddhi app, and capturing them seperately (Refer [this](https://github.com/wso2/carbon-analytics/blob/master/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/designgenerator/builders/EventFlowBuilder.java#L110))_**

## Goals
> Ignore a query's 'info' annotation within Query config generation, rather than in Annotation config generation

## Approach
> Skipping the `info` annotation's generation in `QueryConfigGenerator`, and capturing it seperately

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
> https://github.com/wso2/carbon-analytics/pull/1391