### PR TITLE
Return noContent response status when no siddhi file is deployed

### DIFF
--- a/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/impl/ManagersApiServiceImpl.java
+++ b/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/impl/ManagersApiServiceImpl.java
@@ -112,8 +112,10 @@ public class ManagersApiServiceImpl extends ManagersApiService {
                     .getAppsWaitingForDeploy();
 
             if (deployedSiddhiAppHolder.isEmpty() && waitingToDeploy.isEmpty()) {
-                logger.info("There is no siddhi apps");
-                return Response.ok().entity("There is no siddhi app  in the manager node").build();
+                if (logger.isDebugEnabled()) {
+                    logger.debug("No Siddhi application is available in the manager node.");
+                }
+                return Response.noContent().entity("No Siddhi application is available in the manager node").build();
             } else {
                 List<SiddhiAppDetails> appList = new ArrayList<>();
                 for (Map.Entry<String, List<SiddhiAppHolder>> en : waitingToDeploy.entrySet()) {


### PR DESCRIPTION
## Purpose
> When no siddhi application is available in the manager node, it returned a OK response. This response.body fails to be parsed as a  JSON since it's just a string in the Status Dashboard causing   
 [760](https://github.com/wso2/product-sp/issues/760) issue.
