### PR TITLE
Add capability to enable/disable analytics solutions.

### DIFF
--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/StreamProcessorDeployer.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/StreamProcessorDeployer.java
@@ -259,7 +259,7 @@ public class StreamProcessorDeployer implements Deployer {
                     }
                 }
             } catch (ConfigurationException e) {
-                log.error("Failed to read " + SiddhiAppProcessorConstants.ANALYTICS_SOLUTIONS
+                log.error("Failed to read '" + SiddhiAppProcessorConstants.ANALYTICS_SOLUTIONS
                         + "' property from the deployment.yaml file. Default server type: " + serverType.name() +
                         " will be set.", e);
             }

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/StreamProcessorDeployer.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/StreamProcessorDeployer.java
@@ -26,6 +26,8 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.wso2.carbon.config.ConfigurationException;
+import org.wso2.carbon.config.provider.ConfigProvider;
 import org.wso2.carbon.deployment.engine.Artifact;
 import org.wso2.carbon.deployment.engine.ArtifactType;
 import org.wso2.carbon.deployment.engine.Deployer;
@@ -46,6 +48,7 @@ import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.util.LinkedHashMap;
 
 /**
  * {@code StreamProcessorDeployer} is responsible for all Siddhi Appp file deployment tasks
@@ -63,6 +66,10 @@ public class StreamProcessorDeployer implements Deployer {
     private ArtifactType artifactType = new ArtifactType<>("siddhi");
     private SimulationDependencyListener simulationDependencyListener;
     private URL directoryLocation;
+    private static ServerType serverType = ServerType.SP; // Default server type
+    private static boolean isAnalyticsEnabledOnSP = false;
+    private static boolean apimAnalyticsEnabledOnSP = false;
+    private static boolean eiAnalyticsEnabledOnSP = false;
 
     public static void deploySiddhiQLFile(File file) throws Exception {
         InputStream inputStream = null;
@@ -73,6 +80,10 @@ public class StreamProcessorDeployer implements Deployer {
             String siddhiAppFileName = file.getName();
             if (siddhiAppFileName.endsWith(SiddhiAppProcessorConstants.SIDDHI_APP_FILE_EXTENSION)) {
                 String siddhiAppFileNameWithoutExtension = getFileNameWithoutExtenson(siddhiAppFileName);
+                SiddhiAppType siddhiAppType = getArtifactType(siddhiAppFileNameWithoutExtension);
+                if (!isDeploymentAllowed(siddhiAppType)) {
+                    return;
+                }
                 String siddhiApp = getStringFromInputStream(inputStream);
                 try {
                     siddhiAppName = StreamProcessorDataHolder.getStreamProcessorService().
@@ -145,6 +156,124 @@ public class StreamProcessorDeployer implements Deployer {
         return fileName;
     }
 
+    private static SiddhiAppType getArtifactType(String fileName) {
+        fileName = fileName.toUpperCase();
+        if (fileName.startsWith(SiddhiAppProcessorConstants.APIM_SIDDHI_APP_PREFIX)) {
+            return SiddhiAppType.APIM;
+        } else if (fileName.startsWith(SiddhiAppProcessorConstants.EI_SIDDHI_APP_PREFIX)) {
+            return SiddhiAppType.EI;
+        } else if (fileName.startsWith(SiddhiAppProcessorConstants.IS_SIDDHI_APP_PREFIX)) {
+            return SiddhiAppType.IS;
+        } else {
+            return SiddhiAppType.OTHER;
+        }
+    }
+
+    private static boolean isDeploymentAllowed(SiddhiAppType siddhiAppType) {
+        switch (serverType) {
+            case SP:
+                switch (siddhiAppType) {
+                    case OTHER:
+                        return true;
+                    case APIM:
+                        if (apimAnalyticsEnabledOnSP) {
+                            return true;
+                        }
+                        break;
+                    case IS:
+                        if (isAnalyticsEnabledOnSP) {
+                            return true;
+                        }
+                        break;
+                    case EI:
+                        if (eiAnalyticsEnabledOnSP) {
+                            return true;
+                        }
+                        break;
+                }
+                break;
+            case APIM:
+                if (siddhiAppType.name().equals(SiddhiAppType.APIM.name())) {
+                    return true;
+                }
+                break;
+            case IS:
+                if (siddhiAppType.name().equals(SiddhiAppType.IS.name())) {
+                    return true;
+                }
+                break;
+            case EI:
+                if (siddhiAppType.name().equals(SiddhiAppType.EI.name())) {
+                    return true;
+                }
+                break;
+        }
+        return false;
+    }
+
+    private void setServerType() {
+        ConfigProvider configProvider = StreamProcessorDataHolder.getInstance().getConfigProvider();
+        if (configProvider != null) {
+            try {
+                LinkedHashMap analyticsSolutionsMap = (LinkedHashMap) configProvider.
+                        getConfigurationObject(SiddhiAppProcessorConstants.ANALYTICS_SOLUTIONS);
+                if (analyticsSolutionsMap != null) {
+                    Object typeObject = analyticsSolutionsMap.get(
+                            SiddhiAppProcessorConstants.WSO2_SERVER_TYPE);
+                    if (typeObject != null) {
+                        String type = typeObject.toString();
+                        switch (type) {
+                            case SiddhiAppProcessorConstants.WSO2_SERVER_TYPE_SP:
+                                serverType = ServerType.SP;
+                                break;
+                            case SiddhiAppProcessorConstants.WSO2_SERVER_TYPE_APIM_ANALYTICS:
+                                serverType = ServerType.APIM;
+                                break;
+                            case SiddhiAppProcessorConstants.WSO2_SERVER_TYPE_IS_ANALYTICS:
+                                serverType = ServerType.IS;
+                                break;
+                            case SiddhiAppProcessorConstants.WSO2_SERVER_TYPE_EI_ANALYTICS:
+                                serverType = ServerType.EI;
+                                break;
+                            default:
+                                serverType = ServerType.SP;
+                                break;
+                        }
+                        if (serverType.name().equals(ServerType.SP.name())) {
+                            Object tempObject = analyticsSolutionsMap.get(
+                                    SiddhiAppProcessorConstants.IS_ANALYTICS_ENABLED);
+                            if (tempObject != null) {
+                                isAnalyticsEnabledOnSP = Boolean.parseBoolean(tempObject.toString());
+                            }
+                            tempObject = analyticsSolutionsMap.get(
+                                    SiddhiAppProcessorConstants.APIM_ANALYTICS_ENABLED);
+                            if (tempObject != null) {
+                                apimAnalyticsEnabledOnSP = Boolean.parseBoolean(tempObject.toString());
+                            }
+                            tempObject = analyticsSolutionsMap.get(
+                                    SiddhiAppProcessorConstants.EI_ANALYTICS_ENABLED);
+                            if (tempObject != null) {
+                                eiAnalyticsEnabledOnSP = Boolean.parseBoolean(tempObject.toString());
+                            }
+                        }
+                    }
+                }
+            } catch (ConfigurationException e) {
+                log.error("Failed to read " + SiddhiAppProcessorConstants.ANALYTICS_SOLUTIONS
+                        + "' property from the deployment.yaml file. Default server type: " + serverType.name() +
+                        " will be set.", e);
+            }
+        }
+    }
+
+    public enum SiddhiAppType {
+        EI, IS, APIM, OTHER
+    }
+
+    public enum ServerType {
+        EI, IS, APIM, SP
+    }
+
     @Activate
     protected void activate(BundleContext bundleContext) {
         // Nothing to do.
@@ -154,6 +283,7 @@ public class StreamProcessorDeployer implements Deployer {
     public void init() {
         try {
             directoryLocation = new URL("file:" + SiddhiAppProcessorConstants.SIDDHI_APP_FILES_DIRECTORY);
+            setServerType();
             log.debug("Stream Processor Deployer initiated.");
         } catch (MalformedURLException e) {
             log.error("Error while initializing directoryLocation" + SiddhiAppProcessorConstants.

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/StreamProcessorDeployer.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/StreamProcessorDeployer.java
@@ -49,6 +49,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * {@code StreamProcessorDeployer} is responsible for all Siddhi Appp file deployment tasks
@@ -215,52 +216,57 @@ public class StreamProcessorDeployer implements Deployer {
         ConfigProvider configProvider = StreamProcessorDataHolder.getInstance().getConfigProvider();
         if (configProvider != null) {
             try {
-                LinkedHashMap analyticsSolutionsMap = (LinkedHashMap) configProvider.
-                        getConfigurationObject(SiddhiAppProcessorConstants.ANALYTICS_SOLUTIONS);
-                if (analyticsSolutionsMap != null) {
-                    Object typeObject = analyticsSolutionsMap.get(
-                            SiddhiAppProcessorConstants.WSO2_SERVER_TYPE);
-                    if (typeObject != null) {
-                        String type = typeObject.toString();
-                        switch (type) {
-                            case SiddhiAppProcessorConstants.WSO2_SERVER_TYPE_SP:
-                                serverType = ServerType.SP;
-                                break;
-                            case SiddhiAppProcessorConstants.WSO2_SERVER_TYPE_APIM_ANALYTICS:
-                                serverType = ServerType.APIM;
-                                break;
-                            case SiddhiAppProcessorConstants.WSO2_SERVER_TYPE_IS_ANALYTICS:
-                                serverType = ServerType.IS;
-                                break;
-                            case SiddhiAppProcessorConstants.WSO2_SERVER_TYPE_EI_ANALYTICS:
-                                serverType = ServerType.EI;
-                                break;
-                            default:
-                                serverType = ServerType.SP;
-                                break;
-                        }
+                String type = (String) ((Map) configProvider
+                        .getConfigurationObject("wso2.carbon")).get(SiddhiAppProcessorConstants.WSO2_SERVER_TYPE);
+                if (type != null) {
+                    switch (type) {
+                        case SiddhiAppProcessorConstants.WSO2_SERVER_TYPE_SP:
+                            serverType = ServerType.SP;
+                            break;
+                        case SiddhiAppProcessorConstants.WSO2_SERVER_TYPE_APIM_ANALYTICS:
+                            serverType = ServerType.APIM;
+                            break;
+                        case SiddhiAppProcessorConstants.WSO2_SERVER_TYPE_IS_ANALYTICS:
+                            serverType = ServerType.IS;
+                            break;
+                        case SiddhiAppProcessorConstants.WSO2_SERVER_TYPE_EI_ANALYTICS:
+                            serverType = ServerType.EI;
+                            break;
+                        default:
+                            serverType = ServerType.SP;
+                            break;
+                    }
+                    try {
                         if (serverType.name().equals(ServerType.SP.name())) {
-                            Object tempObject = analyticsSolutionsMap.get(
-                                    SiddhiAppProcessorConstants.IS_ANALYTICS_ENABLED);
-                            if (tempObject != null) {
-                                isAnalyticsEnabledOnSP = Boolean.parseBoolean(tempObject.toString());
-                            }
-                            tempObject = analyticsSolutionsMap.get(
-                                    SiddhiAppProcessorConstants.APIM_ANALYTICS_ENABLED);
-                            if (tempObject != null) {
-                                apimAnalyticsEnabledOnSP = Boolean.parseBoolean(tempObject.toString());
-                            }
-                            tempObject = analyticsSolutionsMap.get(
-                                    SiddhiAppProcessorConstants.EI_ANALYTICS_ENABLED);
-                            if (tempObject != null) {
-                                eiAnalyticsEnabledOnSP = Boolean.parseBoolean(tempObject.toString());
+                            LinkedHashMap analyticsSolutionsMap = (LinkedHashMap) configProvider.
+                                    getConfigurationObject(SiddhiAppProcessorConstants.ANALYTICS_SOLUTIONS);
+                            if (analyticsSolutionsMap != null) {
+                                Object directoryPathObject = analyticsSolutionsMap.get(
+                                        SiddhiAppProcessorConstants.IS_ANALYTICS_ENABLED);
+                                if (directoryPathObject != null) {
+                                    isAnalyticsEnabledOnSP = Boolean.parseBoolean(directoryPathObject.toString());
+                                }
+                                directoryPathObject = analyticsSolutionsMap.get(
+                                        SiddhiAppProcessorConstants.APIM_ANALYTICS_ENABLED);
+                                if (directoryPathObject != null) {
+                                    apimAnalyticsEnabledOnSP = Boolean.parseBoolean(directoryPathObject.toString());
+                                }
+                                directoryPathObject = analyticsSolutionsMap.get(
+                                        SiddhiAppProcessorConstants.EI_ANALYTICS_ENABLED);
+                                if (directoryPathObject != null) {
+                                    eiAnalyticsEnabledOnSP = Boolean.parseBoolean(directoryPathObject.toString());
+                                }
                             }
                         }
+                    } catch (ConfigurationException e) {
+                        log.error("Failed to read " + SiddhiAppProcessorConstants.ANALYTICS_SOLUTIONS
+                                + "'property from the deployment.yaml file. None of the analytics solutions will " +
+                                "be deployed. ", e);
                     }
                 }
             } catch (ConfigurationException e) {
-                log.error("Failed to read '" + SiddhiAppProcessorConstants.ANALYTICS_SOLUTIONS
-                        + "' property from the deployment.yaml file. Default server type: " + serverType.name() +
+                log.error("Failed to read the wso2.carbon server " + SiddhiAppProcessorConstants.WSO2_SERVER_TYPE
+                        + "'property from the deployment.yaml file. Default value " + serverType.name() +
                         " will be set.", e);
             }
         }
@@ -426,3 +432,4 @@ public class StreamProcessorDeployer implements Deployer {
         }
     }
 }
+

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/util/SiddhiAppProcessorConstants.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/util/SiddhiAppProcessorConstants.java
@@ -33,6 +33,21 @@ public class SiddhiAppProcessorConstants {
     public static final String WSO2_ARTIFACT_DEPLOYMENT_NS = "wso2.artifact.deployment";
     public static final String WSO2_ARTIFACT_DEPLOYMENT_REPOSITORY_LOCATION = "repositoryLocation";
 
+    public static final String ANALYTICS_SOLUTIONS = "analytics.solutions";
+
+    public static final String WSO2_SERVER_TYPE = "type";
+    public static final String WSO2_SERVER_TYPE_SP = "wso2-sp";
+    public static final String WSO2_SERVER_TYPE_APIM_ANALYTICS = "apim.analytics";
+    public static final String WSO2_SERVER_TYPE_IS_ANALYTICS = "is.analytics";
+    public static final String WSO2_SERVER_TYPE_EI_ANALYTICS = "ei.analytics";
+
+    public static final String APIM_ANALYTICS_ENABLED = "APIM-analytics.enabled";
+    public static final String IS_ANALYTICS_ENABLED = "IS-analytics.enabled";
+    public static final String EI_ANALYTICS_ENABLED = "EI-analytics.enabled";
+
+    public static final String APIM_SIDDHI_APP_PREFIX = "APIM_";
+    public static final String IS_SIDDHI_APP_PREFIX = "IS_";
+    public static final String EI_SIDDHI_APP_PREFIX = "EI_";
 
     /**
      * Runtime modes of Stream Processor engine

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/util/SiddhiAppProcessorConstants.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/util/SiddhiAppProcessorConstants.java
@@ -37,9 +37,9 @@ public class SiddhiAppProcessorConstants {
 
     public static final String WSO2_SERVER_TYPE = "type";
     public static final String WSO2_SERVER_TYPE_SP = "wso2-sp";
-    public static final String WSO2_SERVER_TYPE_APIM_ANALYTICS = "apim.analytics";
-    public static final String WSO2_SERVER_TYPE_IS_ANALYTICS = "is.analytics";
-    public static final String WSO2_SERVER_TYPE_EI_ANALYTICS = "ei.analytics";
+    public static final String WSO2_SERVER_TYPE_APIM_ANALYTICS = "wso2-apim-analytics";
+    public static final String WSO2_SERVER_TYPE_IS_ANALYTICS = "wso2-is-analytics";
+    public static final String WSO2_SERVER_TYPE_EI_ANALYTICS = "wso2-ei-analytics";
 
     public static final String APIM_ANALYTICS_ENABLED = "APIM-analytics.enabled";
     public static final String IS_ANALYTICS_ENABLED = "IS-analytics.enabled";

--- a/pom.xml
+++ b/pom.xml
@@ -1604,7 +1604,7 @@
         <osgi.service.tracker.import.version.range>[1.5.1, 2.0.0)</osgi.service.tracker.import.version.range>
 
         <!-- Dependencies -->
-        <carbon.kernel.version>5.2.6</carbon.kernel.version>
+        <carbon.kernel.version>5.2.8</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[5.2.6, 6.0.0)</carbon.kernel.package.import.version.range>
         <carbon.kernel.pax.version>5.2.6</carbon.kernel.pax.version>
 


### PR DESCRIPTION
## Purpose
Add capability to enable/disable analytics solutions.

## Documentation (obsolte after e3e2a00)
Users can enable/disable anlytics solutions by adding following root element to deployment.yaml file.

```
analytics.solutions:
  type: wso2-sp
  IS-analytics.enabled: false
  APIM-analytics.enabled: true
  EI-analytics.enabled: true
```
### Description:
type: 
- Possible values are wso2-sp, apim.analytics, is.analytics and ei.analytics
- If one of apim.analytics, is.analytics and ei.analytics is put, only the artifacts belonging to the corresponding type will be deployed. 
- For example, if type is set to `apim.analytics` then all (and only) the siddhi apps related to APIM analytics solutions are deployed. In this case, SP server cannot be used to deploy any other siddhi app.
- If `wso2-sp` is set, optionally one or many of other ananlytics solutions can be enabled on top of SP.
