### PR TITLE
Passthrough app creation issue has been fixed.

### DIFF
--- a/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/appcreator/SPSiddhiAppCreator.java
+++ b/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/appcreator/SPSiddhiAppCreator.java
@@ -81,7 +81,7 @@ public class SPSiddhiAppCreator extends AbstractSiddhiAppCreator {
                         continue;
                     }
                     //Remove if there is any previous R/R or ALL publishing
-                    sinkValuesMap.remove(siddhiAppName + "." + outputStream.getStreamName());
+                    sinkList.remove(siddhiAppName + "." + outputStream.getStreamName());
                     partitionKeys.put(holder.getGroupingField(), holder.getParallelism());
                     sinkValuesMap.put(ResourceManagerConstants.PARTITION_KEY, holder.getGroupingField());
                     List<String> destinations = new ArrayList<>(holder.getParallelism());

--- a/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/topology/SiddhiTopologyCreatorImpl.java
+++ b/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/topology/SiddhiTopologyCreatorImpl.java
@@ -117,7 +117,6 @@ public class SiddhiTopologyCreatorImpl implements SiddhiTopologyCreator {
 
                 //store partition details
                 storePartitionInfo((Partition) executionElement, execGroupName);
-
                 //for a partition iterate over containing queries to identify required inputStreams and OutputStreams
                 for (Query query : ((Partition) executionElement).getQueryList()) {
                     if (AnnotationHelper.getAnnotation(SiddhiTopologyCreatorConstants.DISTRIBUTED_IDENTIFIER,
@@ -776,11 +775,20 @@ public class SiddhiTopologyCreatorImpl implements SiddhiTopologyCreator {
                 }
                 siddhiTopologyDataHolder.getPartitionKeyGroupMap().put(streamID + partitionKey, execGroupName);
                 siddhiTopologyDataHolder.getPartitionKeyMap().put(streamID, partitionKey);
-
+                updateInputStreamDataHolders(streamID, partitionKey);
             } else {
                 //Not yet supported
                 throw new SiddhiAppValidationException("Unsupported: "
                         + execGroupName + " Range PartitionType not Supported in Distributed SetUp");
+            }
+        }
+    }
+
+    private void updateInputStreamDataHolders(String streamID, String partitionKey) {
+        for (SiddhiQueryGroup siddhiQueryGroup : siddhiTopologyDataHolder.getSiddhiQueryGroupMap().values()) {
+            InputStreamDataHolder holder = siddhiQueryGroup.getInputStreams().get(streamID);
+            if (holder != null && holder.getSubscriptionStrategy().getStrategy() != TransportStrategy.FIELD_GROUPING) {
+                holder.getSubscriptionStrategy().setPartitionKey(partitionKey);
             }
         }
     }

--- a/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/topology/SiddhiTopologyCreatorImpl.java
+++ b/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/topology/SiddhiTopologyCreatorImpl.java
@@ -513,19 +513,16 @@ public class SiddhiTopologyCreatorImpl implements SiddhiTopologyCreator {
                 InputStreamDataHolder inputStreamDataHolder = entry.getValue();
                 if (inputStreamDataHolder.getEventHolderType().equals(EventHolder.STREAM) && inputStreamDataHolder
                         .isUserGiven()) {
-
                     createPassthrough = true;
                     String runtimeDefinition = removeMetaInfoStream(streamId,
                             inputStreamDataHolder.getStreamDefinition(), SiddhiTopologyCreatorConstants
                                     .SOURCE_IDENTIFIER);
-
                     if (siddhiQueryGroup1.getParallelism() > SiddhiTopologyCreatorConstants.DEFAULT_PARALLEL) {
                         passthroughQueriesAvailable = true;
                         passthroughQueries.addAll(generatePassthroughQueryList(
                                 streamId, inputStreamDataHolder, runtimeDefinition));
                         inputStreamDataHolder.setStreamDefinition(runtimeDefinition);
                         inputStreamDataHolder.setUserGiven(false);
-
                         InputStreamDataHolder holder1 = siddhiQueryGroup1.getInputStreams().get(streamId);
                         String consumingStream = "${" + streamId + "} " + removeMetaInfoStream(streamId,
                                 holder1.getStreamDefinition(), SiddhiTopologyCreatorConstants.SOURCE_IDENTIFIER);
@@ -550,15 +547,14 @@ public class SiddhiTopologyCreatorImpl implements SiddhiTopologyCreator {
                                 inputStreamDataHolder.setStreamDefinition(runtimeDefinition);
                                 inputStreamDataHolder.setUserGiven(false);
                                 createPassthrough = false;
-
                                 InputStreamDataHolder holder1 = siddhiQueryGroup1.getInputStreams().get(streamId);
                                 consumingStream = "${" + streamId + "} " + removeMetaInfoStream(streamId,
-                                        holder1.getStreamDefinition(), SiddhiTopologyCreatorConstants.SOURCE_IDENTIFIER);
+                                        holder1.getStreamDefinition(),
+                                        SiddhiTopologyCreatorConstants.SOURCE_IDENTIFIER);
                                 holder1.setStreamDefinition(consumingStream);
                                 holder1.setUserGiven(false);
 
                             }
-
                             InputStreamDataHolder holder2 = siddhiQueryGroup2.getInputStreams().get(streamId);
                             consumingStream = "${" + streamId + "} " + removeMetaInfoStream(streamId,
                                     holder2.getStreamDefinition(), SiddhiTopologyCreatorConstants.SOURCE_IDENTIFIER);

--- a/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/topology/SiddhiTopologyCreatorImpl.java
+++ b/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/topology/SiddhiTopologyCreatorImpl.java
@@ -522,11 +522,11 @@ public class SiddhiTopologyCreatorImpl implements SiddhiTopologyCreator {
                                 streamId, inputStreamDataHolder, runtimeDefinition));
                         inputStreamDataHolder.setStreamDefinition(runtimeDefinition);
                         inputStreamDataHolder.setUserGiven(false);
-                        InputStreamDataHolder holder1 = siddhiQueryGroup1.getInputStreams().get(streamId);
+                        InputStreamDataHolder holder = siddhiQueryGroup1.getInputStreams().get(streamId);
                         String consumingStream = "${" + streamId + "} " + removeMetaInfoStream(streamId,
-                                holder1.getStreamDefinition(), SiddhiTopologyCreatorConstants.SOURCE_IDENTIFIER);
-                        holder1.setStreamDefinition(consumingStream);
-                        holder1.setUserGiven(false);
+                                holder.getStreamDefinition(), SiddhiTopologyCreatorConstants.SOURCE_IDENTIFIER);
+                        holder.setStreamDefinition(consumingStream);
+                        holder.setUserGiven(false);
                         createPassthrough = false;
                     }
 

