### PR TITLE
Fix issue in confirmation dialog box for delete an element [Design -View]

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/drop-elements.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/drop-elements.js
@@ -1202,6 +1202,7 @@ define(['require', 'log', 'lodash', 'jquery', 'partition', 'stream', 'query', 'f
             function showPopOver(dataObj, element) {
                 $(dataObj).popover({
                     trigger: 'focus',
+                    placement:'auto',
                     title: 'Are you sure you want to delete?',
                     html: true,
                     content: function () {


### PR DESCRIPTION
## Purpose
>Fixing the issue of scrolling  when confirmation dialog box appear at screen margins

## Issue
>When an element is near to screen margins [left and top margin ] and when delete button clicked, the popover shows with screen x-axis scroll,but unable to scroll due to the overlapping of the div.

## Approach
>Defining the placement property  for the popover as auto 