### PR TITLE
Fix NPE when login API invoked before IDPClient service dependency resolved

### DIFF
--- a/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/impl/LoginApiServiceImpl.java
+++ b/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/impl/LoginApiServiceImpl.java
@@ -17,6 +17,8 @@
  */
 package org.wso2.carbon.analytics.auth.rest.api.impl;
 
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.analytics.auth.rest.api.LoginApiService;
@@ -25,6 +27,7 @@ import org.wso2.carbon.analytics.auth.rest.api.dto.ErrorDTO;
 import org.wso2.carbon.analytics.auth.rest.api.dto.RedirectionDTO;
 import org.wso2.carbon.analytics.auth.rest.api.dto.UserDTO;
 import org.wso2.carbon.analytics.auth.rest.api.internal.DataHolder;
+import org.wso2.carbon.analytics.auth.rest.api.internal.ServiceComponent;
 import org.wso2.carbon.analytics.auth.rest.api.util.AuthRESTAPIConstants;
 import org.wso2.carbon.analytics.auth.rest.api.util.AuthUtil;
 import org.wso2.carbon.analytics.idp.client.core.api.IdPClient;
@@ -50,6 +53,30 @@ import javax.ws.rs.core.Response;
 public class LoginApiServiceImpl extends LoginApiService {
 
     private static final Logger LOG = LoggerFactory.getLogger(LoginApiServiceImpl.class);
+
+    @Reference(
+            service = ServiceComponent.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unRegisterServiceComponet"
+    )
+    public void registerServiceComponet(ServiceComponent serviceComponent) {
+        LOG.debug("@Reference(bind) ServiceComponent which sets IdP Client");
+    }
+
+    public void unRegisterServiceComponet(ServiceComponent serviceComponent) {
+        LOG.debug("@Reference(bind) ServiceComponent which sets IdP Client was removed");
+    }
+
+    @Activate
+    protected void start(BundleContext bundleContext) {
+        LOG.debug("Login API started");
+    }
+
+    @Deactivate
+    protected void stop() {
+        LOG.debug("Login API stopped");
+    }
 
     @Override
     public Response loginAppNamePost(String appName

--- a/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/impl/LogoutApiServiceImpl.java
+++ b/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/impl/LogoutApiServiceImpl.java
@@ -17,12 +17,15 @@
  */
 package org.wso2.carbon.analytics.auth.rest.api.impl;
 
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.analytics.auth.rest.api.LogoutApiService;
 import org.wso2.carbon.analytics.auth.rest.api.NotFoundException;
 import org.wso2.carbon.analytics.auth.rest.api.dto.ErrorDTO;
 import org.wso2.carbon.analytics.auth.rest.api.internal.DataHolder;
+import org.wso2.carbon.analytics.auth.rest.api.internal.ServiceComponent;
 import org.wso2.carbon.analytics.auth.rest.api.util.AuthRESTAPIConstants;
 import org.wso2.carbon.analytics.auth.rest.api.util.AuthUtil;
 import org.wso2.carbon.analytics.idp.client.core.exception.IdPClientException;
@@ -41,6 +44,30 @@ import javax.ws.rs.core.Response;
 public class LogoutApiServiceImpl extends LogoutApiService {
 
     private static final Logger LOG = LoggerFactory.getLogger(LogoutApiServiceImpl.class);
+
+    @Reference(
+            service = ServiceComponent.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unRegisterServiceComponet"
+    )
+    public void registerServiceComponet(ServiceComponent serviceComponent) {
+        LOG.debug("@Reference(bind) ServiceComponent which sets IdP Client");
+    }
+
+    public void unRegisterServiceComponet(ServiceComponent serviceComponent) {
+        LOG.debug("@Reference(bind) ServiceComponent which sets IdP Client was removed");
+    }
+
+    @Activate
+    protected void start(BundleContext bundleContext) {
+        LOG.debug("Logout API started");
+    }
+
+    @Deactivate
+    protected void stop() {
+        LOG.debug("Logout API stopped");
+    }
 
     @Override
     public Response logoutAppNamePost(String appName

--- a/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/internal/ServiceComponent.java
+++ b/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/internal/ServiceComponent.java
@@ -30,7 +30,6 @@ import org.wso2.carbon.analytics.idp.client.core.api.IdPClient;
  * Service component to get IdPClient OSGi service.
  */
 @Component(
-        name = "ServiceComponentAuthRestAPI",
         service = ServiceComponent.class,
         immediate = true
 )


### PR DESCRIPTION
## Purpose
$subject. Fixes https://github.com/wso2/carbon-analytics/issues/1531

## Goals
Fix NPE thrown if the IdP dependency is not resolved properly before the API is invoked.

## Approach
Hold the API becoming active till the reference is resolved

## Documentation
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes