### PR TITLE
Change siddhi import sample view and add sample search feature.

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/Workspace.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/Workspace.java
@@ -22,6 +22,7 @@ import com.google.gson.JsonObject;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Map;
 
 /**
  * Interface for the workspace related functionality.
@@ -102,4 +103,11 @@ public interface Workspace {
      */
     void log(String logger, String timestamp, String level, String URL, String message, String layout)
             throws IOException;
+
+    /**
+     * List the samples in the given path with descriptions
+     * @param sampleMap provided sample map
+     * @return samples with descriptions
+     */
+    JsonArray listSamplesInPath(Map<String, String> sampleMap);
 }

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/EditorDataHolder.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/EditorDataHolder.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.siddhi.editor.core.internal;
 import org.osgi.framework.BundleContext;
 import org.wso2.siddhi.core.SiddhiManager;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -33,6 +34,7 @@ public class EditorDataHolder {
     private static BundleContext bundleContext;
     private static DebugProcessorService debugProcessorService;
     private static Map<String, DebugRuntime> siddhiAppMap = new ConcurrentHashMap<>();
+    private static Map<String, String> siddhiSampleMap = Collections.emptyMap();
 
     private EditorDataHolder() {
 
@@ -68,5 +70,13 @@ public class EditorDataHolder {
 
     public static void setBundleContext(BundleContext bundleContext) {
         EditorDataHolder.bundleContext = bundleContext;
+    }
+
+    public static Map<String, String> getSiddhiSampleMap() {
+        return siddhiSampleMap;
+    }
+
+    public static void setSiddhiSampleMap(Map<String, String> siddhiSampleMap) {
+        EditorDataHolder.siddhiSampleMap = siddhiSampleMap;
     }
 }

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/EditorMicroservice.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/EditorMicroservice.java
@@ -79,6 +79,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.AccessDeniedException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/EditorMicroservice.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/EditorMicroservice.java
@@ -79,7 +79,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.AccessDeniedException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -892,7 +891,7 @@ public class EditorMicroservice implements Microservice {
                 new EditorSiddhiAppRuntimeService(), null);
         serviceRegistration = bundleContext.registerService(EventStreamService.class.getName(),
                 new DebuggerEventStreamService(), null);
-        getSampleFiles();
+        loadSampleFiles();
     }
 
     /**
@@ -949,7 +948,7 @@ public class EditorMicroservice implements Microservice {
         this.configProvider = null;
     }
 
-    protected void getSampleFiles() {
+    protected void loadSampleFiles() {
         String location = (Paths.get(Constants.CARBON_HOME, Constants.DIRECTORY_SAMPLE,
                 Constants.DIRECTORY_ARTIFACTS)).toString();
         String relativePath = "";

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/EditorMicroservice.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/EditorMicroservice.java
@@ -960,7 +960,7 @@ public class EditorMicroservice implements Microservice {
         String regex = "@[Aa][Pp][Pp]:[Dd][Ee][Ss][Cc][Rr][Ii][Pp][Tt][Ii][Oo][Nn]\\(['|\"](.*?)['|\"]\\)";
         Pattern pattern = Pattern.compile(regex);
         try {
-            Map<String,String> sampleMap=new HashMap<>();
+            Map<String, String> sampleMap = new HashMap<>();
             List<java.nio.file.Path> collect = Files.walk(pathLocation)
                     .filter(s -> s.toString().endsWith(".siddhi"))
                     .sorted()
@@ -973,12 +973,12 @@ public class EditorMicroservice implements Microservice {
                     String description = matcher.group();
                     descriptionText = description.substring(description.indexOf("(") + 1, description.lastIndexOf(")"));
                 }
-                java.nio.file.Path relativeSamplePath=pathLocation.relativize(path);
-                sampleMap.put(relativeSamplePath.toString(),descriptionText);
+                java.nio.file.Path relativeSamplePath = pathLocation.relativize(path);
+                sampleMap.put(relativeSamplePath.toString(), descriptionText);
             }
             EditorDataHolder.setSiddhiSampleMap(sampleMap);
         } catch (IOException e) {
-            log.error("Error while reading the sample descriptions.",e);
+            log.error("Error while reading the sample descriptions.", e);
         }
     }
 }

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/local/LocalFSWorkspace.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/local/LocalFSWorkspace.java
@@ -35,6 +35,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Comparator;
 import java.util.Iterator;
+import java.util.Map;
 
 /**
  * Workspace implementation for local file system.
@@ -232,5 +233,16 @@ public class LocalFSWorkspace implements Workspace {
         result.addProperty("file", path.toString());
         result.addProperty("exists", exists);
         return result;
+    }
+
+    public JsonArray listSamplesInPath(Map<String, String> sampleMap) {
+        JsonArray samples = new JsonArray();
+        sampleMap.entrySet().stream().forEach(entry -> {
+            JsonObject sampleObject = new JsonObject();
+            sampleObject.addProperty("path", entry.getKey());
+            sampleObject.addProperty("description", entry.getValue());
+            samples.add(sampleObject);
+        });
+        return samples;
     }
 }

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/css/fileDialog.css
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/css/fileDialog.css
@@ -21,6 +21,16 @@
     color: #fff;
 }
 
+.search-file-dialog-form-control{
+    width: 90%;
+    margin-left: 30px;
+    background-color: #2C2C2C;
+    border-style: none;
+    height: 35px;
+    padding-left: 10px;
+    color: #fff;
+}
+
 .file-dialog-form-scrollable-block{
     padding: 20px 20px;
     overflow: auto;

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/css/fileDialog.css
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/css/fileDialog.css
@@ -23,7 +23,7 @@
 
 .search-file-dialog-form-control{
     width: 90%;
-    margin-left: 30px;
+    margin-left: 35px;
     background-color: #2C2C2C;
     border-style: none;
     height: 35px;

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/dialog/open-sample-file-dialog.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/dialog/open-sample-file-dialog.js
@@ -65,7 +65,7 @@ define(['require', 'lodash','jquery', 'log', 'backbone', 'file_browser', 'worksp
                     "<span aria-hidden='true'>&times;</span>" +
                     "</button>" +
                     "<h4 class='modal-title file-dialog-title'>Import Sample</h4>" +
-                    "<hr class='style1'>"+
+                    "<hr class='style1'>" +
                     "</div>" +
                     "<div class='modal-body'>" +
                     "<div class='container-fluid'>" +
@@ -124,42 +124,41 @@ define(['require', 'lodash','jquery', 'log', 'backbone', 'file_browser', 'worksp
                 var openSampleConfigModal = sampleFileOpen.filter("#openSampleConfigModal");
                 var openFileWizardError = sampleFileOpen.find("#openFileWizardError");
                 var location = sampleFileOpen.find("input").filter("#location");
-                var locationSearch= sampleFileOpen.find("input").filter("#locationSearch");
+                var locationSearch = sampleFileOpen.find("input").filter("#locationSearch");
 
-                var treeContainer  = sampleFileOpen.find("div").filter("#sampleTable");
+                var treeContainer = sampleFileOpen.find("div").filter("#sampleTable");
                 var bodyUlSampleContent = $('<ul class="recent-files clearfix"></ul>');
                 bodyUlSampleContent.attr('id', "sampleList");
-                var browserStorage = app.browserStorage;
                 var workspaceServiceURL = app.config.services.workspace.endpoint;
                 var getSampleDescServiceURL = workspaceServiceURL + "/listFiles/samples/descriptions";
-                var samplesWithDes={};
+                var samplesWithDes = {};
 
-                 $.ajax({
+                $.ajax({
                     type: "GET",
                     contentType: "json",
                     url: getSampleDescServiceURL,
                     async: false,
-                    success: function(data) {
-                        samplesWithDes=data;
+                    success: function (data) {
+                        samplesWithDes = data;
                     },
-                    error: function(e) {
+                    error: function (e) {
                         alertError("Unable to read a sample file.");
                         throw "Unable to read a sample file.";
                     }
 
                 });
 
-                samplesWithDes.forEach(function(sample){
-                    var sampleName=sample.path;
+                samplesWithDes.forEach(function (sample) {
+                    var sampleName = sample.path;
                     var config =
                         {
-                            "sampleName":  ((sampleName.substring(sampleName.lastIndexOf('/')+1)).split(".siddhi"))[0],
-                            "sampleDes":sample.description,
+                            "sampleName": ((sampleName.substring(sampleName.lastIndexOf('/') + 1)).split(".siddhi"))[0],
+                            "sampleDes": sample.description,
                             "parentContainer": bodyUlSampleContent,
                             "firstItem": true,
                             "clickEventCallback": function (event) {
                                 event.preventDefault();
-                                var payload=sampleName;
+                                var payload = sampleName;
                                 openSample(payload);
                             }
                         };
@@ -168,8 +167,8 @@ define(['require', 'lodash','jquery', 'log', 'backbone', 'file_browser', 'worksp
                     treeContainer.append(bodyUlSampleContent);
                 });
 
-                locationSearch.keyup(function(){
-                    var searchText= locationSearch.val();
+                locationSearch.keyup(function () {
+                    var searchText = locationSearch.val();
                     searchSample(bodyUlSampleContent, searchText);
                 });
 
@@ -246,8 +245,8 @@ define(['require', 'lodash','jquery', 'log', 'backbone', 'file_browser', 'worksp
                     });
                 };
 
-                 function openSample(payload) {
-                    var fileRelativeLocation = "artifacts" +self.app.getPathSeperator() +payload
+                function openSample(payload) {
+                    var fileRelativeLocation = "artifacts" + self.app.getPathSeperator() + payload;
                     var workspaceServiceURL = app.config.services.workspace.endpoint;
                     var openSampleServiceURL = workspaceServiceURL + "/read/sample";
                     var browserStorage = app.browserStorage;
@@ -262,7 +261,7 @@ define(['require', 'lodash','jquery', 'log', 'backbone', 'file_browser', 'worksp
                             if (xhr.status == 200) {
                                 var file = new File({
                                     content: data.content
-                                },{
+                                }, {
                                     storage: browserStorage
                                 });
                                 openSampleConfigModal.modal('hide');
@@ -274,9 +273,9 @@ define(['require', 'lodash','jquery', 'log', 'backbone', 'file_browser', 'worksp
                         },
                         error: function (res, errorCode, error) {
                             var msg = _.isString(error) ? error : res.statusText;
-                            if(isJsonString(res.responseText)){
+                            if (isJsonString(res.responseText)) {
                                 var resObj = JSON.parse(res.responseText);
-                                if(_.has(resObj, 'Error')){
+                                if (_.has(resObj, 'Error')) {
                                     msg = _.get(resObj, 'Error');
                                 }
                             }
@@ -286,21 +285,21 @@ define(['require', 'lodash','jquery', 'log', 'backbone', 'file_browser', 'worksp
                     });
                 };
 
-                function searchSample(sampleContent,searchText){
+                function searchSample(sampleContent, searchText) {
                     var filter = searchText.toUpperCase();
                     var sampleElements = sampleContent[0].getElementsByTagName("li");
-                    var noResultsElement  = sampleFileOpen.find("div").filter("#noResults");
-                    var unmatchedCount=0;
+                    var noResultsElement = sampleFileOpen.find("div").filter("#noResults");
+                    var unmatchedCount = 0;
                     for (var i = 0; i < sampleElements.length; i++) {
                         var sampleElement = sampleElements[i].getElementsByTagName("a")[0];
-                        if (sampleElement.innerText.toUpperCase().indexOf(filter) > -1){
+                        if (sampleElement.innerText.toUpperCase().indexOf(filter) > -1) {
                             sampleElements[i].style.display = "";
                         } else {
                             sampleElements[i].style.display = "none";
-                            unmatchedCount+=1;
+                            unmatchedCount += 1;
                         }
                     }
-                    var isMatched= (unmatchedCount===sampleElements.length);
+                    var isMatched = (unmatchedCount === sampleElements.length);
                     noResultsElement.toggle(isMatched);
                 }
             },

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/dialog/open-sample-file-dialog.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/dialog/open-sample-file-dialog.js
@@ -72,10 +72,10 @@ define(['require', 'lodash','jquery', 'log', 'backbone', 'file_browser', 'worksp
                     "<form class='form-horizontal' onsubmit='return false'>" +
                     "<div class='form-group'>" +
                     "<label for='locationSearch' class='col-sm-2 file-dialog-label'>Search :</label>" +
-                    "<input type='text' class='search-file-dialog-form-control' id='locationSearch'>" +
+                    "<input type='text' class='search-file-dialog-form-control' id='locationSearch' autofocus>" +
                     "</div>" +
                     "<div class='form-group'>" +
-                    "<div class='file-dialog-form-scrollable-block'>" +
+                    "<div class='file-dialog-form-scrollable-block' style='padding: 10px 4px; margin-left:35px;'>" +
                     "<div id='noResults' style='display:none;'>No results found</div>" +
                     "<div id='sampleTable' class='samples-pane'>" +
                     "</div>" +

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
@@ -1233,6 +1233,7 @@
             source_modify_operation: "commons/js/undo-manager/source-modify-operation",
             undoable_operation: "commons/js/undo-manager/undoable-operation",
             sample_preview: "js/sample-preview/sample-preview-view",
+            sample_view: "js/sample-view/sample-view",
             output_console_list: "js/output-console/console-list",
             console: "js/output-console/console",
             service_console: "js/output-console/service-console-manager",

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/sample-view/sample-view.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/sample-view/sample-view.js
@@ -16,14 +16,11 @@
  * under the License.
  */
 
-define(['require', 'jquery', 'lodash','log'], function (require, $,  _,log) {
-
-    var ServiceView = function(config){
+define(['require', 'jquery', 'lodash', 'log'], function (require, $, _, log) {
+    var ServiceView = function (config) {
         this._config = config;
     };
-
     ServiceView.prototype.constructor = ServiceView;
-
     ServiceView.prototype.render = function () {
         var config = this._config;
         var errMsg;
@@ -34,24 +31,19 @@ define(['require', 'jquery', 'lodash','log'], function (require, $,  _,log) {
         }
         // get parent container which is innerSamples div
         var parentContainer = _.get(config, 'parentContainer');
-
         this._sampleName = config.sampleName;
         this._content = config.sampleDes;
 
         //create the parent for drawn svg
         var sampleLi = $("<li class='col-md-6'></li>");
-
         var linkSample = $("<a href='#' style='height: 100px;display: block;'></a>");
         linkSample.text(this._sampleName);
         linkSample.bind('click', config.clickEventCallback);
 
-        var description = "<span class='description'>" + this._content +"</span>";
+        var description = "<span class='description'>" + this._content + "</span>";
         linkSample.append(description);
-
         sampleLi.append(linkSample);
         parentContainer.append(sampleLi);
     };
-
     return ServiceView;
-
 });

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/sample-view/sample-view.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/sample-view/sample-view.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+define(['require', 'jquery', 'lodash','log'], function (require, $,  _,log) {
+
+    var ServiceView = function(config){
+        this._config = config;
+    };
+
+    ServiceView.prototype.constructor = ServiceView;
+
+    ServiceView.prototype.render = function () {
+        var config = this._config;
+        var errMsg;
+        if (!_.has(config, 'parentContainer')) {
+            errMsg = 'unable to find configuration for parentContainer';
+            log.error(errMsg);
+            throw errMsg;
+        }
+        // get parent container which is innerSamples div
+        var parentContainer = _.get(config, 'parentContainer');
+
+        this._sampleName = config.sampleName;
+        this._content = config.sampleDes;
+
+        //create the parent for drawn svg
+        var sampleLi = $("<li class='col-md-6'></li>");
+
+        var linkSample = $("<a href='#' style='height: 100px;display: block;'></a>");
+        linkSample.text(this._sampleName);
+        linkSample.bind('click', config.clickEventCallback);
+
+        var description = "<span class='description'>" + this._content +"</span>";
+        linkSample.append(description);
+
+        sampleLi.append(linkSample);
+        parentContainer.append(sampleLi);
+    };
+
+    return ServiceView;
+
+});


### PR DESCRIPTION
## Purpose
Change the current siddhi import sample dialog view from jsTree to a table with the sample description included and add the search feature for the samples.

## Goals
User should be able to import the siddhi samples via a table view.
User should be able to view the siddhi samples with their descriptions.
User should be able to search the siddhi samples.

## Approach
Converting the jsTree view into table view.
Adding the descriptions along with the siddhi samples.
Adding the search bar to filter the siddhi samples by the sample title and description.

The new siddhi import sample dialog view is as follows.

![screenshot from 2018-11-21 08-51-14](https://user-images.githubusercontent.com/25476980/48817130-f060eb80-ed6a-11e8-991c-ce38e2783be6.png)
