### PR TITLE
Introduce 'properties' for siddhi configurations

### DIFF
--- a/components/org.wso2.carbon.stream.processor.common/src/main/java/org/wso2/carbon/stream/processor/common/utils/config/FileConfigManager.java
+++ b/components/org.wso2.carbon.stream.processor.common/src/main/java/org/wso2/carbon/stream/processor/common/utils/config/FileConfigManager.java
@@ -96,8 +96,19 @@ public class FileConfigManager implements ConfigManager {
 
     @Override
     public String extractProperty(String name) {
+        String property = null;
         if (configProvider != null) {
-            if ("shardId".equalsIgnoreCase(name)) {
+            try {
+                RootConfiguration rootConfiguration =
+                        configProvider.getConfigurationObject(RootConfiguration.class);
+                if (null != rootConfiguration && null != rootConfiguration.getProperties()) {
+                    property =  rootConfiguration.getProperties().get(name);
+                }
+            } catch (ConfigurationException e) {
+                LOGGER.error("Could not initiate the siddhi configuration object, " + e.getMessage(), e);
+            }
+
+            if (property == null && "shardId".equalsIgnoreCase(name)) {
                 try {
                     ClusterConfig clusterConfig =
                             configProvider.getConfigurationObject(ClusterConfig.class);
@@ -119,21 +130,11 @@ public class FileConfigManager implements ConfigManager {
                 } catch (ConfigurationException e) {
                     LOGGER.error("Could not initiate the wso2.carbon configuration object, " + e.getMessage(), e);
                 }
-            } else {
-                try {
-                    RootConfiguration rootConfiguration =
-                            configProvider.getConfigurationObject(RootConfiguration.class);
-                    if (null != rootConfiguration && null != rootConfiguration.getProperties()) {
-                        return rootConfiguration.getProperties().get(name);
-                    }
-                } catch (ConfigurationException e) {
-                    LOGGER.error("Could not initiate the siddhi configuration object, " + e.getMessage(), e);
-                }
             }
         }
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Could not find a matching configuration for property name: " + name + "");
         }
-        return null;
+        return property;
     }
 }

--- a/components/org.wso2.carbon.stream.processor.common/src/main/java/org/wso2/carbon/stream/processor/common/utils/config/RootConfiguration.java
+++ b/components/org.wso2.carbon.stream.processor.common/src/main/java/org/wso2/carbon/stream/processor/common/utils/config/RootConfiguration.java
@@ -21,7 +21,9 @@ import org.wso2.carbon.config.annotation.Configuration;
 import org.wso2.carbon.config.annotation.Element;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * {@code RootConfiguration} is a bean class for root level configuration.
@@ -35,9 +37,13 @@ public class RootConfiguration {
     @Element(description = "References list", required = false)
     private List<Reference> refs;
 
+    @Element(description = "Properties list", required = false)
+    private Map<String, String> properties;
+
     public RootConfiguration() {
         extensions = new ArrayList<>();
         refs = new ArrayList<>();
+        properties = new HashMap<>();
     }
 
     public List<Extension> getExtensions() {
@@ -46,5 +52,9 @@ public class RootConfiguration {
 
     public List<Reference> getRefs() {
         return refs;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1536,8 +1536,8 @@
 
     <properties>
         <carbon.analytics.version>2.0.475-SNAPSHOT</carbon.analytics.version>
-        <siddhi.version>4.3.0</siddhi.version>
-        <siddhi.bundle.version>4.3.0</siddhi.bundle.version>
+        <siddhi.version>4.3.3</siddhi.version>
+        <siddhi.bundle.version>4.3.3</siddhi.bundle.version>
         <siddhi.version.range>[4.0.0, 5.0.0)</siddhi.version.range>
         <carbon.analytics-common.version>6.0.72</carbon.analytics-common.version>
         <carbon.analytics-common.version.range>[6.0.66, 6.1.0)</carbon.analytics-common.version.range>


### PR DESCRIPTION
## Purpose
This is to introduce 'properties' for siddhi configurations. 
If partitioning by id should be enabled, it can be provided under siddhi -> properties as follows.
Also, in order to provide `shardId` through deployment.yaml of WSO2 SP, it should be provided under properties.

```yaml
siddhi:
  properties
    partitionById: true
    shardId: wso2-sp
```
## Goal
This was implemented as a part of providing support for https://github.com/wso2/analytics-apim/issues/598

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
