### PR TITLE
[Editor] Export Siddhi files as a Docker

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/commons/configs/DockerConfigs.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/commons/configs/DockerConfigs.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.siddhi.editor.core.commons.configs;
+
+import org.wso2.carbon.config.annotation.Configuration;
+import org.wso2.carbon.config.annotation.Element;
+
+/**
+ * Represents Docker configurations in the deployment.yaml.
+ */
+@Configuration(namespace = "docker.configs", description = "Docker configurations in Editor")
+public class DockerConfigs {
+    @Element(description = "Version of the product and the Docker image")
+    private String productVersion = "latest";
+
+    public String getProductVersion() {
+        return productVersion;
+    }
+}

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/commons/request/DockerDownloadRequest.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/commons/request/DockerDownloadRequest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.siddhi.editor.core.commons.request;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Bean class to represent the docker download request payload.
+ */
+public class DockerDownloadRequest {
+    private String profile;
+    private List<String> files = new ArrayList<>();
+
+    public String getProfile() {
+        return profile;
+    }
+
+    public void setProfile(String profile) {
+        this.profile = profile;
+    }
+
+    public List<String> getFiles() {
+        return files;
+    }
+
+    public void setFiles(List<String> files) {
+        this.files = files;
+    }
+}

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/exception/DockerGenerationException.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/exception/DockerGenerationException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.siddhi.editor.core.exception;
+
+/**
+ * Represents the exception when generating Docker artifacts.
+ */
+public class DockerGenerationException extends Exception {
+
+    public DockerGenerationException(String message) {
+        super(message);
+    }
+
+    public DockerGenerationException(String message, Exception e) {
+        super(message, e);
+    }
+}

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/DockerUtils.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/DockerUtils.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.siddhi.editor.core.internal;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.carbon.config.ConfigurationException;
+import org.wso2.carbon.config.provider.ConfigProvider;
+import org.wso2.carbon.siddhi.editor.core.commons.configs.DockerConfigs;
+import org.wso2.carbon.siddhi.editor.core.exception.DockerGenerationException;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.wso2.carbon.siddhi.editor.core.util.Constants.CARBON_HOME;
+import static org.wso2.carbon.siddhi.editor.core.util.Constants.DIRECTORY_DEPLOYMENT;
+import static org.wso2.carbon.siddhi.editor.core.util.Constants.DIRECTORY_WORKSPACE;
+import static org.wso2.carbon.siddhi.editor.core.util.Constants.RUNTIME_PATH;
+
+/**
+ * This class creates Docker artifacts with given Siddhi files.
+ */
+public class DockerUtils {
+    private static final Logger log = LoggerFactory.getLogger(DockerUtils.class);
+    private static final String RESOURCES_DIR = "resources/docker-export";
+    private static final String SIDDHI_FILES_DIR = "siddhi-files";
+    private static final String README_FILE = "README.md";
+    private static final String DOCKER_COMPOSE_FILE = "docker-compose.yml";
+    private static final String DOCKER_COMPOSE_EDITOR_FILE = "docker-compose.editor.yml";
+    private static final String DOCKER_COMPOSE_WORKER_FILE = "docker-compose.worker.yml";
+    private static final String PRODUCT_VERSION_TOKEN = "\\{\\{PRODUCT_VERSION}}";
+    private final ConfigProvider configProvider;
+    private DockerConfigs dockerConfigs;
+
+    public DockerUtils(ConfigProvider configProvider) {
+        this.configProvider = configProvider;
+    }
+
+    /**
+     * Create a zip archive.
+     *
+     * @param siddhiFiles List of Siddhi siddhiFiles
+     * @return Zip archive file
+     */
+    public File createArchive(String profile, List<String> siddhiFiles) throws DockerGenerationException {
+        // Create <CARBON_HOME>/tmp/docker-export directory.
+        String tmpDirPath = Paths.get(CARBON_HOME, "tmp", "docker-export").toString();
+        File tmpDir = new File(tmpDirPath);
+        if (!tmpDir.exists() && !tmpDir.mkdirs()) {
+            throw new DockerGenerationException("Cannot create temporary directory at " + tmpDirPath);
+        }
+
+        // Create the destination zip file in the <CARBON_HOME>/tmp directory.
+        String destFilename = UUID.randomUUID().toString();
+        String destPath = Paths.get(tmpDirPath, destFilename).toString();
+        File zipFile = new File(destPath);
+        log.debug("Created temporary zip archive at " + destPath);
+
+        // Create zip archive.
+        ZipOutputStream outputStream = null;
+        try {
+            outputStream = new ZipOutputStream(new FileOutputStream(zipFile));
+            for (Map.Entry<String, Path> entry : getFileMap(profile, siddhiFiles).entrySet()) {
+                // Create zip entry for each file in the map.
+                ZipEntry zipEntry = new ZipEntry(entry.getKey());
+                outputStream.putNextEntry(zipEntry);
+                byte[] data = DOCKER_COMPOSE_FILE.equals(entry.getKey()) ?
+                        this.readDockerComposeFile(entry.getValue()) : Files.readAllBytes(entry.getValue());
+                outputStream.write(data, 0, data.length);
+                outputStream.closeEntry();
+            }
+        } catch (IOException e) {
+            throw new DockerGenerationException("Cannot write to the zip file.", e);
+        } catch (ConfigurationException e) {
+            throw new DockerGenerationException("Cannot read configurations from the deployment.yaml", e);
+        } finally {
+            if (outputStream != null) {
+                try {
+                    outputStream.close();
+                } catch (IOException e) {
+                    log.error("Cannot close the zip file.", e);
+                }
+            }
+        }
+        return zipFile;
+    }
+
+    /**
+     * Create file map for the zip archive.
+     *
+     * @param siddhiFiles Siddhi files to be included
+     * @return File map
+     */
+    private Map<String, Path> getFileMap(String profile, List<String> siddhiFiles) {
+        Map<String, Path> files = new HashMap<>();
+
+        // Add readme.md and the respective docker-compose.yml files.
+        files.put(README_FILE, Paths.get(RUNTIME_PATH, RESOURCES_DIR, README_FILE));
+        files.put(DOCKER_COMPOSE_FILE, Paths.get(RUNTIME_PATH, RESOURCES_DIR,
+                "editor".equals(profile) ? DOCKER_COMPOSE_EDITOR_FILE : DOCKER_COMPOSE_WORKER_FILE));
+
+        // Add selected Siddhi files.
+        for (String siddhiFile : siddhiFiles) {
+            String key = Paths.get(SIDDHI_FILES_DIR, siddhiFile).toString();
+            Path path = Paths.get(RUNTIME_PATH, DIRECTORY_DEPLOYMENT, DIRECTORY_WORKSPACE, siddhiFile);
+            files.put(key, path);
+        }
+        return files;
+    }
+
+    /**
+     * Read docker-compose.yml file and replace the string tokens with valid values read from configurations.
+     *
+     * @param path Path to the docker-compose.yml file
+     * @return Content
+     * @throws IOException
+     * @throws ConfigurationException
+     */
+    private byte[] readDockerComposeFile(Path path) throws IOException, ConfigurationException {
+        String productVersion = this.getConfigrations().getProductVersion();
+
+        byte[] data = Files.readAllBytes(path);
+        String content = new String(data, StandardCharsets.UTF_8);
+        String replacedContent = content
+                .replaceAll(PRODUCT_VERSION_TOKEN, productVersion);
+        return replacedContent.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Read configurations from the deployment.yaml.
+     *
+     * @return Configuration object
+     * @throws ConfigurationException
+     */
+    private DockerConfigs getConfigrations() throws ConfigurationException {
+        if (this.dockerConfigs == null) {
+            this.dockerConfigs = configProvider.getConfigurationObject(DockerConfigs.class);
+        }
+        return this.dockerConfigs;
+    }
+}

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/dialog/docker-export-dialog.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/dialog/docker-export-dialog.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+define(['require', 'jquery', 'log', 'backbone', 'file_browser'],
+    function (require, $, log, Backbone, FileBrowser) {
+    var DockerExportDialog = Backbone.View.extend(
+        /** @lends DockerExportDialog.prototype */
+        {
+            /**
+             * @augments Backbone.View
+             * @constructs
+             * @class DockerExportDialog
+             * @param {Object} options configuration options
+             */
+            initialize: function (options) {
+                this.app = options;
+                this.pathSeparator = this.app.getPathSeperator();
+                this.dialogContainer = $(_.get(this.app, 'config.dialog.container'));
+            },
+
+            show: function () {
+                this.modalContainer.modal('show');
+            },
+
+            render: function () {
+                var self = this,
+                    options = _.get(self.app, 'config.docker_export_dialog');
+
+                if(!_.isNil(this.modalContainer)){
+                    this.modalContainer.remove();
+                }
+
+                var exportModal = $(options.selector).clone();
+                var treeContainer = exportModal.find('#file-tree');
+                var exportButton = exportModal.find('#exportButton');
+
+                var fileBrowser = new FileBrowser({container: treeContainer, application: self.app, fetchFiles: true,
+                    showWorkspace: true, multiSelect: true});
+                fileBrowser.render();
+                this.fileBrowser = fileBrowser;
+
+                this.listenTo(fileBrowser, 'selected', function (files) {
+                    if (files.length > 0) {
+                        exportButton.removeAttr('disabled');
+                    } else {
+                        exportButton.attr('disabled', 'disabled');
+                    }
+                });
+
+                exportButton.on('click', function() {
+                    var payload = {
+                        profile: exportModal.find('#dockerProfile').val(),
+                        files: []
+                    };
+
+                    var files = self.fileBrowser.getSelected();
+                    for (var i = 0; i < files.length; i++) {
+                        var fileName = _.last(files[i].id.split(self.pathSeparator));
+                        if (fileName.lastIndexOf(".siddhi") !== -1) {
+                            payload.files.push(fileName);
+                        }
+                    }
+                    var downloadURL = window.location.protocol + "//" + window.location.host +
+                        "/editor/docker/download?q=" + encodeURIComponent(JSON.stringify(payload));
+                    $('#frm-download').attr('src', downloadURL);
+                });
+
+                this.dialogContainer.append(exportModal);
+                this.modalContainer = exportModal;
+            }
+        });
+    return DockerExportDialog;
+});

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/dialog/module.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/dialog/module.js
@@ -18,9 +18,10 @@
 
 define(['./save-to-file-dialog','./replace-confirm-dialog','./open-file-dialog','./close-confirm-dialog',
         './import-file-dialog', './export-file-dialog','./settings-dialog','./close-all-confirm-dialog',
-        './delete-confirm-dialog','./open-sample-file-dialog'],
+        './delete-confirm-dialog','./open-sample-file-dialog', './docker-export-dialog'],
     function (SaveToFileDialog,ReplaceConfirmDialog,OpenFileDialog,CloseConfirmDialog,ImportFileDialog,
-        ExportFileDialog,SettingsDialog,CloseAllConfirmDialog,DeleteConfirmDialog,OpenSampleFileDialog) {
+              ExportFileDialog,SettingsDialog,CloseAllConfirmDialog,DeleteConfirmDialog,OpenSampleFileDialog,
+              DockerExportDialog) {
     return {
         save_to_file_dialog: SaveToFileDialog,
         open_file_dialog: OpenFileDialog,
@@ -31,6 +32,7 @@ define(['./save-to-file-dialog','./replace-confirm-dialog','./open-file-dialog',
         settings_dialog: SettingsDialog,
         CloseAllConfirmDialog: CloseAllConfirmDialog,
         DeleteConfirmDialog: DeleteConfirmDialog,
-        open_sample_file_dialog: OpenSampleFileDialog
+        open_sample_file_dialog: OpenSampleFileDialog,
+        docker_export_dialog: DockerExportDialog
     };
 });

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/menu-bar/file-menu.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/menu-bar/file-menu.js
@@ -148,6 +148,14 @@ define(([],function (){
                 disabled: false
             },
             {
+                id: "exportAsDocker",
+                label: "Export as Docker",
+                command: {
+                    id: "export-docker"
+                },
+                disabled: false
+            },
+            {
                 id: "close",
                 label: "Close File",
                 command: {

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/workspace/workspace.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/workspace/workspace.js
@@ -554,6 +554,14 @@ define(['ace/ace', 'jquery', 'lodash', 'log','dialogs','./service-client','welco
                 this._exportFileDialog.render();
             };
 
+            this.exportAsDocker = function() {
+                if (_.isNil(this._dockerExportDialog)) {
+                    this._dockerExportDialog = new Dialogs.docker_export_dialog(app);
+                }
+                this._dockerExportDialog.render();
+                this._dockerExportDialog.show();
+            };
+
             this.handleExport = function(options) {
                 var activeTab = app.tabController.getActiveTab();
                 var file = activeTab.getFile();
@@ -671,6 +679,8 @@ define(['ace/ace', 'jquery', 'lodash', 'log','dialogs','./service-client','welco
 
             // Export file export dialog
             app.commandManager.registerHandler('export-file-export-dialog', this.exportFileExportDialog, this);
+
+            app.commandManager.registerHandler('export-docker', this.exportAsDocker, this);
 
             app.commandManager.registerHandler('open-replace-file-confirm-dialog', this.openReplaceFileConfirmDialog,
                 this);

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/css/styles.css
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/css/styles.css
@@ -271,7 +271,7 @@ a.ui-button:active, .ui-button:active,
   font-size: 1.4rem;
 }
 
-/* Cross platform */ 
+/* Cross platform */
 
 @media (min-width: 1440px) and (max-width: 1679px) {
   html {
@@ -518,6 +518,11 @@ margin-bottom: 5px;
   margin-bottom: 15px;
 }
 
+/* Export as docker modal */
+.modalDockerExport .modal-dialog {
+  width: 500px;
+}
+
 body.sticky-footer {
   padding-bottom: 20px;
 }
@@ -564,5 +569,12 @@ body.sticky-footer {
 	left: 0px;
 	right: 0px;
 	z-index: 90;
-	background: rgba(90, 90, 90, 0.5);
+  background: rgba(90, 90, 90, 0.5);
+}
+
+.docker-export-file-tree {
+  border: 1px solid #444;
+  height: 200px;
+  padding: 5px;
+  background-color: #2C2C2C;
 }

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
@@ -1333,6 +1333,43 @@
 </div>
 
 
+<!--Start: Docker Export Modal-->
+<div class="modal fade modalDockerExport" id="modalDockerExport" tabindex="-1" role="dialog">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content clearfix">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <i class="fw fw-cancel about-dialog-close"></i></button>
+                <h3 class="modal-title" id="aboutDockerExportLabel">Export as Docker</h3>
+            </div>
+            <div class="modal-body add-margin-top-2x add-margin-bottom-2x">
+                <form>
+                    <h4>Export as Docker</h4>
+                    <hr/>
+                    <div class="form-group">
+                        <label for="dockerProfile">Profile:</label>
+                        <select class="form-control" id="dockerProfile">
+                            <option value="editor">Editor</option>
+                            <option value="worker">Worker</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="dockerProfile">Files to be included:</label>
+                        <div id="file-tree" class="docker-export-file-tree"></div>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal" id="exportButton"
+                        disabled="disabled">Export</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<iframe id="frm-download" style="display: none;"></iframe>
+
+
 <script src="/editor/commons/lib/requirejs-2.3.2/require.js"></script>
 <script type="text/javascript">
     requirejs.config({
@@ -1695,6 +1732,10 @@
             settings_dialog:{
                 selector: "#modalSettings",
                 submit_button: "#saveSettingsButton"
+            },
+            docker_export_dialog: {
+                selector: '#modalDockerExport',
+                submitButton: '#exportButton'
             },
             output_controller: {
                 container: "#console-container",

--- a/features/org.wso2.carbon.siddhi.editor.core.feature/src/main/resources/docker-export/README.md
+++ b/features/org.wso2.carbon.siddhi.editor.core.feature/src/main/resources/docker-export/README.md
@@ -1,0 +1,44 @@
+# WSO2 Stream Processor Studio Docker Artifacts
+
+Docker artifacts in WSO2 Stream Processor Studio can be used to build Docker containers with Siddhi files.
+
+## Directory Structure
+
+In WSO2 Stream Processor Studio, Docker artifacts can be created for either **Editor** profile or **Worker** profile. Directory structure of the ZIP file is as follows.
+
+```
+.
+├── README.md
+├── docker-compose.yml
+└── workspace
+    ├── <SIDDHI_FILE_1>.siddhi
+    └── <SIDDHI_FILE_2>.siddhi
+```
+
+
+Purpose of each file in the above archive is as follows.
+
+- **README.md**: This readme file.
+- **docker-compose.yml**: Docker Compose file which contains Docker configurations to build and run the Docker container.
+- **siddhi-files**: Directory which contains Siddhi files.
+
+## How to Run?
+
+To run this archive, following applications are required.
+
+- Docker
+- Docker Compose
+
+Once the above prerequisites are installed in your environment, follow the steps mentioned below to create and run the docker image.
+
+1. Unzip the docker-artifact.zip archive file. The extracted directory will be referred as `<DOCKER_HOME>` within this document.
+
+2. Go to `<DOCKER_HOME>` directory.
+
+3. Run the following command to start the Docker container.
+
+```
+docker-compose up
+```
+
+

--- a/features/org.wso2.carbon.siddhi.editor.core.feature/src/main/resources/docker-export/docker-compose.editor.yml
+++ b/features/org.wso2.carbon.siddhi.editor.core.feature/src/main/resources/docker-export/docker-compose.editor.yml
@@ -1,0 +1,28 @@
+# Copyright 2018 WSO2, Inc. (http://wso2.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+version: '2.3'
+services:
+  editor:
+    image: docker.wso2.com/wso2sp-editor:{{PRODUCT_VERSION}}
+    container_name: wso2sp-editor
+    ports:
+      - "9390:9390"
+    healthcheck:
+      test: ["CMD", "nc", "-z","localhost", "9390"]
+      interval: 10s
+      timeout: 120s
+      retries: 5
+    volumes:
+      - ./siddhi-files:/home/wso2carbon/siddhi-files

--- a/features/org.wso2.carbon.siddhi.editor.core.feature/src/main/resources/docker-export/docker-compose.worker.yml
+++ b/features/org.wso2.carbon.siddhi.editor.core.feature/src/main/resources/docker-export/docker-compose.worker.yml
@@ -1,0 +1,28 @@
+# Copyright 2018 WSO2, Inc. (http://wso2.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+version: '2.3'
+services:
+  editor:
+    image: docker.wso2.com/wso2sp-worker:{{PRODUCT_VERSION}}
+    container_name: wso2sp-worker
+    ports:
+      - "9090:9090"
+    healthcheck:
+      test: ["CMD", "nc", "-z","localhost", "9090"]
+      interval: 10s
+      timeout: 120s
+      retries: 5
+    volumes:
+      - ./siddhi-files:/home/wso2carbon/siddhi-files

--- a/features/org.wso2.carbon.siddhi.editor.core.feature/src/main/resources/p2.inf
+++ b/features/org.wso2.carbon.siddhi.editor.core.feature/src/main/resources/p2.inf
@@ -3,3 +3,6 @@ org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../conf
 org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../conf/editor/);\
 org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../conf/editor/osgi);\
 org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../lib/features/org.wso2.carbon.siddhi.editor.core_${feature.version}/resources/launch.properties/,target:${installFolder}/../../conf/editor/osgi/launch.properties,overwrite:true);\
+org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../editor/);\
+org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../editor/resources/);\
+org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../lib/features/org.wso2.carbon.siddhi.editor.core_${feature.version}/docker-export,target:${installFolder}/../editor/resources/docker-export,overwrite:true);\


### PR DESCRIPTION
## Purpose
This PR introduces a new menu item in Editor to download a set of selected Siddhi files as a ZIP archive.

Resolves https://github.com/wso2/product-sp/issues/883

## Approach
Once the Siddhi files have been created via the Editor, a user can use this feature to download these files as a Docker-compose ZIP archive. For that, a new menu item has been introduced at `File -> Export as Docker`.

This shows a dialog to select the runtime/profile which needs to be used (either Editor or Worker) and select Siddhi files from the `workspace`. Once the user clicks on the **Export** button, the ZIP file will be downloaded.

The ZIP file contains the following directory structure.

```
.
├── README.md
├── docker-compose.yml
└── [siddhi-files]
    ├── <SIDDHI_FILE_1>.siddhi
    └── <SIDDHI_FILE_2>.siddhi
```

Once the ZIP file is extracted, the user can run the respective Docker container via following command (This requires the target environment to have `docker` and `docker-compose` installed and configured).

```
docker-compose up
```

### Change the Docker image and product versions

To change the Docker image version and the product version in the respective `docker-compose` file, a new configuration has been introduced in the Editor's deployment.yaml file.

```yaml
# Configurations for Docker export feature
docker.configs:
  productVersion: '4.4.0'
``` 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes