### PR TITLE
 Add separate Microservices Runner in the Siddhi Stores Api service

### DIFF
--- a/components/distribution/carbon-home/conf/worker/deployment.yaml
+++ b/components/distribution/carbon-home/conf/worker/deployment.yaml
@@ -55,7 +55,7 @@ wso2.transport.http:
     -
       id: "http-sender"
 
-stores.api:
+siddhi.stores.query.api:
   transportProperties:
     -
       name: "server.bootstrap.socket.timeout"

--- a/components/org.wso2.carbon.siddhi.store.api.rest/pom.xml
+++ b/components/org.wso2.carbon.siddhi.store.api.rest/pom.xml
@@ -199,8 +199,5 @@
             org.wso2.carbon.analytics.msf4j.interceptor.common.*;version="${carbon.analytics.version.range}",
             *;resolution:=optional
         </import.package>
-        <carbon.component>
-            osgi.service; objectClass="org.wso2.msf4j.Microservice"; serviceCount="1"
-        </carbon.component>
     </properties>
 </project>

--- a/components/org.wso2.carbon.siddhi.store.api.rest/src/gen/java/org/wso2/carbon/siddhi/store/api/rest/StoresApi.java
+++ b/components/org.wso2.carbon.siddhi.store.api.rest/src/gen/java/org/wso2/carbon/siddhi/store/api/rest/StoresApi.java
@@ -57,6 +57,7 @@ public class StoresApi implements HAStateChangeListener {
     private static TransportsConfiguration transportsConfiguration;
     private static MicroservicesRunner microservicesRunner;
     private static volatile boolean microserviceActive;
+    private static final String ROOT_CONFIG_ELEMENT = "siddhi.stores.query.api";
 
     @POST
     @Path("/query")
@@ -152,10 +153,10 @@ public class StoresApi implements HAStateChangeListener {
     protected void registerConfigProvider(ConfigProvider configProvider) {
         SiddhiStoreDataHolder.getInstance().setConfigProvider(configProvider);
         try {
-            transportsConfiguration = configProvider.getConfigurationObject("stores.api",
+            transportsConfiguration = configProvider.getConfigurationObject(ROOT_CONFIG_ELEMENT,
                     TransportsConfiguration.class);
         } catch (ConfigurationException e) {
-            log.error("Error while loading TransportsConfiguration", e);
+            log.error("Error while loading TransportsConfiguration for " + ROOT_CONFIG_ELEMENT, e);
         }
     }
 

--- a/components/org.wso2.carbon.siddhi.store.api.rest/src/gen/java/org/wso2/carbon/siddhi/store/api/rest/StoresApi.java
+++ b/components/org.wso2.carbon.siddhi.store.api.rest/src/gen/java/org/wso2/carbon/siddhi/store/api/rest/StoresApi.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.config.provider.ConfigProvider;
 import org.wso2.carbon.siddhi.store.api.rest.factories.StoresApiServiceFactory;
 import org.wso2.carbon.siddhi.store.api.rest.model.ModelApiResponse;
 import org.wso2.carbon.siddhi.store.api.rest.model.Query;
+import org.wso2.carbon.stream.processor.core.HAStateChangeListener;
 import org.wso2.carbon.stream.processor.core.SiddhiAppRuntimeService;
 
 import javax.ws.rs.Consumes;
@@ -43,14 +44,14 @@ import org.wso2.transport.http.netty.config.TransportsConfiguration;
 
 @Component(
         name = "siddhi-store-query-service",
-        service = StoresApi.class,
+        service = HAStateChangeListener.class,
         immediate = true
 )
 @Path("/stores")
 @io.swagger.annotations.Api(description = "The stores API")
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaMSF4JServerCodegen",
         date = "2017-11-01T11:26:25.925Z")
-public class StoresApi {
+public class StoresApi implements HAStateChangeListener {
     private Logger log = LoggerFactory.getLogger(StoresApi.class);
     private final StoresApiService delegate = StoresApiServiceFactory.getStoresApi();
     private static TransportsConfiguration transportsConfiguration;
@@ -172,4 +173,13 @@ public class StoresApi {
     protected void unregisterAuthenticationInterceptor(AuthenticationInterceptor authenticationInterceptor) {
     }
 
+    @Override
+    public void becameActive() {
+        startStoresApiMicroservice();
+    }
+
+    @Override
+    public void becamePassive() {
+        stopStoresApiMicroservice();
+    }
 }

--- a/components/org.wso2.carbon.siddhi.store.api.rest/src/gen/java/org/wso2/carbon/siddhi/store/api/rest/StoresApi.java
+++ b/components/org.wso2.carbon.siddhi.store.api.rest/src/gen/java/org/wso2/carbon/siddhi/store/api/rest/StoresApi.java
@@ -88,7 +88,10 @@ public class StoresApi implements HAStateChangeListener {
     protected void start(BundleContext bundleContext) throws Exception {
         log.debug("Siddhi Store REST API activated.");
         microservicesRunner = new MicroservicesRunner(transportsConfiguration);
-        microservicesRunner.addGlobalRequestInterceptor(new AuthenticationInterceptor());
+        if (SiddhiStoreDataHolder.getInstance().getAuthenticationInterceptor() != null) {
+            microservicesRunner.addGlobalRequestInterceptor(SiddhiStoreDataHolder.getInstance().
+                    getAuthenticationInterceptor());
+        }
         microservicesRunner.deploy(new StoresApi());
         startStoresApiMicroservice();
     }
@@ -168,9 +171,11 @@ public class StoresApi implements HAStateChangeListener {
             unbind = "unregisterAuthenticationInterceptor"
     )
     protected void registerAuthenticationInterceptor(AuthenticationInterceptor authenticationInterceptor) {
+        SiddhiStoreDataHolder.getInstance().setAuthenticationInterceptor(authenticationInterceptor);
     }
 
     protected void unregisterAuthenticationInterceptor(AuthenticationInterceptor authenticationInterceptor) {
+        SiddhiStoreDataHolder.getInstance().setAuthenticationInterceptor(null);
     }
 
     @Override

--- a/components/org.wso2.carbon.siddhi.store.api.rest/src/main/java/org/wso2/carbon/siddhi/store/api/rest/SiddhiStoreDataHolder.java
+++ b/components/org.wso2.carbon.siddhi.store.api.rest/src/main/java/org/wso2/carbon/siddhi/store/api/rest/SiddhiStoreDataHolder.java
@@ -19,6 +19,7 @@
 
 package org.wso2.carbon.siddhi.store.api.rest;
 
+import org.wso2.carbon.analytics.msf4j.interceptor.common.AuthenticationInterceptor;
 import org.wso2.carbon.config.provider.ConfigProvider;
 import org.wso2.carbon.stream.processor.core.SiddhiAppRuntimeService;
 
@@ -28,6 +29,7 @@ import org.wso2.carbon.stream.processor.core.SiddhiAppRuntimeService;
 public class SiddhiStoreDataHolder {
     private SiddhiAppRuntimeService siddhiAppRuntimeService;
     private ConfigProvider configProvider;
+    private AuthenticationInterceptor authenticationInterceptor;
 
     private static SiddhiStoreDataHolder  instance = new SiddhiStoreDataHolder();
 
@@ -53,5 +55,13 @@ public class SiddhiStoreDataHolder {
 
     public ConfigProvider getConfigProvider() {
         return configProvider;
+    }
+
+    public AuthenticationInterceptor getAuthenticationInterceptor() {
+        return authenticationInterceptor;
+    }
+
+    public void setAuthenticationInterceptor(AuthenticationInterceptor authenticationInterceptor) {
+        this.authenticationInterceptor = authenticationInterceptor;
     }
 }

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/HAStateChangeListener.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/HAStateChangeListener.java
@@ -1,0 +1,34 @@
+/*
+ *   Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an
+ *   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *   KIND, either express or implied.  See the License for the
+ *   specific language governing permissions and limitations
+ *   under the License.
+ *
+ */
+package org.wso2.carbon.stream.processor.core;
+
+/**
+ * This represents the interface which defines the apis for HA State Change Notifier
+ */
+public interface HAStateChangeListener {
+    /**
+     * The state change lister function when the current node became active
+     */
+    public void becameActive();
+
+    /**
+     * The state change lister function when the current node became passive
+     */
+    public void becamePassive();
+}

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/ServiceComponent.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/ServiceComponent.java
@@ -40,6 +40,7 @@ import org.wso2.carbon.siddhi.metrics.core.internal.service.MetricsServiceCompon
 import org.wso2.carbon.stream.processor.common.EventStreamService;
 import org.wso2.carbon.stream.processor.common.utils.config.FileConfigManager;
 import org.wso2.carbon.stream.processor.core.DeploymentMode;
+import org.wso2.carbon.stream.processor.core.HAStateChangeListener;
 import org.wso2.carbon.stream.processor.core.NodeInfo;
 import org.wso2.carbon.stream.processor.core.SiddhiAppRuntimeService;
 import org.wso2.carbon.stream.processor.core.distribution.DistributionService;
@@ -439,6 +440,28 @@ public class ServiceComponent {
 
     protected void unregisterServerListener(ServerEventListener serverEventListener) {
         StreamProcessorDataHolder.removeServerListener(serverEventListener);
+    }
+
+    /**
+     * Get the HAStateChangeListener service.
+     * This is the bind method that gets called for HAStateChangeListener service
+     * registration that satisfy the policy.
+     *
+     * @param haStateChangeListener the ha state change server listeners that is registered as a service.
+     */
+    @Reference(
+            name = "org.wso2.carbon.stream.processor.core.HAStateChangeListener",
+            service = HAStateChangeListener.class,
+            cardinality = ReferenceCardinality.MULTIPLE,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unregisterHAStateChangeListener"
+    )
+    protected void registerHAStateChangeListener(HAStateChangeListener haStateChangeListener) {
+        StreamProcessorDataHolder.setHAStateChangeListener(haStateChangeListener);
+    }
+
+    protected void unregisterHAStateChangeListener(HAStateChangeListener haStateChangeListener) {
+        StreamProcessorDataHolder.removeHAStateChangeListener(haStateChangeListener);
     }
 
 }

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/StreamProcessorDataHolder.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/StreamProcessorDataHolder.java
@@ -25,6 +25,7 @@ import org.wso2.carbon.config.provider.ConfigProvider;
 import org.wso2.carbon.databridge.commons.ServerEventListener;
 import org.wso2.carbon.datasource.core.api.DataSourceService;
 import org.wso2.carbon.kernel.CarbonRuntime;
+import org.wso2.carbon.stream.processor.core.HAStateChangeListener;
 import org.wso2.carbon.stream.processor.core.NodeInfo;
 import org.wso2.carbon.stream.processor.core.distribution.DistributionService;
 import org.wso2.carbon.stream.processor.core.ha.HAManager;
@@ -61,6 +62,10 @@ public class StreamProcessorDataHolder {
     private SiddhiAppProcessorConstants.RuntimeMode runtimeMode = SiddhiAppProcessorConstants.RuntimeMode.ERROR;
     private BundleContext bundleContext;
     private ConfigProvider configProvider;
+    /**
+     * List used to hold all the registered hs state change listeners.
+     */
+    private static List<HAStateChangeListener> haStateChangeListenerList = new ArrayList<>();
 
     /**
      * List used to hold all the registered subscribers.
@@ -182,6 +187,18 @@ public class StreamProcessorDataHolder {
 
     public static void removeServerListener(ServerEventListener serverListener) {
         serverListeners.remove(serverListener);
+    }
+
+    public static void setHAStateChangeListener(HAStateChangeListener haStateChangeListener) {
+        haStateChangeListenerList.add(haStateChangeListener);
+    }
+
+    public static void removeHAStateChangeListener(HAStateChangeListener haStateChangeListener) {
+        haStateChangeListenerList.remove(haStateChangeListener);
+    }
+
+    public static List<HAStateChangeListener> getHaStateChangeListenerList() {
+        return haStateChangeListenerList;
     }
 
     public static List<ServerEventListener> getServerListeners() {

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/persistence/dto/RDBMSQueryConfigurationEntry.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/persistence/dto/RDBMSQueryConfigurationEntry.java
@@ -18,10 +18,6 @@
 
 package org.wso2.carbon.stream.processor.core.persistence.dto;
 
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-
 /**
  * Class that maps individual database entries from resources/rdbms-table-config.xml
  */
@@ -36,7 +32,6 @@ public class RDBMSQueryConfigurationEntry {
     private String deleteQuery;
     private String deleteOldRevisionsQuery;
     private String countQuery;
-    private String selectAllLatestRevisionsForSiddhiAppsQuery;
 
     public String getDatabaseName() {
         return databaseName;
@@ -118,13 +113,4 @@ public class RDBMSQueryConfigurationEntry {
         this.countQuery = countQuery;
     }
 
-    public String getSelectAllLatestRevisionsForSiddhiAppsQuery() {
-
-        return selectAllLatestRevisionsForSiddhiAppsQuery;
-    }
-
-    public void setSelectAllLatestRevisionsForSiddhiAppsQuery(String selectAllLatestRevisionsForSiddhiAppsQuery) {
-
-        this.selectAllLatestRevisionsForSiddhiAppsQuery = selectAllLatestRevisionsForSiddhiAppsQuery;
-    }
 }

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/persistence/util/PersistenceConstants.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/persistence/util/PersistenceConstants.java
@@ -39,6 +39,5 @@ public class PersistenceConstants {
     public static final String DELETE_ROW_FROM_TABLE = "DELETE_ROW_FROM_TABLE";
     public static final String DELETE_OLD_REVISIONS = "DELETE_OLD_REVISIONS";
     public static final String COUNT_NUMBER_REVISIONS = "COUNT_NUMBER_REVISIONS";
-    public static final String SELECT_ALL_LAST_REVISION = "SELECT_ALL_LAST_REVISIONS";
 
 }

--- a/components/osgi-tests/src/test/resources/conf/configuration/deployment.yaml
+++ b/components/osgi-tests/src/test/resources/conf/configuration/deployment.yaml
@@ -103,7 +103,7 @@ databridge.config:
         sslReceiverThreadPoolSize: '100'
         hostName: 0.0.0.0
 
-stores.api:
+siddhi.stores.query.api:
   transportProperties:
     -
       name: "server.bootstrap.socket.timeout"

--- a/components/osgi-tests/src/test/resources/conf/deployment.yaml
+++ b/components/osgi-tests/src/test/resources/conf/deployment.yaml
@@ -54,7 +54,7 @@ wso2.transport.http:
     -
       id: "http-sender"
 
-stores.api:
+siddhi.stores.query.api:
   transportProperties:
     -
       name: "server.bootstrap.socket.timeout"

--- a/components/osgi-tests/src/test/resources/conf/distributed/resource/deployment.yaml
+++ b/components/osgi-tests/src/test/resources/conf/distributed/resource/deployment.yaml
@@ -55,7 +55,7 @@ wso2.transport.http:
     -
       id: "http-sender"
 
-stores.api:
+siddhi.stores.query.api:
   transportProperties:
     -
       name: "server.bootstrap.socket.timeout"

--- a/components/osgi-tests/src/test/resources/conf/ha/deployment.yaml
+++ b/components/osgi-tests/src/test/resources/conf/ha/deployment.yaml
@@ -85,7 +85,7 @@ wso2.transport.http:
     -
       id: "http-sender"
 
-stores.api:
+siddhi.stores.query.api:
   transportProperties:
     -
       name: "server.bootstrap.socket.timeout"

--- a/components/osgi-tests/src/test/resources/conf/metrics/deployment.yaml
+++ b/components/osgi-tests/src/test/resources/conf/metrics/deployment.yaml
@@ -55,7 +55,7 @@ wso2.transport.http:
     -
       id: "http-sender"
 
-stores.api:
+siddhi.stores.query.api:
   transportProperties:
     -
       name: "server.bootstrap.socket.timeout"

--- a/components/osgi-tests/src/test/resources/conf/persistence/db/deployment-structure.yaml
+++ b/components/osgi-tests/src/test/resources/conf/persistence/db/deployment-structure.yaml
@@ -55,7 +55,7 @@ wso2.transport.http:
     -
       id: "http-sender"
 
-stores.api:
+siddhi.stores.query.api:
   transportProperties:
     -
       name: "server.bootstrap.socket.timeout"

--- a/components/osgi-tests/src/test/resources/conf/persistence/file/configTest/deployment.yaml
+++ b/components/osgi-tests/src/test/resources/conf/persistence/file/configTest/deployment.yaml
@@ -55,7 +55,7 @@ wso2.transport.http:
     -
       id: "http-sender"
 
-stores.api:
+siddhi.stores.query.api:
   transportProperties:
     -
       name: "server.bootstrap.socket.timeout"

--- a/components/osgi-tests/src/test/resources/conf/persistence/file/default/deployment.yaml
+++ b/components/osgi-tests/src/test/resources/conf/persistence/file/default/deployment.yaml
@@ -85,7 +85,7 @@ wso2.transport.http:
     -
       id: "http-sender"
 
-stores.api:
+siddhi.stores.query.api:
   transportProperties:
     -
       name: "server.bootstrap.socket.timeout"


### PR DESCRIPTION
## Purpose
> The purpose of this PR is to add separate Microservices Runner in the Siddhi Stores API service. The current Stores API start with the default microservice runner with the 'wso2.transport.http' configuration, with the new fix we can define the different transport properties and it will start new microservice runner and deploy the StoresAPI microservice. 

- The requirement of having separate transport properties for Stores API is we need to disable the StoresAPI endpoint in HA Passive node. The Stores API uses the  'SiddhiAppRuntime' for the query execution, but in the HA deployment only the active node processing the events, so we need to avoid usage of 'SiddhiAppRuntime' in the passive mode.

- We introduce new transport properties as we cannot stop the default microservice runner which may use by the other microservice. Also, in the HA deployment, if we need to load balancing(failover) the StoresAPI endpoint without configuring the LB, we should stop the HTTP/S(TCP) connection between the LB and endpoint(TCP Probing)

## Goals
> Add separate Microservices Runner in the Siddhi Stores API service

## Approach
> Create new microservice runner with 'MicroservicesRunner(TransportsConfiguration transportsConfiguration)' constructor and stop/start the runner in the method becamePassive()/becameActive() of the HAStateChangeListener service.

## User stories
> N/A

## Release note
> N/A

## Documentation
> We need to update the product documentation as follows:
Version: SP4.3.0

1) https://docs.wso2.com/display/SP430/Configuring+Default+Ports

**Worker Runtime**
```
siddhi.stores.query.api:
  transportProperties:
    -
      name: "server.bootstrap.socket.timeout"
      value: 60
    -
      name: "client.bootstrap.socket.timeout"
      value: 60
    -
      name: "latency.metrics.enabled"
      value: true

  listenerConfigurations:
    -
      id: "default"
      host: "0.0.0.0"
      port: 7070
    -
      id: "msf4j-https"
      host: "0.0.0.0"
      port: 7443
      scheme: https
      keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
      keyStorePassword: wso2carbon
      certPass: wso2carbon
```
7070  Siddhi Stores Query API HTTP port
7443  Siddhi Stores Query API HTTPS port

**Editor Runtime**
```
siddhi.stores.query.api:
  transportProperties:
    -
      name: "server.bootstrap.socket.timeout"
      value: 60
    -
      name: "client.bootstrap.socket.timeout"
      value: 60
    -
      name: "latency.metrics.enabled"
      value: true

  listenerConfigurations:
    -
      id: "default"
      host: "0.0.0.0"
      port: 7370
    -
      id: "msf4j-https"
      host: "0.0.0.0"
      port: 7743
      scheme: https
      keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
      keyStorePassword: wso2carbon
      certPass: wso2carbon
```
7370  Siddhi Stores Query API HTTP port
7743  Siddhi Stores Query API HTTPS port

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Integration tests
   > SiddhiStoreAPITestcase.class  77%

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A