### PR TITLE
Fix the issue in Siddhi Store Query API not working with editor runtime

### DIFF
--- a/components/org.wso2.carbon.event.simulator.core/pom.xml
+++ b/components/org.wso2.carbon.event.simulator.core/pom.xml
@@ -59,10 +59,6 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.analytics</groupId>
-            <artifactId>org.wso2.carbon.stream.processor.core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.analytics</groupId>
             <artifactId>org.wso2.carbon.stream.processor.common</artifactId>
         </dependency>
         <dependency>
@@ -146,6 +142,19 @@
         <dependency>
             <groupId>org.wso2.carbon.analytics-common</groupId>
             <artifactId>org.wso2.carbon.database.query.manager</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-joda</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-json-provider</artifactId>
         </dependency>
     </dependencies>
 

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/EditorSiddhiAppRuntimeService.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/EditorSiddhiAppRuntimeService.java
@@ -1,0 +1,52 @@
+/*
+ *   Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an
+ *   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *   KIND, either express or implied.  See the License for the
+ *   specific language governing permissions and limitations
+ *   under the License.
+ *
+ */
+
+package org.wso2.carbon.siddhi.editor.core;
+
+import org.wso2.carbon.siddhi.editor.core.internal.DebugRuntime;
+import org.wso2.carbon.siddhi.editor.core.internal.EditorDataHolder;
+import org.wso2.carbon.stream.processor.common.SiddhiAppRuntimeService;
+import org.wso2.siddhi.core.SiddhiAppRuntime;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This class contains the implementations of the apis related to SiddhiAppRuntimes
+ */
+public class EditorSiddhiAppRuntimeService implements SiddhiAppRuntimeService {
+
+    @Override
+    public Map<String, SiddhiAppRuntime> getActiveSiddhiAppRuntimes() {
+        Map<String, DebugRuntime> siddhiApps = EditorDataHolder.getSiddhiAppMap();
+        Map<String, SiddhiAppRuntime> siddhiAppRuntimes = new HashMap<>();
+        for (Map.Entry<String, DebugRuntime> entry : siddhiApps.entrySet()) {
+            if (entry.getValue() != null && (entry.getValue().getMode() == DebugRuntime.Mode.RUN ||
+                    entry.getValue().getMode() == DebugRuntime.Mode.DEBUG)) {
+                siddhiAppRuntimes.put(entry.getKey(), entry.getValue().getSiddhiAppRuntime());
+            }
+        }
+        return siddhiAppRuntimes;
+    }
+
+    @Override
+    public void enableSiddhiAppStatistics(boolean statsEnabled) {
+        //ignore the editor runtime statistics
+    }
+}

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/DebugRuntime.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/DebugRuntime.java
@@ -169,6 +169,10 @@ public class DebugRuntime {
         }
     }
 
-    protected enum Mode {RUN, DEBUG, STOP, FAULTY}
+    public SiddhiAppRuntime getSiddhiAppRuntime() {
+        return siddhiAppRuntime;
+    }
+
+    public enum Mode {RUN, DEBUG, STOP, FAULTY}
 
 }

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/EditorMicroservice.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/EditorMicroservice.java
@@ -36,6 +36,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.config.provider.ConfigProvider;
+import org.wso2.carbon.siddhi.editor.core.EditorSiddhiAppRuntimeService;
 import org.wso2.carbon.siddhi.editor.core.Workspace;
 import org.wso2.carbon.siddhi.editor.core.commons.metadata.MetaData;
 import org.wso2.carbon.siddhi.editor.core.commons.request.ValidationRequest;
@@ -59,6 +60,7 @@ import org.wso2.carbon.siddhi.editor.core.util.designview.designgenerator.Design
 import org.wso2.carbon.siddhi.editor.core.util.designview.exceptions.CodeGenerationException;
 import org.wso2.carbon.siddhi.editor.core.util.designview.exceptions.DesignGenerationException;
 import org.wso2.carbon.stream.processor.common.EventStreamService;
+import org.wso2.carbon.stream.processor.common.SiddhiAppRuntimeService;
 import org.wso2.carbon.stream.processor.common.utils.config.FileConfigManager;
 import org.wso2.msf4j.Microservice;
 import org.wso2.msf4j.Request;
