### PR TITLE
Add debounce when creating parse tree on editor change

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/source-editor/editor.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/source-editor/editor.js
@@ -489,11 +489,15 @@ define(["ace/ace", "jquery", "./constants", "./utils", "./completion-engine", ".
              *
              * @param {string} editorText Text in the editor after the change
              */
+            var editorChangeDelayTimer;
             self.onEditorChange = function (editorText) {
-                worker.postMessage(JSON.stringify({
-                    type: constants.worker.EDITOR_CHANGE_EVENT,
-                    data: editorText
-                }));
+                clearTimeout(editorChangeDelayTimer);
+                editorChangeDelayTimer = setTimeout(function () {
+                    worker.postMessage(JSON.stringify({
+                        type: constants.worker.EDITOR_CHANGE_EVENT,
+                        data: editorText
+                    }));
+                }, 2000);
             };
 
             /**


### PR DESCRIPTION
## Purpose
For every change in editor, parse tree is generated and it consumes high CPU, adding a debounce with 2 second delay to reduce the frequency.
#https://github.com/wso2/product-sp/issues/755

