### PR TITLE
Preserve the design view changes when switching between design -view and source view

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/workspace/file.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/workspace/file.js
@@ -40,6 +40,8 @@ define(['jquery', 'lodash', 'backbone', 'log'], function ($, _, Backbone, log) {
                     }
                     this._storage = _.get(options, 'storage');
                     this._storage .create(this);
+                } else {
+                    this.setHash(this.generateHash(this.getContent().trim()));
                 }
             },
             generateHash: function (hashCode) {


### PR DESCRIPTION
## Goal
> Preserve the design view changes when switching between 'Design-View' and the 'Source-View' when there is no change in the Source view
## Approach
>Generate a hash code from the 'Source-View' content and checking the hash code, is same or not when switching between the design and the source views. A variable is created at the design view to compare the hash code of the file.
*If both hash codes are same do not render.
*If both hash codes are different, render the design view and assign the file hash code for the variable in the design view