@@ -121,6 +123,7 @@ public class EditorMicroservice implements Microservice {
                     .build()
             );
     private ConfigProvider configProvider;
+    private ServiceRegistration siddhiAppRuntimeServiceRegistration;
 
     public EditorMicroservice() {
         workspace = new LocalFSWorkspace();
@@ -869,7 +872,8 @@ public class EditorMicroservice implements Microservice {
         siddhiManager.setConfigManager(fileConfigManager);
         EditorDataHolder.setSiddhiManager(siddhiManager);
         EditorDataHolder.setBundleContext(bundleContext);
-
+        siddhiAppRuntimeServiceRegistration = bundleContext.registerService(SiddhiAppRuntimeService.class.getName(),
+                new EditorSiddhiAppRuntimeService(), null);
         serviceRegistration = bundleContext.registerService(EventStreamService.class.getName(),
                 new DebuggerEventStreamService(), null);
     }

--- a/components/org.wso2.carbon.siddhi.store.api.rest/pom.xml
+++ b/components/org.wso2.carbon.siddhi.store.api.rest/pom.xml
@@ -105,7 +105,7 @@
 
         <dependency>
             <groupId>org.wso2.carbon.analytics</groupId>
-            <artifactId>org.wso2.carbon.stream.processor.core</artifactId>
+            <artifactId>org.wso2.carbon.stream.processor.common</artifactId>
         </dependency>
 
         <dependency>
@@ -196,6 +196,7 @@
             org.wso2.msf4j.*;version="${msf4j.import.version.range}",
             org.wso2.siddhi.*;version="${siddhi.version.range}",
             org.wso2.transport.http.netty.config.*;version="${carbon.transport.package.import.version.range}",
+            org.wso2.carbon.stream.processor.common.*;version="${carbon.analytics.version.range}",
             org.wso2.carbon.analytics.msf4j.interceptor.common.*;version="${carbon.analytics.version.range}",
             *;resolution:=optional
         </import.package>

--- a/components/org.wso2.carbon.siddhi.store.api.rest/src/gen/java/org/wso2/carbon/siddhi/store/api/rest/StoresApi.java
+++ b/components/org.wso2.carbon.siddhi.store.api.rest/src/gen/java/org/wso2/carbon/siddhi/store/api/rest/StoresApi.java
@@ -29,8 +29,8 @@ import org.wso2.carbon.config.provider.ConfigProvider;
 import org.wso2.carbon.siddhi.store.api.rest.factories.StoresApiServiceFactory;
 import org.wso2.carbon.siddhi.store.api.rest.model.ModelApiResponse;
 import org.wso2.carbon.siddhi.store.api.rest.model.Query;
-import org.wso2.carbon.stream.processor.core.HAStateChangeListener;
-import org.wso2.carbon.stream.processor.core.SiddhiAppRuntimeService;
+import org.wso2.carbon.stream.processor.common.HAStateChangeListener;
+import org.wso2.carbon.stream.processor.common.SiddhiAppRuntimeService;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
@@ -126,6 +126,7 @@ public class StoresApi implements HAStateChangeListener {
     @Deactivate
     protected void stop() throws Exception {
         log.debug("Siddhi Store REST API deactivated.");
+        stopStoresApiMicroservice();
     }
 
     @Reference(

--- a/components/org.wso2.carbon.siddhi.store.api.rest/src/main/java/org/wso2/carbon/siddhi/store/api/rest/SiddhiStoreDataHolder.java
+++ b/components/org.wso2.carbon.siddhi.store.api.rest/src/main/java/org/wso2/carbon/siddhi/store/api/rest/SiddhiStoreDataHolder.java
@@ -21,7 +21,7 @@ package org.wso2.carbon.siddhi.store.api.rest;
 
 import org.wso2.carbon.analytics.msf4j.interceptor.common.AuthenticationInterceptor;
 import org.wso2.carbon.config.provider.ConfigProvider;
-import org.wso2.carbon.stream.processor.core.SiddhiAppRuntimeService;
+import org.wso2.carbon.stream.processor.common.SiddhiAppRuntimeService;
 
 /**
  * This class holds the services referenced by the store api micro services {@link StoresApi}

--- a/components/org.wso2.carbon.siddhi.store.api.rest/src/main/java/org/wso2/carbon/siddhi/store/api/rest/impl/StoresApiServiceImpl.java
+++ b/components/org.wso2.carbon.siddhi.store.api.rest/src/main/java/org/wso2/carbon/siddhi/store/api/rest/impl/StoresApiServiceImpl.java
@@ -28,7 +28,7 @@ import org.wso2.carbon.siddhi.store.api.rest.StoresApiService;
 import org.wso2.carbon.siddhi.store.api.rest.model.ModelApiResponse;
 import org.wso2.carbon.siddhi.store.api.rest.model.Query;
 import org.wso2.carbon.siddhi.store.api.rest.model.Record;
-import org.wso2.carbon.stream.processor.core.SiddhiAppRuntimeService;
+import org.wso2.carbon.stream.processor.common.SiddhiAppRuntimeService;
 import org.wso2.siddhi.core.SiddhiAppRuntime;
 import org.wso2.siddhi.core.event.Event;
 

--- a/components/org.wso2.carbon.stream.processor.common/src/main/java/org/wso2/carbon/stream/processor/common/HAStateChangeListener.java
+++ b/components/org.wso2.carbon.stream.processor.common/src/main/java/org/wso2/carbon/stream/processor/common/HAStateChangeListener.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *   Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *   WSO2 Inc. licenses this file to you under the Apache License,
  *   Version 2.0 (the "License"); you may not use this file except
@@ -16,17 +16,19 @@
  *   under the License.
  *
  */
-
-package org.wso2.carbon.stream.processor.core;
-
-import org.wso2.siddhi.core.SiddhiAppRuntime;
-
-import java.util.Map;
+package org.wso2.carbon.stream.processor.common;
 
 /**
- * This represents the interface which defines the apis for SiddhiApp Runtimes
+ * This represents the interface which defines the apis for HA State Change Notifier
  */
-public interface SiddhiAppRuntimeService {
-    Map<String, SiddhiAppRuntime> getActiveSiddhiAppRuntimes();
-    void enableSiddhiAppStatistics(boolean statsEnabled);
+public interface HAStateChangeListener {
+    /**
+     * The state change lister function when the current node became active
+     */
+    public void becameActive();
+
+    /**
+     * The state change lister function when the current node became passive
+     */
+    public void becamePassive();
 }

--- a/components/org.wso2.carbon.stream.processor.common/src/main/java/org/wso2/carbon/stream/processor/common/SiddhiAppRuntimeService.java
+++ b/components/org.wso2.carbon.stream.processor.common/src/main/java/org/wso2/carbon/stream/processor/common/SiddhiAppRuntimeService.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *   WSO2 Inc. licenses this file to you under the Apache License,
  *   Version 2.0 (the "License"); you may not use this file except
@@ -16,19 +16,17 @@
  *   under the License.
  *
  */
-package org.wso2.carbon.stream.processor.core;
+
+package org.wso2.carbon.stream.processor.common;
+
+import org.wso2.siddhi.core.SiddhiAppRuntime;
+
+import java.util.Map;
 
 /**
- * This represents the interface which defines the apis for HA State Change Notifier
+ * This represents the interface which defines the apis for SiddhiApp Runtimes
  */
-public interface HAStateChangeListener {
-    /**
-     * The state change lister function when the current node became active
-     */
-    public void becameActive();
-
-    /**
-     * The state change lister function when the current node became passive
-     */
-    public void becamePassive();
+public interface SiddhiAppRuntimeService {
+    Map<String, SiddhiAppRuntime> getActiveSiddhiAppRuntimes();
+    void enableSiddhiAppStatistics(boolean statsEnabled);
 }

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/ha/HAManager.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/ha/HAManager.java
@@ -22,7 +22,7 @@ import org.apache.log4j.Logger;
 import org.wso2.carbon.cluster.coordinator.service.ClusterCoordinator;
 import org.wso2.carbon.databridge.commons.ServerEventListener;
 import org.wso2.carbon.stream.processor.core.DeploymentMode;
-import org.wso2.carbon.stream.processor.core.HAStateChangeListener;
+import org.wso2.carbon.stream.processor.common.HAStateChangeListener;
 import org.wso2.carbon.stream.processor.core.NodeInfo;
 import org.wso2.carbon.stream.processor.core.event.queue.EventListMapManager;
 import org.wso2.carbon.stream.processor.core.ha.tcp.TCPServer;

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/CarbonSiddhiAppRuntimeService.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/CarbonSiddhiAppRuntimeService.java
@@ -21,7 +21,7 @@ package org.wso2.carbon.stream.processor.core.internal;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wso2.carbon.stream.processor.core.SiddhiAppRuntimeService;
+import org.wso2.carbon.stream.processor.common.SiddhiAppRuntimeService;
 import org.wso2.siddhi.core.SiddhiAppRuntime;
 
 import java.util.HashMap;

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/ServiceComponent.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/ServiceComponent.java
@@ -40,9 +40,9 @@ import org.wso2.carbon.siddhi.metrics.core.internal.service.MetricsServiceCompon
 import org.wso2.carbon.stream.processor.common.EventStreamService;
 import org.wso2.carbon.stream.processor.common.utils.config.FileConfigManager;
 import org.wso2.carbon.stream.processor.core.DeploymentMode;
-import org.wso2.carbon.stream.processor.core.HAStateChangeListener;
+import org.wso2.carbon.stream.processor.common.HAStateChangeListener;
 import org.wso2.carbon.stream.processor.core.NodeInfo;
-import org.wso2.carbon.stream.processor.core.SiddhiAppRuntimeService;
+import org.wso2.carbon.stream.processor.common.SiddhiAppRuntimeService;
 import org.wso2.carbon.stream.processor.core.distribution.DistributionService;
 import org.wso2.carbon.stream.processor.core.ha.HAManager;
 import org.wso2.carbon.stream.processor.core.ha.exception.HAModeException;
@@ -450,7 +450,7 @@ public class ServiceComponent {
      * @param haStateChangeListener the ha state change server listeners that is registered as a service.
      */
     @Reference(
-            name = "org.wso2.carbon.stream.processor.core.HAStateChangeListener",
+            name = "org.wso2.carbon.stream.processor.common.HAStateChangeListener",
             service = HAStateChangeListener.class,
             cardinality = ReferenceCardinality.MULTIPLE,
             policy = ReferencePolicy.DYNAMIC,

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/StreamProcessorDataHolder.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/StreamProcessorDataHolder.java
@@ -25,7 +25,7 @@ import org.wso2.carbon.config.provider.ConfigProvider;
 import org.wso2.carbon.databridge.commons.ServerEventListener;
 import org.wso2.carbon.datasource.core.api.DataSourceService;
 import org.wso2.carbon.kernel.CarbonRuntime;
-import org.wso2.carbon.stream.processor.core.HAStateChangeListener;
+import org.wso2.carbon.stream.processor.common.HAStateChangeListener;
 import org.wso2.carbon.stream.processor.core.NodeInfo;
 import org.wso2.carbon.stream.processor.core.distribution.DistributionService;
 import org.wso2.carbon.stream.processor.core.ha.HAManager;

--- a/components/org.wso2.carbon.stream.processor.statistics/src/main/java/org/wso2/carbon/stream/processor/statistics/internal/StreamProcessorStatisticDataHolder.java
+++ b/components/org.wso2.carbon.stream.processor.statistics/src/main/java/org/wso2/carbon/stream/processor/statistics/internal/StreamProcessorStatisticDataHolder.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 import org.wso2.carbon.config.provider.ConfigProvider;
 import org.wso2.carbon.metrics.core.MetricManagementService;
 import org.wso2.carbon.stream.processor.core.NodeInfo;
-import org.wso2.carbon.stream.processor.core.SiddhiAppRuntimeService;
+import org.wso2.carbon.stream.processor.common.SiddhiAppRuntimeService;
 
 /**
  * This is the data holder of stream processor statistics component.

--- a/components/org.wso2.carbon.stream.processor.statistics/src/main/java/org/wso2/carbon/stream/processor/statistics/internal/service/SiddhiAppRuntimeServiceComponent.java
+++ b/components/org.wso2.carbon.stream.processor.statistics/src/main/java/org/wso2/carbon/stream/processor/statistics/internal/service/SiddhiAppRuntimeServiceComponent.java
@@ -28,7 +28,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.config.ConfigurationException;
-import org.wso2.carbon.stream.processor.core.SiddhiAppRuntimeService;
+import org.wso2.carbon.stream.processor.common.SiddhiAppRuntimeService;
 import org.wso2.carbon.stream.processor.statistics.internal.StreamProcessorStatisticDataHolder;
 
 /**

--- a/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/HAActiveNodeTestcase.java
+++ b/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/HAActiveNodeTestcase.java
@@ -36,7 +36,7 @@
 //import org.wso2.carbon.stream.processor.common.EventStreamService;
 //import org.wso2.carbon.stream.processor.core.DeploymentMode;
 //import org.wso2.carbon.stream.processor.core.NodeInfo;
-//import org.wso2.carbon.stream.processor.core.SiddhiAppRuntimeService;
+//import org.wso2.carbon.stream.processor.common.SiddhiAppRuntimeService;
 //import org.wso2.carbon.stream.processor.core.model.OutputSyncTimestampCollection;
 //
 //import java.net.URI;

--- a/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/SiddhiAsAPITestcase.java
+++ b/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/SiddhiAsAPITestcase.java
@@ -29,10 +29,9 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.analytics.test.osgi.util.TestUtil;
 import org.wso2.carbon.analytics.test.osgi.util.HTTPResponseMessage;
 import org.wso2.carbon.container.CarbonContainerFactory;
-import org.wso2.carbon.container.options.CarbonDistributionOption;
 import org.wso2.carbon.kernel.CarbonServerInfo;
 import org.wso2.carbon.stream.processor.common.EventStreamService;
-import org.wso2.carbon.stream.processor.core.SiddhiAppRuntimeService;
+import org.wso2.carbon.stream.processor.common.SiddhiAppRuntimeService;
 
 import java.net.URI;
 import java.nio.file.Path;

--- a/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/SiddhiMetricsAPITestcase.java
+++ b/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/SiddhiMetricsAPITestcase.java
@@ -33,7 +33,7 @@ import org.wso2.carbon.container.CarbonContainerFactory;
 import org.wso2.carbon.kernel.CarbonServerInfo;
 import org.wso2.carbon.siddhi.store.api.rest.ApiResponseMessage;
 import org.wso2.carbon.stream.processor.common.EventStreamService;
-import org.wso2.carbon.stream.processor.core.SiddhiAppRuntimeService;
+import org.wso2.carbon.stream.processor.common.SiddhiAppRuntimeService;
 import org.wso2.carbon.stream.processor.statistics.bean.WorkerMetrics;
 import org.wso2.carbon.stream.processor.statistics.bean.WorkerStatistics;
 import org.wso2.msf4j.MicroservicesRegistry;

--- a/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/SiddhiMetricsTestcase.java
+++ b/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/SiddhiMetricsTestcase.java
@@ -32,7 +32,7 @@ import org.wso2.carbon.kernel.CarbonServerInfo;
 import org.wso2.carbon.metrics.core.MetricManagementService;
 import org.wso2.carbon.metrics.core.MetricService;
 import org.wso2.carbon.metrics.core.jmx.MetricsMXBean;
-import org.wso2.carbon.stream.processor.core.SiddhiAppRuntimeService;
+import org.wso2.carbon.stream.processor.common.SiddhiAppRuntimeService;
 import org.wso2.siddhi.core.SiddhiAppRuntime;
 import org.wso2.siddhi.core.event.Event;
 import org.wso2.siddhi.core.stream.input.InputHandler;

--- a/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/SiddhiStoreAPITestcase.java
+++ b/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/SiddhiStoreAPITestcase.java
@@ -41,7 +41,7 @@ import org.wso2.carbon.siddhi.store.api.rest.ApiResponseMessage;
 import org.wso2.carbon.siddhi.store.api.rest.model.ModelApiResponse;
 import org.wso2.carbon.siddhi.store.api.rest.model.Query;
 import org.wso2.carbon.stream.processor.common.EventStreamService;
-import org.wso2.carbon.stream.processor.core.SiddhiAppRuntimeService;
+import org.wso2.carbon.stream.processor.common.SiddhiAppRuntimeService;
 import org.wso2.msf4j.MicroservicesRegistry;
 import org.wso2.siddhi.core.event.Event;
 

--- a/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/StatusDashboardWorkerTestCase.java
+++ b/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/StatusDashboardWorkerTestCase.java
@@ -30,7 +30,7 @@ import org.wso2.carbon.analytics.test.osgi.util.TestUtil;
 import org.wso2.carbon.container.CarbonContainerFactory;
 import org.wso2.carbon.kernel.CarbonServerInfo;
 import org.wso2.carbon.stream.processor.common.EventStreamService;
-import org.wso2.carbon.stream.processor.core.SiddhiAppRuntimeService;
+import org.wso2.carbon.stream.processor.common.SiddhiAppRuntimeService;
 import org.wso2.msf4j.MicroservicesRegistry;
 
 import javax.inject.Inject;

--- a/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/util/TestUtil.java
+++ b/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/util/TestUtil.java
@@ -19,7 +19,7 @@ package org.wso2.carbon.analytics.test.osgi.util;
 import io.netty.handler.codec.http.HttpMethod;
 import org.awaitility.Duration;
 import org.wso2.carbon.stream.processor.common.EventStreamService;
-import org.wso2.carbon.stream.processor.core.SiddhiAppRuntimeService;
+import org.wso2.carbon.stream.processor.common.SiddhiAppRuntimeService;
 import org.wso2.msf4j.MicroservicesRegistry;
 import org.wso2.siddhi.core.SiddhiAppRuntime;
 

--- a/features/org.wso2.carbon.event.simulator.core.feature/pom.xml
+++ b/features/org.wso2.carbon.event.simulator.core.feature/pom.xml
@@ -62,10 +62,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.analytics</groupId>
-            <artifactId>org.wso2.carbon.stream.processor.core</artifactId>
-        </dependency>
 
         <!--Dependencies for event simulation begins here-->
 
@@ -200,10 +196,6 @@
                                 <bundle>
                                     <symbolicName>com.google.gson</symbolicName>
                                     <version>${gson.version}</version>
-                                </bundle>
-                                <bundle>
-                                    <symbolicName>org.wso2.carbon.stream.processor.core</symbolicName>
-                                    <version>${carbon.analytics.version}</version>
                                 </bundle>
                                 <bundle>
                                     <symbolicName>json</symbolicName>

--- a/features/org.wso2.carbon.siddhi.store.api.rest.feature/pom.xml
+++ b/features/org.wso2.carbon.siddhi.store.api.rest.feature/pom.xml
@@ -59,10 +59,6 @@
             <artifactId>slf4j</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.analytics</groupId>
-            <artifactId>org.wso2.carbon.stream.processor.core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.siddhi</groupId>
             <artifactId>siddhi-core</artifactId>
         </dependency>


### PR DESCRIPTION
## Purpose
> The purpose of this PR is to introduce a new Editor Siddhi App Runtime service. This service will be serving Siddhi Runtime Applications which are in run/debug mode on the editor runtime. Currently, it has only 'CarbonSiddhiAppRuntimeService' which is used in worker runtime. But for the editor runtime, CarbonSiddhiAppRuntimeService is a dummy object and its returns empty map for the getActiveSiddhiAppRuntimes() method.

## Goals
> Add new Editor Siddhi App Runtime Service

## Approach
> We first need to avoid 'CarbonSiddhiAppRuntimeService' reference from the editor runtime, as we need to register new SiddhiAppRuntimeService into store API in editor runtime mode. Hence we have moved the 'SiddhiAppRuntimeService' impl into common location and update/remove the usage of stream.processor.core dependency from the editor related components. Then we introduce new EditorSiddhiAppRuntimeService which maintain a map with Siddhi Runtime currently in run/debug mode. 

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
 - Integration tests

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A