--- a/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/topology/SiddhiTopologyCreatorImpl.java
+++ b/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/topology/SiddhiTopologyCreatorImpl.java
@@ -513,11 +513,32 @@ public class SiddhiTopologyCreatorImpl implements SiddhiTopologyCreator {
                 InputStreamDataHolder inputStreamDataHolder = entry.getValue();
                 if (inputStreamDataHolder.getEventHolderType().equals(EventHolder.STREAM) && inputStreamDataHolder
                         .isUserGiven()) {
+
                     createPassthrough = true;
+                    String runtimeDefinition = removeMetaInfoStream(streamId,
+                            inputStreamDataHolder.getStreamDefinition(), SiddhiTopologyCreatorConstants
+                                    .SOURCE_IDENTIFIER);
+
+                    if (siddhiQueryGroup1.getParallelism() > SiddhiTopologyCreatorConstants.DEFAULT_PARALLEL) {
+                        passthroughQueriesAvailable = true;
+                        passthroughQueries.addAll(generatePassthroughQueryList(
+                                streamId, inputStreamDataHolder, runtimeDefinition));
+                        inputStreamDataHolder.setStreamDefinition(runtimeDefinition);
+                        inputStreamDataHolder.setUserGiven(false);
+
+                        InputStreamDataHolder holder1 = siddhiQueryGroup1.getInputStreams().get(streamId);
+                        String consumingStream = "${" + streamId + "} " + removeMetaInfoStream(streamId,
+                                holder1.getStreamDefinition(), SiddhiTopologyCreatorConstants.SOURCE_IDENTIFIER);
+                        holder1.setStreamDefinition(consumingStream);
+                        holder1.setUserGiven(false);
+                        createPassthrough = false;
+                    }
+
                     for (SiddhiQueryGroup siddhiQueryGroup2 : siddhiQueryGroupsList.subList(i + 1,
                             siddhiQueryGroupsList.size())) {
                         if (siddhiQueryGroup2.getInputStreams().containsKey(streamId)) {
-                            String runtimeDefinition = removeMetaInfoStream(streamId,
+                            String consumingStream = "";
+                            runtimeDefinition = removeMetaInfoStream(streamId,
                                     inputStreamDataHolder.getStreamDefinition(), SiddhiTopologyCreatorConstants
                                             .SOURCE_IDENTIFIER);
                             passthroughQueriesAvailable = true;
@@ -530,12 +551,13 @@ public class SiddhiTopologyCreatorImpl implements SiddhiTopologyCreator {
                                 inputStreamDataHolder.setUserGiven(false);
                                 createPassthrough = false;
 
+                                InputStreamDataHolder holder1 = siddhiQueryGroup1.getInputStreams().get(streamId);
+                                consumingStream = "${" + streamId + "} " + removeMetaInfoStream(streamId,
+                                        holder1.getStreamDefinition(), SiddhiTopologyCreatorConstants.SOURCE_IDENTIFIER);
+                                holder1.setStreamDefinition(consumingStream);
+                                holder1.setUserGiven(false);
+
                             }
-                            InputStreamDataHolder holder1 = siddhiQueryGroup1.getInputStreams().get(streamId);
-                            String consumingStream = "${" + streamId + "} " + removeMetaInfoStream(streamId,
-                                    holder1.getStreamDefinition(), SiddhiTopologyCreatorConstants.SOURCE_IDENTIFIER);
-                            holder1.setStreamDefinition(consumingStream);
-                            holder1.setUserGiven(false);
 
                             InputStreamDataHolder holder2 = siddhiQueryGroup2.getInputStreams().get(streamId);
                             consumingStream = "${" + streamId + "} " + removeMetaInfoStream(streamId,
@@ -564,7 +586,7 @@ public class SiddhiTopologyCreatorImpl implements SiddhiTopologyCreator {
         for (Annotation annotation : definition.getAnnotations()) {
             int parallelism = getSourceParallelism(annotation);
             SiddhiQueryGroup passthroughQueryGroup = createPassthroughQueryGroup(inputStreamDataHolder,
-                                                                                 runtimeDefinition, parallelism);
+                    runtimeDefinition, parallelism);
             passthroughQueryGroup.setReceiverQueryGroup(true);
             passthroughQueryGroupList.add(passthroughQueryGroup);
         }
@@ -620,7 +642,7 @@ public class SiddhiTopologyCreatorImpl implements SiddhiTopologyCreator {
         String passthroughExecGroupName = siddhiTopologyDataHolder.getSiddhiAppName() + "-" +
                 SiddhiTopologyCreatorConstants.PASSTHROUGH + "-" + new Random().nextInt(99999);
         SiddhiQueryGroup siddhiQueryGroup = new SiddhiQueryGroup(passthroughExecGroupName,
-                                                                 parallelism);
+                parallelism);
         String streamId = inputStreamDataHolder.getStreamName();
         Map<String, String> valuesMap = new HashMap();
         String inputStreamID = SiddhiTopologyCreatorConstants.PASSTHROUGH + inputStreamDataHolder.getStreamName();
@@ -633,12 +655,12 @@ public class SiddhiTopologyCreatorImpl implements SiddhiTopologyCreator {
         String outputStreamDefinition = "${" + streamId + "} " + runtimeDefinition;
         siddhiQueryGroup.getInputStreams()
                 .put(inputStreamID, new InputStreamDataHolder(inputStreamID,
-                                                              inputStreamDefinition, EventHolder.STREAM, true,
-                                                              new SubscriptionStrategyDataHolder(
-                                                                      SiddhiTopologyCreatorConstants.DEFAULT_PARALLEL,
-                                                                      TransportStrategy.ALL, null)));
+                        inputStreamDefinition, EventHolder.STREAM, true,
+                        new SubscriptionStrategyDataHolder(
+                                SiddhiTopologyCreatorConstants.DEFAULT_PARALLEL,
+                                TransportStrategy.ALL, null)));
         siddhiQueryGroup.getOutputStreams().put(streamId, new OutputStreamDataHolder(streamId, outputStreamDefinition,
-                                                                                     EventHolder.STREAM, false));
+                EventHolder.STREAM, false));
         return siddhiQueryGroup;
     }
 

--- a/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/topology/SubscriptionStrategyDataHolder.java
+++ b/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/topology/SubscriptionStrategyDataHolder.java
@@ -49,4 +49,8 @@ public class SubscriptionStrategyDataHolder {
     public void setOfferedParallelism(int offeredParallelism) {
         this.offeredParallelism = offeredParallelism;
     }
+
+    public void setPartitionKey(String partitionKey) {
+        this.partitionKey = partitionKey;
+    }
 }

--- a/components/org.wso2.carbon.sp.jobmanager.core/src/test/java/org/wso2/carbon/sp/jobmanager/core/SiddhiTopologyCreatorTestCase.java
+++ b/components/org.wso2.carbon.sp.jobmanager.core/src/test/java/org/wso2/carbon/sp/jobmanager/core/SiddhiTopologyCreatorTestCase.java
@@ -94,7 +94,6 @@ public class SiddhiTopologyCreatorTestCase {
                 + "@source(type='kafka', topic.list='custom_topic', group.id='1', threading.option='single.thread', "
                 + "bootstrap.servers='localhost:9092', @map(type='xml'))"
                 + "Define stream stockStream(symbol string, price float, quantity int, tier string);\n"
-                + "@Sink(type='log')\n"
                 + "Define stream takingOverStream(symbol string, overtakingSymbol string, avgPrice double);\n"
                 + "Define stream companyTriggerStream(symbol string);\n"
                 + "@Store(type='rdbms', jdbc.url='jdbc:mysql://localhost:3306/cepDB',jdbc.driver.name='', "
@@ -1003,67 +1002,7 @@ public class SiddhiTopologyCreatorTestCase {
         }
     }
 
-
-    /**
-     * when user given sources are located in one execGroup which has a parallelilsm > 1 then a passthrough query will
-     * be added in a new execGroup.Newly created execGroup will be moved to as the first element of already created
-     * passthrough queries
-     */
-    @Test
-    public void testUsergivenSourceSingleGroup() {
-        String siddhiApp = "@App:name('MB-Testcase-ptTest')\n" +
-                "@App:description('Testing the MB implementation with passthrough fix.')\n"+
-                "@source(type = 'http', receiver.url='http://localhost:8080/SweetProductionEP', @map(type = 'json'))\n"+
-                "define stream Test1Stream (name string, amount double);\n"+
-                "@sink(type='log')\n"+
-                "define stream Test2Stream (name string, amount double);\n"+
-                "@info(name = 'query1')@dist(parallel='3', execGroup='001')\n"+
-                "Partition with (name of Test1Stream)\n"+
-                "Begin\n"+
-                "from Test1Stream\n"+
-                "select name,amount\n"+
-                "insert into Test2Stream;\n"+
-                "end";
-
-        SiddhiTopologyCreatorImpl siddhiTopologyCreator = new SiddhiTopologyCreatorImpl();
-        SiddhiTopology topology = siddhiTopologyCreator.createTopology(siddhiApp);
-        SiddhiAppCreator appCreator = new SPSiddhiAppCreator();
-        List<DeployableSiddhiQueryGroup> queryGroupList = appCreator.createApps(topology);
-        Assert.assertTrue(queryGroupList.size() == 2, "Four query groups should be created");
-        Assert.assertTrue(queryGroupList.get(0).getGroupName().contains(SiddhiTopologyCreatorConstants.PASSTHROUGH),
-                "Two passthrough queries should be present in separate groups");
-        Assert.assertTrue(queryGroupList.get(0).isReceiverQueryGroup(), "Receiver type should be set");
-
-        Assert.assertTrue(queryGroupList.get(0).getSiddhiQueries().get(0).getApp().contains("@source(type = 'http'," +
-                " receiver.url='http://localhost:8080/SweetProductionEP', @map(type = 'json'))\n" +
-                "define stream passthroughTest1Stream (name string, amount double);\n" +
-                "@sink(type='kafka', topic='MB-Testcase-ptTest.Test1Stream.name' ," +
-                " bootstrap.servers='localhost:9092', @map(type='xml'), @distribution(strategy='partitioned'," +
-                " partitionKey='name', @destination(partition.no = '0'),@destination(partition.no = '1')," +
-                "@destination(partition.no = '2') )) \n" +
-                "define stream Test1Stream (name string, amount double);\n" +
-                "from passthroughTest1Stream select * insert into Test1Stream;"),"Incorrect Query created");
-
-        Assert.assertTrue(queryGroupList.get(1).getSiddhiQueries().get(0).getApp().contains("@App:name('" +
-                "MB-Testcase-ptTest-001-1') \n" +
-                "@source(type='kafka', topic.list='MB-Testcase-ptTest.Test1Stream.name'," +
-                " group.id='MB-Testcase-ptTest-001', threading.option='partition.wise'," +
-                " bootstrap.servers='localhost:9092', partition.no.list='0',@map(type='xml')) \n" +
-                "define stream Test1Stream (name string, amount double);\n" +
-                "@sink(type='log')\n" +
-                "define stream Test2Stream (name string, amount double);\n" +
-                "@info(name = 'query1')\n" +
-                "Partition with (name of Test1Stream)\n" +
-                "Begin\n" +
-                "from Test1Stream\n" +
-                "select name,amount\n" +
-                "insert into Test2Stream;\n" +
-                "end;"),"Incorrect Query Creaeted");
-
-    }
-
-
-    /**
+     /**
      * when a user defined sink stream is used as in an internal source stream, a placeholder corresponding to the
      * streamID will be added to the respective sink so that the placeholder will bridge the stream to the required
      * source.
@@ -1408,6 +1347,159 @@ public class SiddhiTopologyCreatorTestCase {
         Assert.assertTrue(queryGroupList.get(2).getGroupName().contains(SiddhiTopologyCreatorConstants.PASSTHROUGH),
                 "Two passthrough queries should be present in separate groups");
         Assert.assertTrue(queryGroupList.get(2).isReceiverQueryGroup(), "Receiver type should be set");
+
+    }
+
+    /**
+     * Test pass-through creation when multiple subscriptions R/R and Field grouping exist for user given stream.
+     */
+    @Test(dependsOnMethods = "testUsergivenParallelSources")
+    public void testPassthoughWithMultipleSubscription() {
+        String siddhiApp = "@App:name('TestPlan13')\n" +
+
+                "@source(type = 'http', receiver.url='http://localhost:8080/SweetProductionEP', @map(type = 'json'))\n"+
+                "define stream Test1Stream (name string, amount double);\n"+
+                "@sink(type='log')\n"+
+                "define stream Test2Stream (name string, amount double);\n"+
+                "@info(name = 'query2')@dist(parallel='1', execGroup='001')\n"+
+                " from Test1Stream\n"+
+                "select *\n"+
+                "insert into Test3Stream;\n"+
+                "@info(name = 'query1')@dist(parallel='3', execGroup='002')\n"+
+                "Partition with (name of Test1Stream)\n"+
+                "Begin\n"+
+                "from Test1Stream\n"+
+                "select name,amount\n"+
+                "insert into Test2Stream;\n"+
+                "end;";
+
+        SiddhiTopologyCreatorImpl siddhiTopologyCreator = new SiddhiTopologyCreatorImpl();
+        SiddhiTopology topology = siddhiTopologyCreator.createTopology(siddhiApp);
+        SiddhiAppCreator appCreator = new SPSiddhiAppCreator();
+        List<DeployableSiddhiQueryGroup> queryGroupList = appCreator.createApps(topology);
+        Assert.assertTrue(queryGroupList.size() == 3, "Three query groups should be created");
+        Assert.assertTrue(queryGroupList.get(0).getGroupName().contains(SiddhiTopologyCreatorConstants.PASSTHROUGH),
+                          "Passthrough queries should be present in separate groups");
+        Assert.assertTrue(queryGroupList.get(0).isReceiverQueryGroup(), "Receiver type should be set");
+
+        Assert.assertTrue(queryGroupList.get(0).getSiddhiQueries().get(0).getApp()
+                                  .contains("@source(type = 'http', receiver"
+                                                    + ".url='http://localhost:8080/SweetProductionEP', @map(type = "
+                                                    + "'json'))\n"
+                                                    + "define stream passthroughTest1Stream (name string, amount "
+                                                    + "double);\n"
+                                                    + "@sink(type='kafka', topic='TestPlan13.Test1Stream.name' , "
+                                                    + "bootstrap.servers='localhost:9092', @map(type='xml'), "
+                                                    + "@distribution(strategy='partitioned', partitionKey='name', "
+                                                    + "@destination(partition.no = '0'),@destination(partition.no = "
+                                                    + "'1'),@destination(partition.no = '2') )) \n"
+                                                    + "define stream Test1Stream (name string, amount double);\n"
+                                                    + "from passthroughTest1Stream select * insert into Test1Stream;"),
+                          "Incorrect Query created");
+
+        Assert.assertTrue(queryGroupList.get(1).getSiddhiQueries().get(0).getApp()
+                                  .contains("@source(type='kafka', topic.list='TestPlan13.Test1Stream"
+                                                    + ".name', group.id='TestPlan13-001-0', threading.option='single"
+                                                    + ".thread', bootstrap.servers='localhost:9092', @map(type='xml')"
+                                                    + ") \n"
+                                                    + "define stream Test1Stream (name string, amount double);\n"
+                                                    + "define stream Test3Stream (name string, amount double);\n"
+                                                    + "@info(name = 'query2')\n"
+                                                    + " from Test1Stream\n"
+                                                    + "select *\n"
+                                                    + "insert into Test3Stream;"),"Incorrect Query Created");
+
+        Assert.assertTrue(queryGroupList.get(2).getSiddhiQueries().get(0).getApp()
+                                  .contains("@source(type='kafka', topic.list='TestPlan13.Test1Stream"
+                                                    + ".name', group.id='TestPlan13-002', threading.option='partition"
+                                                    + ".wise', bootstrap.servers='localhost:9092', partition.no"
+                                                    + ".list='0',@map(type='xml')) \n"
+                                                    + "define stream Test1Stream (name string, amount double);\n"
+                                                    + "@sink(type='log')\n"
+                                                    + "define stream Test2Stream (name string, amount double);\n"
+                                                    + "@info(name = 'query1')\n"
+                                                    + "Partition with (name of Test1Stream)\n"
+                                                    + "Begin\n"
+                                                    + "from Test1Stream\n"
+                                                    + "select name,amount\n"
+                                                    + "insert into Test2Stream;\n"
+                                                    + "end;"),"Incorrect Query Created");
+
+    }
+
+    /**
+     * when user given sources are located in one execGroup which has a parallelilsm > 1 then a passthrough query will
+     * be added in a new execGroup.Newly created execGroup will be moved to as the first element of already created
+     * passthrough queries
+     */
+    @Test(dependsOnMethods = "testPassthoughWithMultipleSubscription")
+    public void testUsergivenSourceSingleGroup() {
+        String siddhiApp = "@App:name('MB-Testcase-ptTest')\n" +
+                "@App:description('Testing the MB implementation with passthrough fix.')\n"+
+                "@source(type = 'http', receiver.url='http://localhost:8080/SweetProductionEP', @map(type = 'json'))\n"+
+                "define stream Test1Stream (name string, amount double);\n"+
+                "@sink(type='log')\n"+
+                "define stream Test2Stream (name string, amount double);\n"+
+                "@info(name = 'query1')@dist(parallel='3', execGroup='001')\n"+
+                "Partition with (name of Test1Stream)\n"+
+                "Begin\n"+
+                "from Test1Stream\n"+
+                "select name,amount\n"+
+                "insert into Test2Stream;\n"+
+                "end";
+
+        SiddhiTopologyCreatorImpl siddhiTopologyCreator = new SiddhiTopologyCreatorImpl();
+        SiddhiTopology topology = siddhiTopologyCreator.createTopology(siddhiApp);
+        SiddhiAppCreator appCreator = new SPSiddhiAppCreator();
+        List<DeployableSiddhiQueryGroup> queryGroupList = appCreator.createApps(topology);
+        Assert.assertTrue(queryGroupList.size() == 2, "Four query groups should be created");
+        Assert.assertTrue(queryGroupList.get(0).getGroupName().contains(SiddhiTopologyCreatorConstants.PASSTHROUGH),
+                          "Two passthrough queries should be present in separate groups");
+        Assert.assertTrue(queryGroupList.get(0).isReceiverQueryGroup(), "Receiver type should be set");
+
+        Assert.assertTrue(queryGroupList.get(0).getSiddhiQueries().get(0).getApp()
+                                  .contains("@source(type = 'http'," +
+                                                    " receiver.url='http://localhost:8080/SweetProductionEP', @map"
+                                                    + "(type = 'json'))\n"
+                                                    +
+                                                    "define stream passthroughTest1Stream (name string, amount "
+                                                    + "double);\n"
+                                                    +
+                                                    "@sink(type='kafka', topic='MB-Testcase-ptTest.Test1Stream.name' ,"
+                                                    +
+                                                    " bootstrap.servers='localhost:9092', @map(type='xml'), "
+                                                    + "@distribution(strategy='partitioned',"
+                                                    +
+                                                    " partitionKey='name', @destination(partition.no = '0'),"
+                                                    + "@destination(partition.no = '1'),"
+                                                    +
+                                                    "@destination(partition.no = '2') )) \n" +
+                                                    "define stream Test1Stream (name string, amount double);\n" +
+                                                    "from passthroughTest1Stream select * insert into Test1Stream;"),
+                          "Incorrect Query created");
+
+        Assert.assertTrue(queryGroupList.get(1).getSiddhiQueries().get(0).getApp()
+                                  .contains("@App:name('" +
+                                                    "MB-Testcase-ptTest-001-1') \n" +
+                                                    "@source(type='kafka', topic.list='MB-Testcase-ptTest.Test1Stream"
+                                                    + ".name',"
+                                                    +
+                                                    " group.id='MB-Testcase-ptTest-001', threading.option='partition"
+                                                    + ".wise',"
+                                                    +
+                                                    " bootstrap.servers='localhost:9092', partition.no.list='0',@map"
+                                                    + "(type='xml')) \n"
+                                                    +
+                                                    "define stream Test1Stream (name string, amount double);\n" +
+                                                    "@sink(type='log')\n" +
+                                                    "define stream Test2Stream (name string, amount double);\n" +
+                                                    "@info(name = 'query1')\n" +
+                                                    "Partition with (name of Test1Stream)\n" +
+                                                    "Begin\n" +
+                                                    "from Test1Stream\n" +
+                                                    "select name,amount\n" +
+                                                    "insert into Test2Stream;\n" +
+                                                    "end;"), "Incorrect Query Created");
 
     }
 


### PR DESCRIPTION
## Purpose
This will solve the issue related to the passthrough query group creation in siddhi topology. When a user defined siddhi source is used by a single execution group which has parallel attribute more than one then a pass-through query should be created. That was not handled in topology creation. This PR fixes that issue.

## Goals
The fix includes the scenario and particular pass-through query will be created to that.

## Approach
Relevant logic for the scenario included to the code base.

## Automation tests
 - Unit tests 
   Added unit tests

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 1.8.0
