### PR TITLE
Add MySQL, H2, MSSQL, Oracle, PostgreSQL support for distributed deployment

### DIFF
--- a/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/bean/DeploymentConfig.java
+++ b/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/bean/DeploymentConfig.java
@@ -20,8 +20,10 @@ package org.wso2.carbon.sp.jobmanager.core.bean;
 
 import org.wso2.carbon.config.annotation.Configuration;
 import org.wso2.carbon.config.annotation.Element;
+import org.wso2.carbon.database.query.manager.config.Queries;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 
 /**
  * This class represents the deployment configuration for distributed deployment.
@@ -54,6 +56,8 @@ public class DeploymentConfig implements Serializable {
     private String factoryInitial;
     @Element(description = "provider url configuration for siddhi-jms-io")
     private String providerUrl;
+    @Element(description = "Database queries template array list.")
+    private ArrayList<Queries> queries = new ArrayList<>();
 
     public String getProviderUrl() {
         return providerUrl;
@@ -150,4 +154,13 @@ public class DeploymentConfig implements Serializable {
     public void setAllocationAlgorithm(String allocationAlgorithm) {
         this.allocationAlgorithm = allocationAlgorithm;
     }
+
+    public ArrayList<Queries> getQueries() {
+        return queries;
+    }
+
+    public void setQueries(ArrayList<Queries> queries) {
+        this.queries = queries;
+    }
+
 }

--- a/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/bean/DeploymentConfig.java
+++ b/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/bean/DeploymentConfig.java
@@ -24,6 +24,7 @@ import org.wso2.carbon.database.query.manager.config.Queries;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * This class represents the deployment configuration for distributed deployment.
@@ -57,7 +58,7 @@ public class DeploymentConfig implements Serializable {
     @Element(description = "provider url configuration for siddhi-jms-io")
     private String providerUrl;
     @Element(description = "Database queries template array list.")
-    private ArrayList<Queries> queries = new ArrayList<>();
+    private List<Queries> queries = new ArrayList<>();
 
     public String getProviderUrl() {
         return providerUrl;
@@ -155,11 +156,11 @@ public class DeploymentConfig implements Serializable {
         this.allocationAlgorithm = allocationAlgorithm;
     }
 
-    public ArrayList<Queries> getQueries() {
+    public List<Queries> getQueries() {
         return queries;
     }
 
-    public void setQueries(ArrayList<Queries> queries) {
+    public void setQueries(List<Queries> queries) {
         this.queries = queries;
     }
 

--- a/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/impl/RDBMSServiceImpl.java
+++ b/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/impl/RDBMSServiceImpl.java
@@ -68,19 +68,20 @@ public class RDBMSServiceImpl {
     public RDBMSServiceImpl() {
         List<Queries> deploymentQueries = ServiceDataHolder.getDeploymentConfig().getQueries();
         List<Queries> componentQueries = new ArrayList<Queries>();
-        URL url = this.getClass().getClassLoader().getResource("queries.yaml");
+        URL url = this.getClass().getClassLoader().getResource(ResourceManagerConstants.QUERY_YAML_FILE_NAME);
         if (url != null) {
             DeploymentConfig componentConfigurations = null;
             try {
                 componentConfigurations = readYamlContent(url.openStream());
             } catch (IOException e) {
-                throw new RuntimeException("Unable to read queries.yaml file.");
+                throw new ResourceManagerException("Unable to read " + ResourceManagerConstants.QUERY_YAML_FILE_NAME +
+                        " file.");
             }
             if (componentConfigurations != null) {
                 componentQueries = componentConfigurations.getQueries();
             }
         } else {
-            throw new RuntimeException("Unable to load queries.yaml file from resources.");
+            throw new ResourceManagerException("Unable to load queries.yaml file from resources.");
         }
         String datasourceName = ServiceDataHolder.getDeploymentConfig().getDatasource();
         if (datasourceName == null) {
@@ -99,9 +100,11 @@ public class RDBMSServiceImpl {
         Connection conn = null;
         try {
             conn = this.datasource.getConnection();
-            queries = QueryProvider.mergeMapping(conn.getMetaData().getDatabaseProductName(), conn.getMetaData().getDatabaseProductVersion(), componentQueries, deploymentQueries);
+            queries = QueryProvider.mergeMapping(conn.getMetaData().getDatabaseProductName(),
+                    conn.getMetaData().getDatabaseProductVersion(), componentQueries, deploymentQueries);
         } catch (QueryMappingNotAvailableException e) {
-            throw new ResourceManagerException("Error in getting the mapping query. Please check queries under deployment.config in deployment.yaml", e);
+            throw new ResourceManagerException("Error in getting the mapping query. Please check queries under " +
+                    "deployment.config in deployment.yaml", e);
         } catch (SQLException e) {
             throw new ResourceManagerException("Error when getting connection for SP_MGT_DB datasource", e);
         } finally {

--- a/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/util/ResourceManagerConstants.java
+++ b/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/util/ResourceManagerConstants.java
@@ -143,4 +143,6 @@ public class ResourceManagerConstants {
 
     public static final String PS_SELECT_RESOURCE_MAPPING_ROW = "ps_select_resource_mapping_row";
 
+    public static final String QUERY_YAML_FILE_NAME = "queries.yaml";
+
 }

--- a/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/util/ResourceManagerConstants.java
+++ b/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/util/ResourceManagerConstants.java
@@ -133,16 +133,14 @@ public class ResourceManagerConstants {
 
     public static final String TASK_GET_RESOURCE_MAPPING = "Getting resource mapping group";
 
-    public static final String CREATE_RESOURCE_MAPPING_TABLE =
-            "CREATE TABLE IF NOT EXISTS RESOURCE_POOL_TABLE (\n"
-                    + "                        GROUP_ID VARCHAR(512) NOT NULL,\n"
-                    + "                        RESOURCE_MAPPING BLOB NOT NULL,\n"
-                    + "                        PRIMARY KEY (GROUP_ID)\n" + ");\n";
+    public static final String CREATE_RESOURCE_MAPPING_TABLE = "create_resource_mapping_table";
 
-    public static final String PS_REPLACE_RESOURCE_MAPPING_ROW =
-            "REPLACE INTO RESOURCE_POOL_TABLE (GROUP_ID, RESOURCE_MAPPING) VALUES (?,?);";
+    public static final String CHECK_FOR_RESOURCE_MAPPING_TABLE = "check_for_resource_mapping_table";
 
-    public static final String PS_SELECT_RESOURCE_MAPPING_ROW =
-            "SELECT GROUP_ID, RESOURCE_MAPPING FROM RESOURCE_POOL_TABLE WHERE GROUP_ID =?";
+    public static final String PS_DELETE_RESOURCE_MAPPING_ROW = "ps_delete_resource_mapping_row";
+
+    public static final String PS_INSERT_RESOURCE_MAPPING_ROW = "ps_insert_resource_mapping_row";
+
+    public static final String PS_SELECT_RESOURCE_MAPPING_ROW = "ps_select_resource_mapping_row";
 
 }

--- a/components/org.wso2.carbon.sp.jobmanager.core/src/main/resources/queries.yaml
+++ b/components/org.wso2.carbon.sp.jobmanager.core/src/main/resources/queries.yaml
@@ -1,0 +1,55 @@
+queries:
+  -
+    mappings:
+      check_for_resource_mapping_table: ~
+      create_resource_mapping_table: ~
+      ps_delete_resource_mapping_row: ~
+      ps_insert_resource_mapping_row: ~
+      ps_select_resource_mapping_row: ~
+    type: default
+    version: default
+  -
+    mappings:
+      check_for_resource_mapping_table: "SELECT 1 FROM RESOURCE_POOL_TABLE"
+      create_resource_mapping_table: "CREATE TABLE RESOURCE_POOL_TABLE (GROUP_ID VARCHAR(512) NOT NULL, RESOURCE_MAPPING BLOB NOT NULL, PRIMARY KEY (GROUP_ID))"
+      ps_delete_resource_mapping_row: "DELETE FROM RESOURCE_POOL_TABLE WHERE GROUP_ID = ?"
+      ps_insert_resource_mapping_row: "INSERT INTO RESOURCE_POOL_TABLE (GROUP_ID, RESOURCE_MAPPING) VALUES (?,?)"
+      ps_select_resource_mapping_row: "SELECT GROUP_ID, RESOURCE_MAPPING FROM RESOURCE_POOL_TABLE WHERE GROUP_ID =?"
+    type: H2
+    version: default
+  -
+    mappings:
+      check_for_resource_mapping_table: "SELECT 1 FROM RESOURCE_POOL_TABLE"
+      create_resource_mapping_table: "CREATE TABLE RESOURCE_POOL_TABLE (GROUP_ID VARCHAR(512) NOT NULL, RESOURCE_MAPPING BLOB NOT NULL, PRIMARY KEY (GROUP_ID))"
+      ps_delete_resource_mapping_row: "DELETE FROM RESOURCE_POOL_TABLE WHERE GROUP_ID = ?"
+      ps_insert_resource_mapping_row: "INSERT INTO RESOURCE_POOL_TABLE (GROUP_ID, RESOURCE_MAPPING) VALUES (?,?)"
+      ps_select_resource_mapping_row: "SELECT GROUP_ID, RESOURCE_MAPPING FROM RESOURCE_POOL_TABLE WHERE GROUP_ID =?"
+    type: MySQL
+    version: default
+  -
+    mappings:
+      check_for_resource_mapping_table: "SELECT 1 FROM resource_pool_table"
+      create_resource_mapping_table: "CREATE TABLE resource_pool_table (group_id text PRIMARY KEY, resource_mapping bytea NOT NULL)"
+      ps_delete_resource_mapping_row: "DELETE FROM resource_pool_table WHERE GROUP_ID = ?"
+      ps_insert_resource_mapping_row: "INSERT INTO resource_pool_table (GROUP_ID, RESOURCE_MAPPING) VALUES (?,?)"
+      ps_select_resource_mapping_row: "SELECT GROUP_ID, RESOURCE_MAPPING FROM resource_pool_table WHERE GROUP_ID =?"
+    type: PostgreSQL
+    version: default
+  -
+    mappings:
+      check_for_resource_mapping_table: "SELECT 1 FROM RESOURCE_POOL_TABLE"
+      create_resource_mapping_table: "CREATE TABLE RESOURCE_POOL_TABLE (GROUP_ID VARCHAR(512) NOT NULL, RESOURCE_MAPPING BLOB NOT NULL, PRIMARY KEY (GROUP_ID))"
+      ps_delete_resource_mapping_row: "DELETE FROM RESOURCE_POOL_TABLE WHERE GROUP_ID = ?"
+      ps_insert_resource_mapping_row: "INSERT INTO RESOURCE_POOL_TABLE (GROUP_ID, RESOURCE_MAPPING) VALUES (?,?)"
+      ps_select_resource_mapping_row: "SELECT GROUP_ID, RESOURCE_MAPPING FROM RESOURCE_POOL_TABLE WHERE GROUP_ID =?"
+    type: Oracle
+    version: default
+  -
+    mappings:
+      check_for_resource_mapping_table: "SELECT 1 FROM RESOURCE_POOL_TABLE"
+      create_resource_mapping_table: "CREATE TABLE  RESOURCE_POOL_TABLE (GROUP_ID VARCHAR(512) NOT NULL, RESOURCE_MAPPING varbinary(MAX) NOT NULL, PRIMARY KEY (GROUP_ID))"
+      ps_delete_resource_mapping_row: "DELETE FROM RESOURCE_POOL_TABLE WHERE GROUP_ID = ?"
+      ps_insert_resource_mapping_row: "INSERT INTO RESOURCE_POOL_TABLE (GROUP_ID, RESOURCE_MAPPING) VALUES (?,?)"
+      ps_select_resource_mapping_row: "SELECT GROUP_ID, RESOURCE_MAPPING FROM RESOURCE_POOL_TABLE WHERE GROUP_ID =?"
+    type: Microsoft SQL Server
+    version: default

--- a/pom.xml
+++ b/pom.xml
@@ -1539,7 +1539,7 @@
         <siddhi.version>4.2.26</siddhi.version>
         <siddhi.bundle.version>4.2.26</siddhi.bundle.version>
         <siddhi.version.range>[4.0.0, 5.0.0)</siddhi.version.range>
-        <carbon.analytics-common.version>6.0.70</carbon.analytics-common.version>
+        <carbon.analytics-common.version>6.0.71</carbon.analytics-common.version>
         <carbon.analytics-common.version.range>[6.0.66, 6.1.0)</carbon.analytics-common.version.range>
         <carbon.analytics.version.range>[2.0.0, 3.0.0)</carbon.analytics.version.range>
 


### PR DESCRIPTION
## Purpose
> Add MySQL, H2, MSSQL, Oracle, PostgreSQL support for distributed deployment

## Goals
> The user can configure the distributed deployment with above mentioned databases, as well as by adding queries which supports other databases by adding the details to "queries" section in "deployment.config" in manager config's deployment.yaml.
