### PR TITLE
fix column loading issue in db simulation

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
@@ -816,7 +816,7 @@
             <label class="custom-radio">
                 <input type="radio" name="timestamp-option" value="attribute">
                 <span class="helper">Timestamp Attribute</span>
-                <select name="timestamp-attribute" class="form-control" disabled></select>
+                <select name="timestamp-attribute" class="form-control feed-attribute-db" disabled></select>
                 <!--<input type="text" class="form-control" name="timestamp-attribute" disabled>-->
             </label>
         </div>


### PR DESCRIPTION
## Purpose
> Fixing issue https://github.com/wso2/product-sp/issues/854

## Goals
> Fix 'Timestamp attribute' in the feed config is not editable when configuring Database simulation.

## Approach
> Columns are populated using a class added to the select element. Added the class to the timestamp select as well.