### PR TITLE
Preserve escape,new line chars when switching between Source/Design view.

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/codegenerator/generators/SourceSinkCodeGenerator.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/codegenerator/generators/SourceSinkCodeGenerator.java
@@ -61,7 +61,7 @@ public class SourceSinkCodeGenerator {
 
         if (sourceSink.getOptions() != null && !sourceSink.getOptions().isEmpty()) {
             sourceSinkStringBuilder.append(SiddhiCodeBuilderConstants.COMMA)
-                    .append(SubElementCodeGenerator.generateParameterList(sourceSink.getOptions()));
+                    .append(SubElementCodeGenerator.generateElementList(sourceSink.getOptions()));
         }
 
         if (sourceSink.getMap() != null) {
@@ -91,7 +91,7 @@ public class SourceSinkCodeGenerator {
 
         if (mapper.getOptions() != null && !mapper.getOptions().isEmpty()) {
             mapperStringBuilder.append(SiddhiCodeBuilderConstants.COMMA)
-                    .append(SubElementCodeGenerator.generateParameterList(mapper.getOptions()));
+                    .append(SubElementCodeGenerator.generateElementList(mapper.getOptions()));
         }
 
         if (mapper.getPayloadOrAttribute() != null) {
@@ -154,7 +154,7 @@ public class SourceSinkCodeGenerator {
         StringBuilder mapperListAttributeStringBuilder = new StringBuilder();
         int valuesLeft = mapperListAttribute.getValue().size();
         for (String value : mapperListAttribute.getValue()) {
-            if (value.contains("\"")) {
+            if (value.contains("\"") || value.contains("\n")) {
                 mapperListAttributeStringBuilder.append(SiddhiCodeBuilderConstants.ESCAPE_SEQUENCE)
                         .append(value)
                         .append(SiddhiCodeBuilderConstants.ESCAPE_SEQUENCE);
@@ -189,7 +189,7 @@ public class SourceSinkCodeGenerator {
             mapperMapAttributeStringBuilder.append(entry.getKey())
                     .append(SiddhiCodeBuilderConstants.EQUAL);
             String value = entry.getValue();
-            if (value.contains("\"")) {
+            if (value.contains("\"") || value.contains("\n")) {
                 mapperMapAttributeStringBuilder.append(SiddhiCodeBuilderConstants.ESCAPE_SEQUENCE)
                         .append(value)
                         .append(SiddhiCodeBuilderConstants.ESCAPE_SEQUENCE);

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/codegenerator/generators/SubElementCodeGenerator.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/codegenerator/generators/SubElementCodeGenerator.java
@@ -28,6 +28,7 @@ import org.wso2.carbon.siddhi.editor.core.util.designview.constants.CodeGenerato
 import org.wso2.carbon.siddhi.editor.core.util.designview.constants.SiddhiCodeBuilderConstants;
 import org.wso2.carbon.siddhi.editor.core.util.designview.exceptions.CodeGenerationException;
 import org.wso2.carbon.siddhi.editor.core.util.designview.utilities.CodeGeneratorUtils;
+import org.wso2.siddhi.query.api.annotation.Element;
 
 import java.util.List;
 import java.util.Map;
@@ -176,6 +177,30 @@ public class SubElementCodeGenerator {
         int parametersLeft = parameters.size();
         for (String parameter : parameters) {
             parametersStringBuilder.append(parameter);
+            if (parametersLeft != 1) {
+                parametersStringBuilder.append(SiddhiCodeBuilderConstants.COMMA);
+            }
+            parametersLeft--;
+        }
+
+        return parametersStringBuilder.toString();
+    }
+
+    /**
+     * Generate's the Siddhi code representation of a element list
+     *
+     * @param elements The elements list
+     * @return The Siddhi code representation of the given elements list
+     */
+    public static String generateElementList(List<String> elements) {
+        if (elements == null || elements.isEmpty()) {
+            return SiddhiCodeBuilderConstants.EMPTY_STRING;
+        }
+
+        StringBuilder parametersStringBuilder = new StringBuilder();
+        int parametersLeft = elements.size();
+        for (String parameter : elements) {
+            parametersStringBuilder.append(Element.toStringWithEscapeChars(parameter));
             if (parametersLeft != 1) {
                 parametersStringBuilder.append(SiddhiCodeBuilderConstants.COMMA);
             }

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/codegenerator/generators/SubElementCodeGenerator.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/codegenerator/generators/SubElementCodeGenerator.java
@@ -28,7 +28,6 @@ import org.wso2.carbon.siddhi.editor.core.util.designview.constants.CodeGenerato
 import org.wso2.carbon.siddhi.editor.core.util.designview.constants.SiddhiCodeBuilderConstants;
 import org.wso2.carbon.siddhi.editor.core.util.designview.exceptions.CodeGenerationException;
 import org.wso2.carbon.siddhi.editor.core.util.designview.utilities.CodeGeneratorUtils;
-import org.wso2.siddhi.query.api.annotation.Element;
 
 import java.util.List;
 import java.util.Map;
@@ -200,7 +199,7 @@ public class SubElementCodeGenerator {
         StringBuilder parametersStringBuilder = new StringBuilder();
         int parametersLeft = elements.size();
         for (String parameter : elements) {
-            parametersStringBuilder.append(Element.toStringWithEscapeChars(parameter));
+            parametersStringBuilder.append(toStringWithEscapeChars(parameter));
             if (parametersLeft != 1) {
                 parametersStringBuilder.append(SiddhiCodeBuilderConstants.COMMA);
             }
@@ -312,4 +311,40 @@ public class SubElementCodeGenerator {
     private SubElementCodeGenerator() {
     }
 
+    /**
+     *Converts an element in string format to another string with escape characters
+     * which is the siddhi app code representation of the element.
+     * @param elementStr The element in String format. E.g. title = "The wonder of "foo""
+     * @return The code representation of element. E.g. title = """The wonder of "foo""""
+     */
+    private static String toStringWithEscapeChars(String elementStr) {
+        String key = null, value;
+        if (elementStr == null || elementStr.isEmpty()) {
+            throw new IllegalArgumentException("Input string is either null or empty.");
+        }
+        String[] keyValuePair = elementStr.split(SiddhiCodeBuilderConstants.ELEMENT_KEY_VALUE_SEPARATOR);
+        if (keyValuePair.length == 1) {
+            value = keyValuePair[0].trim().substring(1, keyValuePair[0].length() - 1);
+        } else if (keyValuePair.length == 2) {
+            key = keyValuePair[0];
+            value = keyValuePair[1].trim().substring(1, keyValuePair[1].length() - 1);
+        } else {
+            throw new IllegalArgumentException("Could not convert to Element object. String format is invalid: "
+                    + elementStr);
+        }
+
+        StringBuilder valueWithQuotes = new StringBuilder();
+        if (value != null && (value.contains("\"") || value.contains("\n"))) {
+            valueWithQuotes.append(SiddhiCodeBuilderConstants.ESCAPE_SEQUENCE).append(value)
+                    .append(SiddhiCodeBuilderConstants.ESCAPE_SEQUENCE);
+        } else {
+            valueWithQuotes.append(SiddhiCodeBuilderConstants.DOUBLE_QUOTE).append(value)
+                    .append(SiddhiCodeBuilderConstants.DOUBLE_QUOTE);
+        }
+        if (key != null) {
+            return key + SiddhiCodeBuilderConstants.ELEMENT_KEY_VALUE_SEPARATOR + valueWithQuotes.toString();
+        } else {
+            return valueWithQuotes.toString();
+        }
+    }
 }

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/codegenerator/generators/SubElementCodeGenerator.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/codegenerator/generators/SubElementCodeGenerator.java
@@ -312,10 +312,10 @@ public class SubElementCodeGenerator {
     }
 
     /**
-     *Converts an element in string format to another string with escape characters
-     * which is the siddhi app code representation of the element.
-     * @param elementStr The element in String format. E.g. title = "The wonder of "foo""
-     * @return The code representation of element. E.g. title = """The wonder of "foo""""
+     *Converts an org.wso2.siddhi.query.api.annotation.Element in string format to another string with escape characters
+     * which is the siddhi app code representation of the Element.
+     * @param elementStr The Element in String format. E.g. title = "The wonder of "foo""
+     * @return The code representation of the Element. E.g. title = """The wonder of "foo""""
      */
     private static String toStringWithEscapeChars(String elementStr) {
         String key = null, value;

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/constants/SiddhiCodeBuilderConstants.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/constants/SiddhiCodeBuilderConstants.java
@@ -111,6 +111,8 @@ public class SiddhiCodeBuilderConstants {
     public static final String BEGIN = "begin";
     public static final String END = "end";
 
+    public static final String ELEMENT_KEY_VALUE_SEPARATOR = " = ";
+
     private SiddhiCodeBuilderConstants() {
     }
 

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/css/design-view.css
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/css/design-view.css
@@ -976,3 +976,9 @@ a.list-group-item, button.list-group-item {
     left: 0px;
     top: 0px;
 }
+
+textarea {
+    width: 95%;
+    background: #424242;
+    min-height: 65px;
+}

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
@@ -1209,9 +1209,12 @@
         {{#each this}}
         <div class = "attribute">
                 <div class = "clearfix">
-                {{#if key }} <input type = "text" value = "{{key}}" class = "attr-key" readonly/> {{/if}}
-                <textarea class = "attr-value">{{value}}
-                    </textarea>
+                    {{#if key }}
+                    <input type="text" value="{{key}}" class="attr-key" readonly/>
+                    <input type="text" value="{{value}}" class="attr-value"/>
+                    {{else}}
+                    <textarea class="attr-value"> {{value}} </textarea>
+                    {{/if}}
                 </div>
                 <label class = "error-message"></label>
         </div>

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
@@ -1210,7 +1210,8 @@
         <div class = "attribute">
                 <div class = "clearfix">
                 {{#if key }} <input type = "text" value = "{{key}}" class = "attr-key" readonly/> {{/if}}
-                <input type = "text" value = "{{value}}" class = "attr-value"/>
+                <textarea class = "attr-value">{{value}}
+                    </textarea>
                 </div>
                 <label class = "error-message"></label>
         </div>

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/sink-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/sink-form.js
@@ -352,7 +352,7 @@ define(['log', 'jquery', 'lodash', 'sourceOrSinkAnnotation', 'mapAnnotation', 'p
                             isError = true;
                             return false;
                         } else {
-                            option = custOptName + " = '" + custOptValue + "'";
+                            option = custOptName + " = \"" + custOptValue + "\"";
                             selectedOptions.push(option);
                         }
                     }

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/source-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/source-form.js
@@ -325,7 +325,7 @@ define(['log', 'jquery', 'lodash', 'sourceOrSinkAnnotation', 'mapAnnotation', 'p
                             isError = true;
                             return false;
                         } else {
-                            option = custOptName + " = '" + custOptValue + "'";
+                            option = custOptName + " = \"" + custOptValue + "\"";
                             selectedOptions.push(option);
                         }
                     }
@@ -434,7 +434,7 @@ define(['log', 'jquery', 'lodash', 'sourceOrSinkAnnotation', 'mapAnnotation', 'p
                             return false;
                         }
                     }
-                    option = optionName + " = '" + optionValue + "'";
+                    option = optionName + " = \"" + optionValue + "\"";
                     selectedOptions.push(option);
                 } else {
                     if ($(this).find('.option-checkbox').is(":checked")) {
@@ -454,7 +454,7 @@ define(['log', 'jquery', 'lodash', 'sourceOrSinkAnnotation', 'mapAnnotation', 'p
                                 return false;
                             }
                         }
-                        option = optionName + " = '" + optionValue + "'";
+                        option = optionName + " = \"" + optionValue + "\"";
                         selectedOptions.push(option);
                     }
                 }


### PR DESCRIPTION
## Purpose
Fixes wso2/carbon-analytics#1517 together with https://github.com/wso2/siddhi/pull/964

## Approach
Check whether the value contains new line or double quotes. If so, surround the value with escape sequence.

Also introduced a text area in the Sink Form instead of a text box because text box does not support new line chars.
<img width="1384" alt="screen shot 2018-12-07 at 12 02 35 pm" src="https://user-images.githubusercontent.com/7592890/49631516-55c60500-fa18-11e8-99b0-c0d97923995d.png">
Thanks @erangatl for styling the text area!

## Release note
Preserve escape and new line characters when switching between Source and Design view.

## Related PRs
https://github.com/wso2/siddhi/pull/964

## Migrations (if applicable)
N/A