### PR TITLE
Remove 'editor/workspace/import' api from EditorMicroservice

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/EditorMicroservice.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/EditorMicroservice.java
@@ -385,10 +385,11 @@ public class EditorMicroservice implements Microservice {
     @GET
     @Path("/workspace/listFiles")
     @Produces("application/json")
-    public Response filesInPath(@QueryParam("path") String path) {
+    public Response filesInPath() {
         try {
-            java.nio.file.Path pathLocation = Paths.get(new String(Base64.getDecoder().decode(path), Charset
-                    .defaultCharset()));
+            String location = (Paths.get(Constants.RUNTIME_PATH, Constants.DIRECTORY_DEPLOYMENT,
+                    Constants.DIRECTORY_WORKSPACE)).toString();
+            java.nio.file.Path pathLocation = Paths.get(location);
             return Response.status(Response.Status.OK)
                     .entity(workspace.listFilesInPath(pathLocation))
                     .type(MediaType.APPLICATION_JSON).build();
@@ -540,7 +541,7 @@ public class EditorMicroservice implements Microservice {
                     resolvePath(Paths.get(Constants.RUNTIME_PATH,
                             Constants.DIRECTORY_DEPLOYMENT).toAbsolutePath(),
                             Paths.get(Constants.DIRECTORY_WORKSPACE + System.getProperty(FILE_SEPARATOR) +
-                                            siddhiAppName ));
+                                    siddhiAppName));
             File file = new File(location.toString());
             if (file.delete()) {
                 log.info("Siddi App: " + LogEncoder.removeCRLFCharacters(siddhiAppName) + " is deleted");

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/EditorMicroservice.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/EditorMicroservice.java
@@ -531,37 +531,6 @@ public class EditorMicroservice implements Microservice {
         }
     }
 
-    @POST
-    @Path("/workspace/import")
-    @Produces("application/json")
-    public Response importFile(String path) {
-        try {
-            JsonObject content = workspace.read(Paths.get(path));
-            String location = (Paths.get(Constants.RUNTIME_PATH,
-                    Constants.DIRECTORY_DEPLOYMENT,
-                    Constants.DIRECTORY_WORKSPACE)).toString();
-            String configName = path.substring(path.lastIndexOf(System.getProperty(FILE_SEPARATOR)) + 1);
-            String config = content.get("content").getAsString();
-            StringBuilder pathBuilder = new StringBuilder();
-            pathBuilder.append(location).append(System.getProperty(FILE_SEPARATOR)).append(configName);
-            Files.write(Paths.get(pathBuilder.toString()), config.getBytes(Charset.defaultCharset()));
-            return Response.status(Response.Status.OK)
-                    .entity(content)
-                    .type(MediaType.APPLICATION_JSON).build();
-        } catch (AccessDeniedException e) {
-            Map<String, String> errorMap = new HashMap<>(1);
-            errorMap.put("Error", "File access denied. You don't have enough permission to access");
-            return Response.serverError().entity(errorMap)
-                    .build();
-        } catch (IOException e) {
-            return Response.serverError().entity("failed." + e.getMessage())
-                    .build();
-        } catch (Throwable ignored) {
-            return Response.serverError().entity("failed")
-                    .build();
-        }
-    }
-
     @DELETE
     @Path("/workspace/delete")
     @Produces("application/json")

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/EditorMicroservice.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/EditorMicroservice.java
@@ -450,50 +450,6 @@ public class EditorMicroservice implements Microservice {
     }
 
     @POST
-    @Path("/workspace/export")
-    @Produces("application/json")
-    public Response export(String payload) {
-        try {
-            String location = "";
-            String configName = "";
-            String config = "";
-            Matcher locationMatcher = Pattern.compile("location=(.*?)&configName").matcher(payload);
-            while (locationMatcher.find()) {
-                location = locationMatcher.group(1);
-            }
-            Matcher configNameMatcher = Pattern.compile("configName=(.*?)&").matcher(payload);
-            while (configNameMatcher.find()) {
-                configName = configNameMatcher.group(1);
-            }
-            String[] splitConfigContent = payload.split("config=");
-            if (splitConfigContent.length > 1) {
-                config = splitConfigContent[1];
-            }
-            byte[] base64Config = Base64.getDecoder().decode(config);
-            byte[] base64ConfigName = Base64.getDecoder().decode(configName);
-            byte[] base64Location = Base64.getDecoder().decode(location);
-            Files.write(Paths.get(new String(base64Location, Charset.defaultCharset())
-                    + System.getProperty(FILE_SEPARATOR)
-                    + new String(base64ConfigName, Charset.defaultCharset())), base64Config);
-            JsonObject entity = new JsonObject();
-            entity.addProperty(STATUS, SUCCESS);
-            return Response.status(Response.Status.OK).entity(entity)
-                    .type(MediaType.APPLICATION_JSON).build();
-        } catch (AccessDeniedException e) {
-            Map<String, String> errorMap = new HashMap<>(1);
-            errorMap.put("Error", "File access denied. You don't have enough permission to access");
-            return Response.serverError().entity(errorMap)
-                    .build();
-        } catch (IOException e) {
-            return Response.serverError().entity("failed." + e.getMessage())
-                    .build();
-        } catch (Throwable ignored) {
-            return Response.serverError().entity("failed")
-                    .build();
-        }
-    }
-
-    @POST
     @Path("/workspace/read")
     @Produces("application/json")
     public Response read(String relativePath) {

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/EditorMicroservice.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/EditorMicroservice.java
@@ -260,25 +260,6 @@ public class EditorMicroservice implements Microservice {
     }
 
     @GET
-    @Path("/workspace/list")
-    @Produces("application/json")
-    public Response directoriesInPath(@QueryParam("path") String path) {
-        try {
-            return Response.status(Response.Status.OK)
-                    .entity(workspace.listDirectoriesInPath(
-                            new String(Base64.getDecoder().decode(path), Charset.defaultCharset())))
-                    .type(MediaType.APPLICATION_JSON)
-                    .build();
-        } catch (IOException e) {
-            return Response.serverError().entity("failed." + e.getMessage())
-                    .build();
-        } catch (Throwable ignored) {
-            return Response.serverError().entity("failed")
-                    .build();
-        }
-    }
-
-    @GET
     @Path("/workspace/exists")
     @Produces("application/json")
     public Response fileExists(@QueryParam("path") String path) {

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/EditorMicroservice.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/EditorMicroservice.java
@@ -366,11 +366,11 @@ public class EditorMicroservice implements Microservice {
     @GET
     @Path("/workspace/listFiles")
     @Produces("application/json")
-    public Response filesInPath() {
+    public Response filesInPath(@QueryParam("path") String path) {
         try {
-            String location = (Paths.get(Constants.RUNTIME_PATH, Constants.DIRECTORY_DEPLOYMENT,
-                    Constants.DIRECTORY_WORKSPACE)).toString();
-            java.nio.file.Path pathLocation = Paths.get(location);
+            String location = (Paths.get(Constants.CARBON_HOME)).toString();
+            java.nio.file.Path pathLocation = SecurityUtil.resolvePath(Paths.get(location).toAbsolutePath(),
+                    Paths.get(new String(Base64.getDecoder().decode(path), Charset.defaultCharset())));
             return Response.status(Response.Status.OK)
                     .entity(workspace.listFilesInPath(pathLocation))
                     .type(MediaType.APPLICATION_JSON).build();

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/local/LocalFSWorkspace.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/local/LocalFSWorkspace.java
@@ -183,7 +183,7 @@ public class LocalFSWorkspace implements Workspace {
         Path path = root.getFileName();
         rootObj.addProperty("text", path != null ?
                                     path.toString() : root.toString());
-        rootObj.addProperty("id", root.toAbsolutePath().toString());
+        rootObj.addProperty("id", Paths.get(Constants.CARBON_HOME).relativize(root).toString());
         if (Files.isDirectory(root) && checkChildren) {
             rootObj.addProperty("type", "folder");
             try {

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/file-browser/file-browser.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/file-browser/file-browser.js
@@ -112,7 +112,7 @@ define(['jquery', 'backbone', 'lodash', 'log', /** void module - jquery plugin *
                     return self._workspaceServiceURL + "/root";
                 } else {
                     if (self._fetchFiles) {
-                        return self._workspaceServiceURL + "/listFiles?path=" + btoa(node.id);
+                        return self._workspaceServiceURL + "/listFiles";
                     } else {
                         return self._workspaceServiceURL + "/list?path=" + btoa(node.id);
                     }

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/file-browser/file-browser.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/file-browser/file-browser.js
@@ -112,7 +112,7 @@ define(['jquery', 'backbone', 'lodash', 'log', /** void module - jquery plugin *
                     return self._workspaceServiceURL + "/root";
                 } else {
                     if (self._fetchFiles) {
-                        return self._workspaceServiceURL + "/listFiles";
+                        return self._workspaceServiceURL + "/listFiles?path=" + btoa(node.id);
                     } else {
                         return self._workspaceServiceURL + "/list?path=" + btoa(node.id);
                     }

--- a/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/SiddhiEditorTestCase.java
+++ b/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/SiddhiEditorTestCase.java
@@ -504,56 +504,6 @@ public class SiddhiEditorTestCase {
     }
 
     @Test
-    public void testImportingAFile() throws Exception {
-        String path = "/editor/workspace/import";
-        String contentType = "text/plain";
-        String method = "POST";
-        String userdir = System.getProperty("user.dir");
-        Path sourceFilePath = Paths.get(userdir, "deployment", "ReceiveAndCount.siddhi");
-        String sourceFile = sourceFilePath.toString();
-
-        logger.info("Importing a siddhi application from file system.");
-        HTTPResponseMessage httpResponseMessage = sendHRequest(sourceFile, baseURI, path, contentType, method,
-                true, DEFAULT_USER_NAME, DEFAULT_PASSWORD);
-        Assert.assertEquals(httpResponseMessage.getResponseCode(), 200);
-        Assert.assertEquals(httpResponseMessage.getMessage(), "OK");
-        Assert.assertEquals(httpResponseMessage.getContentType(), "application/json");
-    }
-
-    @Test
-    public void testImportingAnInvalidFile() throws Exception {
-        String path = "/editor/workspace/import";
-        String contentType = "text/plain";
-        String method = "POST";
-        String userdir = System.getProperty("user.dir");
-        Path sourceFilePath = Paths.get(userdir, "invalid.directory", "ReceiveAndCount.siddhi");
-        String sourceFile = sourceFilePath.toString();
-
-        logger.info("Importing a siddhi application from file system.");
-        HTTPResponseMessage httpResponseMessage = sendHRequest(sourceFile, baseURI, path, contentType, method,
-                true, DEFAULT_USER_NAME, DEFAULT_PASSWORD);
-        Assert.assertEquals(httpResponseMessage.getResponseCode(), 500);
-        Assert.assertEquals(httpResponseMessage.getMessage(), "Internal Server Error");
-        Assert.assertEquals(httpResponseMessage.getContentType(), "application/json");
-    }
-
-    @Test
-    public void testImportingANotExistingFile() throws Exception {
-        String path = "/editor/workspace/import";
-        String contentType = "text/plain";
-        String method = "POST";
-        String userdir = System.getProperty("user.dir");
-        Path sourceFilePath = Paths.get(userdir, "deployment", "siddhi-files", "TestInvalidSiddhiApp.siddhi");
-        String sourceFile = sourceFilePath.toString();
-
-        logger.info("Importing a siddhi application from file system.");
-        HTTPResponseMessage httpResponseMessage = sendHRequest(sourceFile, baseURI, path, contentType, method,
-                true, DEFAULT_USER_NAME, DEFAULT_PASSWORD);
-        Assert.assertEquals(httpResponseMessage.getResponseCode(), 500);
-        Assert.assertEquals(httpResponseMessage.getContentType(), "application/json");
-    }
-
-    @Test
     public void testGettingMetadata() throws Exception {
         String path = "/editor/metadata";
         String contentType = "text/plain";

--- a/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/SiddhiEditorTestCase.java
+++ b/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/SiddhiEditorTestCase.java
@@ -421,59 +421,6 @@ public class SiddhiEditorTestCase {
     }
 
     @Test
-    public void testExportingAFile() throws Exception {
-        String path = "/editor/workspace/export";
-        String contentType = "text/plain";
-        String method = "POST";
-        String config = "@App:name(\"SiddhiApp\")\n" +
-                "define stream FooStream (symbol string, price float, volume long);\n" +
-                "@source(type='inMemory', topic='symbol', @map(type='passThrough'))" +
-                "define stream BarStream (symbol string, price float, volume long);\n" +
-                "from FooStream\n" +
-                "select symbol, price, volume\n" +
-                "insert into BarStream;\n";
-
-        String userdir = System.getProperty("user.dir");
-        String location = Paths.get(userdir, "deployment").toString();
-        String encodedLocation = Base64.getEncoder().encodeToString(location.getBytes());
-        String encodedConfig = Base64.getEncoder().encodeToString(config.getBytes());
-        String encodedConfigName = Base64.getEncoder().encodeToString("SiddhiApp.siddhi".getBytes());
-        String body = String.format("location=%s&configName=%s&config=%s", encodedLocation, encodedConfigName,
-                encodedConfig);
-
-        logger.info("Exporting a siddhi app.");
-        HTTPResponseMessage httpResponseMessage = sendHRequest(body, baseURI, path, contentType, method,
-                true, DEFAULT_USER_NAME, DEFAULT_PASSWORD);
-        Assert.assertEquals(httpResponseMessage.getResponseCode(), 200);
-        Assert.assertEquals(httpResponseMessage.getContentType(), "application/json");
-        Assert.assertEquals(httpResponseMessage.getMessage(), "OK");
-    }
-
-    @Test
-    public void testFailureInExportingAFileWithInvalidConfigs() throws Exception {
-        String path = "/editor/workspace/export";
-        String contentType = "text/plain";
-        String method = "POST";
-        String config = "@App:name(\"SiddhiApp\")\n" +
-                "define stream FooStream (symbol string, price float, volume long);\n" +
-                "@source(type='inMemory', topic='symbol', @map(type='passThrough'))" +
-                "define stream BarStream (symbol string, price float, volume long);\n" +
-                "from FooStream\n" +
-                "select symbol, price, volume\n" +
-                "insert into BarStream;\n";
-
-        String configName = "SiddhiApp.siddhi";
-        String body = String.format("location=%s&configName=%s&config=%s", "", configName, config);
-
-        logger.info("Trying to export a file which is not possible to export.");
-        HTTPResponseMessage httpResponseMessage = sendHRequest(body, baseURI, path, contentType, method,
-                true, DEFAULT_USER_NAME, DEFAULT_PASSWORD);
-        Assert.assertEquals(httpResponseMessage.getResponseCode(), 500);
-        Assert.assertEquals(httpResponseMessage.getContentType(), "application/json");
-        Assert.assertEquals(httpResponseMessage.getMessage(), "Internal Server Error");
-    }
-
-    @Test
     public void testReadingSample() throws Exception {
         String path = "/editor/workspace/read/sample";
         String contentType = "text/plain";

--- a/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/SiddhiEditorTestCase.java
+++ b/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/SiddhiEditorTestCase.java
@@ -173,34 +173,6 @@ public class SiddhiEditorTestCase {
     }
 
     @Test
-    public void testListingDirectoriesInPath() throws Exception {
-        String path = "/editor/workspace/list?path=";
-        String contentType = "text/plain";
-        String method = "GET";
-
-        logger.info("Listing existing directories under the given path.");
-        HTTPResponseMessage httpResponseMessage = sendHRequest("", baseURI, path, contentType, method,
-                true, DEFAULT_USER_NAME, DEFAULT_PASSWORD);
-        Assert.assertEquals(httpResponseMessage.getResponseCode(), 200);
-        Assert.assertEquals(httpResponseMessage.getMessage(), "OK");
-        Assert.assertEquals(httpResponseMessage.getContentType(), "application/json");
-    }
-
-    @Test
-    public void testListingDirectoriesInInvalidPath() throws Exception {
-        String path = "/editor/workspace/list?path=invalidPath";
-        String contentType = "text/plain";
-        String method = "GET";
-
-        logger.info("Listing existing directories under the given path.");
-        HTTPResponseMessage httpResponseMessage = sendHRequest("", baseURI, path, contentType, method,
-                true, DEFAULT_USER_NAME, DEFAULT_PASSWORD);
-        Assert.assertEquals(httpResponseMessage.getResponseCode(), 500);
-        Assert.assertEquals(httpResponseMessage.getMessage(), "Internal Server Error");
-        Assert.assertEquals(httpResponseMessage.getContentType(), "application/json");
-    }
-
-    @Test
     public void testCheckingWhetherFileExists() throws Exception {
         String path = "/editor/workspace/exists?path=%s";
         String encodedPath = new String(Base64.getEncoder().encode("logs".getBytes()));


### PR DESCRIPTION
## Purpose
> The purpose of this PR is to remove unused API from the EditorMicroservice.

## Goals
> Remove unused API endpoints form the Editor Runtime

## Documentation
> Please verify whether we have API documentation for Editor Microservice, if available we have to remove the content related to POST 'editor/workspace/import' API endpoint.