### PR TITLE
Fix multi-selector rectangle view for new design view elements.

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/design-grid.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/design-grid.js
@@ -2345,6 +2345,7 @@ define(['require', 'log', 'jquery', 'backbone', 'lodash', 'designViewUtils', 'dr
             new DragSelect({
                 selectables: document.querySelectorAll('.jtk-draggable'),
                 selector: document.getElementById(constants.MULTI_SELECTOR),
+                area: document.getElementById('design-grid-container-' + self.currentTabId),
                 multiSelectKeys: ['ctrlKey', 'shiftKey'],
                 onElementSelect: function (element) {
                     if (!self.selectedObjects.includes(element)) {


### PR DESCRIPTION
## Purpose
To remove the multi-selection rectangle view that will be applied when new design view elements are dropped from the tool panel.

## Goals
User should be able to insert the design view elements without the multi-selection rectangle view.

## Approach
Define the area the multi-selection should be applied.
