### PR TITLE
Add delete periodic persistence store functionality

### DIFF
--- a/components/org.wso2.carbon.stream.processor.core/src/gen/java/org/wso2/carbon/stream/processor/core/api/SiddhiAppsApi.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/gen/java/org/wso2/carbon/stream/processor/core/api/SiddhiAppsApi.java
@@ -213,6 +213,45 @@ public class SiddhiAppsApi implements Microservice {
         return delegate.siddhiAppsAppNameRestorePost(appName, revision, request);
     }
 
+    @DELETE
+    @Path("/{appName}/revisions")
+    @Produces({"application/json"})
+    @io.swagger.annotations.ApiOperation(value = "Deletes all revisions of the periodic state of a Siddhi Application.",
+            notes = "Deletes all revisions of the periodic state of the specified Siddhi Application.", response = InlineResponse400.class, tags = {"State",})
+    @io.swagger.annotations.ApiResponses(value = {
+            @io.swagger.annotations.ApiResponse(code = 200, message = "All revisions of the periodic state of the siddhi application" +
+                    " are deleted succussfully.", response = InlineResponse400.class),
+            @io.swagger.annotations.ApiResponse(code = 404, message = "The Siddhi Application is not found.",
+                    response = InlineResponse400.class),
+            @io.swagger.annotations.ApiResponse(code = 500, message = "An unexpected error occured.",
+                    response = InlineResponse400.class)})
+    public Response siddhiAppsAppNameRevisionsDelete(
+            @Context Request request,
+            @ApiParam(value = "The name of the Siddhi Application.", required = true)
+            @PathParam("appName") String appName,
+            @ApiParam(value = "Whether the redeployment enable or not", required = false)
+            @QueryParam("enabledRedeployment") String enabledRedeployment) throws NotFoundException {
+        return delegate.siddhiAppsAppNameRevisionsDelete(appName, enabledRedeployment, request);
+    }
+
+    @DELETE
+    @Path("/revisions")
+    @Produces({"application/json"})
+    @io.swagger.annotations.ApiOperation(value = "Deletes all revisions of the periodic state of all Siddhi Applications.",
+            notes = "Deletes all revisions of the periodic state of all Siddhi Applications. ", response = InlineResponse400.class, tags={ "State",})
+    @io.swagger.annotations.ApiResponses(value = {
+            @io.swagger.annotations.ApiResponse(code = 200, message = "All revisions of the periodic state of all the siddhi applicationa " +
+                    "are deleted succussfully.", response = InlineResponse400.class),
+            @io.swagger.annotations.ApiResponse(code = 500, message = "An unexpected error occured.",
+                    response = InlineResponse400.class) })
+    public Response siddhiAppsRevisionsDelete(
+            @Context Request request,
+            @ApiParam(value = "Whether the redeployment enable or not", required = false)
+            @QueryParam("enabledRedeployment") String enabledRedeployment)
+            throws NotFoundException {
+        return delegate.siddhiAppsRevisionsDelete(enabledRedeployment, request);
+    }
+
     @GET
     @Path("/{appName}/elements")
     @Produces({"application/json"})

--- a/components/org.wso2.carbon.stream.processor.core/src/gen/java/org/wso2/carbon/stream/processor/core/api/SiddhiAppsApiService.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/gen/java/org/wso2/carbon/stream/processor/core/api/SiddhiAppsApiService.java
@@ -40,6 +40,10 @@ public abstract class SiddhiAppsApiService {
 
     public abstract Response siddhiAppsAppNameBackupPost(String appName, Request request) throws NotFoundException;
 
+    public abstract Response siddhiAppsAppNameRevisionsDelete(String appName, String enabledRedeployment, Request request) throws NotFoundException;
+
+    public abstract Response siddhiAppsRevisionsDelete(String enabledRedeployment, Request request) throws NotFoundException;
+
     public abstract Response siddhiAppsGet(String isActive, Request request) throws NotFoundException;
 
     public abstract Response siddhiAppsPost(String body, Request request) throws NotFoundException;

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/impl/SiddhiAppsApiServiceImpl.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/impl/SiddhiAppsApiServiceImpl.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.analytics.permissions.PermissionProvider;
 import org.wso2.carbon.analytics.permissions.bean.Permission;
+import org.wso2.carbon.stream.processor.common.exception.ResourceNotFoundException;
 import org.wso2.carbon.stream.processor.core.api.ApiResponseMessage;
 import org.wso2.carbon.stream.processor.core.api.ApiResponseMessageWithCode;
 import org.wso2.carbon.stream.processor.core.api.NotFoundException;
@@ -61,6 +62,7 @@ import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -299,6 +301,108 @@ public class SiddhiAppsApiServiceImpl extends SiddhiAppsApiService {
             }
         } catch (Exception e) {
             log.error("Exception occurred when restoring the state for Siddhi App : " + appName, e);
+            jsonString = new Gson().
+                    toJson(new ApiResponseMessageWithCode(ApiResponseMessageWithCode.FILE_PROCESSING_ERROR,
+                            e.getMessage()));
+            status = Response.Status.INTERNAL_SERVER_ERROR;
+        }
+
+        return Response.status(status).entity(jsonString).build();
+    }
+
+    public Response siddhiAppsAppNamePersistenceDelete(String appName, String enabledRedeployment) throws NotFoundException {
+        String jsonString;
+        Response.Status status = Response.Status.OK;
+
+        try {
+            SiddhiAppRuntime siddhiAppRuntime = StreamProcessorDataHolder.getSiddhiManager().getSiddhiAppRuntime(appName);
+
+            if (siddhiAppRuntime != null) {
+                Map<String, SiddhiAppData> siddhiAppMap = StreamProcessorDataHolder.getStreamProcessorService().getSiddhiAppMap();
+                SiddhiAppData siddhiAppContent = siddhiAppMap.get(appName);
+
+                if (enabledRedeployment == null || "true".equals(enabledRedeployment)) {
+                    StreamProcessorDataHolder.
+                            getStreamProcessorService().undeploySiddhiApp(appName);
+                }
+                //clear the persistence store
+                siddhiAppRuntime.clearAllRevisionsOfSiddhiAppInPersistenceStore();
+
+                if (enabledRedeployment == null || "true".equals(enabledRedeployment)) {
+                    StreamProcessorDataHolder.
+                            getStreamProcessorService().deploySiddhiApp(siddhiAppContent.getSiddhiApp(), appName);
+                    jsonString = new Gson().toJson(new ApiResponseMessage(ApiResponseMessage.SUCCESS,
+                            "All revisions of the state persistence are deleted for Siddhi App :" +
+                                    appName));
+                } else {
+                    jsonString = new Gson().toJson(new ApiResponseMessage(ApiResponseMessage.SUCCESS,
+                            "All revisions of the state persistence are deleted for Siddhi App :" +
+                                    appName + " with redeployment."));
+                }
+
+            } else {
+                jsonString = new Gson().toJson(new ApiResponseMessage(ApiResponseMessage.NOT_FOUND,
+                        "There is no Siddhi App exist " +
+                                "with provided name : " + appName));
+                status = Response.Status.NOT_FOUND;
+            }
+
+        } catch (Exception e) {
+            log.error("Exception occurred when deleting the persistance store : " + appName, e);
+            jsonString = new Gson().
+                    toJson(new ApiResponseMessageWithCode(ApiResponseMessageWithCode.FILE_PROCESSING_ERROR,
+                            e.getMessage()));
+            status = Response.Status.INTERNAL_SERVER_ERROR;
+        }
+
+        return Response.status(status).entity(jsonString).build();
+    }
+
+    public Response siddhiAppsRevisionsDelete(String enabledRedeployment) throws NotFoundException {
+        String jsonString;
+        Response.Status status = Response.Status.OK;
+
+        try {
+            Map<String, SiddhiAppData> siddhiApps = StreamProcessorDataHolder.
+                    getStreamProcessorService().getSiddhiAppMap();
+
+            Map<String, SiddhiAppData> storedSiddhiApps = new HashMap<>(siddhiApps);
+
+            if (enabledRedeployment == null || "true".equals(enabledRedeployment)) {
+                //undeploy all the siddhi apps
+                for (Map.Entry<String, SiddhiAppData> entry : siddhiApps.entrySet()) {
+                    if (entry.getValue() != null) {
+                        StreamProcessorDataHolder.getStreamProcessorService().undeploySiddhiApp(entry.getKey());
+
+                    }
+                }
+            }
+            //clear persistence store
+            for (Map.Entry<String, SiddhiAppData> entry : storedSiddhiApps.entrySet()) {
+                if (entry.getValue() != null && entry.getValue().getSiddhiAppRuntime() != null) {
+                    entry.getValue().getSiddhiAppRuntime().clearAllRevisionsOfSiddhiAppInPersistenceStore();
+                }
+            }
+            //deploy all the siddhi apps
+            if (enabledRedeployment == null || "true".equals(enabledRedeployment)) {
+                //deploy persistence store
+                for (Map.Entry<String, SiddhiAppData> entry : storedSiddhiApps.entrySet()) {
+                    if (entry.getValue() != null) {
+                        StreamProcessorDataHolder.getStreamProcessorService().deploySiddhiApp(entry.getValue().getSiddhiApp(), entry.getKey());
+
+                    }
+                }
+                jsonString = new Gson().toJson(new ApiResponseMessage(ApiResponseMessage.SUCCESS,
+                        "All revisions of the state persistence is deleted for Siddhi Apps with redeployment"));
+            } else {
+                jsonString = new Gson().toJson(new ApiResponseMessage(ApiResponseMessage.SUCCESS,
+                        "All revisions of the state persistence is deleted for Siddhi Apps"));
+            }
+
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Exception occurred when deleting the persistance store :", e);
             jsonString = new Gson().
                     toJson(new ApiResponseMessageWithCode(ApiResponseMessageWithCode.FILE_PROCESSING_ERROR,
                             e.getMessage()));
@@ -838,6 +942,29 @@ public class SiddhiAppsApiServiceImpl extends SiddhiAppsApiService {
                     "Siddhi App" + appName).build();
         }
         return siddhiAppsAppNameRestorePost(appName, revision);
+    }
+
+    @Override
+    public Response siddhiAppsAppNameRevisionsDelete(String appName, String enabledRedeployment, Request request)
+            throws NotFoundException {
+
+        if (getUserName(request) != null && !getPermissionProvider().hasPermission(getUserName(request), new
+                Permission(PERMISSION_APP_NAME, MANAGE_SIDDHI_APP_PERMISSION_STRING))) {
+            return Response.status(Response.Status.UNAUTHORIZED).entity("Insufficient permissions to delete the " +
+                    "persistence store of Siddhi App " + appName).build();
+        }
+        return siddhiAppsAppNamePersistenceDelete(appName, enabledRedeployment);
+    }
+
+    @Override
+    public Response siddhiAppsRevisionsDelete(String enabledRedeployment, Request request) throws NotFoundException {
+        if (getUserName(request) != null && !getPermissionProvider().hasPermission(getUserName(request), new
+                Permission(PERMISSION_APP_NAME, MANAGE_SIDDHI_APP_PERMISSION_STRING))) {
+            return Response.status(Response.Status.UNAUTHORIZED).entity("Insufficient permissions to delete the " +
+                    "persistence store of all Siddhi Apps").build();
+        }
+        return siddhiAppsRevisionsDelete(enabledRedeployment);
+
     }
 
     @Override

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/impl/SiddhiAppsApiServiceImpl.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/impl/SiddhiAppsApiServiceImpl.java
@@ -385,9 +385,8 @@ public class SiddhiAppsApiServiceImpl extends SiddhiAppsApiService {
             }
             //deploy all the siddhi apps
             if (enabledRedeployment == null || "true".equals(enabledRedeployment)) {
-                //deploy persistence store
                 for (Map.Entry<String, SiddhiAppData> entry : storedSiddhiApps.entrySet()) {
-                    if (entry.getValue() != null) {
+                    if (entry.getValue() != null && entry.getValue().getSiddhiAppRuntime() != null) {
                         StreamProcessorDataHolder.getStreamProcessorService().deploySiddhiApp(entry.getValue().getSiddhiApp(), entry.getKey());
 
                     }

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/impl/SiddhiAppsApiServiceImpl.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/impl/SiddhiAppsApiServiceImpl.java
@@ -325,7 +325,7 @@ public class SiddhiAppsApiServiceImpl extends SiddhiAppsApiService {
                             getStreamProcessorService().undeploySiddhiApp(appName);
                 }
                 //clear the persistence store
-                siddhiAppRuntime.clearAllRevisionsOfSiddhiAppInPersistenceStore();
+                siddhiAppRuntime.clearAllRevisions();
 
                 if (enabledRedeployment == null || "true".equals(enabledRedeployment)) {
                     StreamProcessorDataHolder.
@@ -379,7 +379,7 @@ public class SiddhiAppsApiServiceImpl extends SiddhiAppsApiService {
             //clear persistence store
             for (Map.Entry<String, SiddhiAppData> entry : storedSiddhiApps.entrySet()) {
                 if (entry.getValue() != null && entry.getValue().getSiddhiAppRuntime() != null) {
-                    entry.getValue().getSiddhiAppRuntime().clearAllRevisionsOfSiddhiAppInPersistenceStore();
+                    entry.getValue().getSiddhiAppRuntime().clearAllRevisions();
                 }
             }
             //deploy all the siddhi apps
@@ -397,9 +397,7 @@ public class SiddhiAppsApiServiceImpl extends SiddhiAppsApiService {
                         "All revisions of the state persistence is deleted for Siddhi Apps"));
             }
 
-        } catch (RuntimeException e) {
-            throw e;
-        } catch (Exception e) {
+        } catch (Throwable e) {
             log.error("Exception occurred when deleting the persistance store :", e);
             jsonString = new Gson().
                     toJson(new ApiResponseMessageWithCode(ApiResponseMessageWithCode.FILE_PROCESSING_ERROR,

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/impl/SiddhiAppsApiServiceImpl.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/impl/SiddhiAppsApiServiceImpl.java
@@ -21,7 +21,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.analytics.permissions.PermissionProvider;
 import org.wso2.carbon.analytics.permissions.bean.Permission;
-import org.wso2.carbon.stream.processor.common.exception.ResourceNotFoundException;
 import org.wso2.carbon.stream.processor.core.api.ApiResponseMessage;
 import org.wso2.carbon.stream.processor.core.api.ApiResponseMessageWithCode;
 import org.wso2.carbon.stream.processor.core.api.NotFoundException;

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/StreamProcessorService.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/StreamProcessorService.java
@@ -68,7 +68,6 @@ public class StreamProcessorService {
     private Map<String, SiddhiAppData> siddhiAppMap = new ConcurrentHashMap<>();
     private BackoffRetryCounter backoffRetryCounter = new BackoffRetryCounter();
     private DistributionService distributionService = StreamProcessorDataHolder.getDistributionService();
-    private boolean isSingleAppPersistenceClear = false;
 
     public void deploySiddhiApp(String siddhiAppContent, String siddhiAppName) throws SiddhiAppConfigurationException,
             SiddhiAppAlreadyExistException, ConnectionUnavailableException {
@@ -118,17 +117,16 @@ public class StreamProcessorService {
                     if (StreamProcessorDataHolder.isPersistenceEnabled()) {
 
                         if (persistenceStoreClearEnabled) {
-
-                            if (siddhiApp != null && siddhiApp.equals(siddhiAppName)) {
-                                siddhiAppRuntime.clearAllRevisionsOfSiddhiAppInPersistenceStore();
-                                isSingleAppPersistenceClear = true;
+                            if (siddhiApp != null) {
+                                if (siddhiApp.equals(siddhiAppName)) {
+                                    siddhiAppRuntime.clearAllRevisions();
+                                    log.info("Deleting all the revisions of the Periodic Persistence of " +
+                                            "Active Node for " + siddhiAppName);
+                                }
+                            } else {
                                 log.info("Deleting all the revisions of the Periodic Persistence of " +
                                         "Active Node for " + siddhiAppName);
-                            } else if (!isSingleAppPersistenceClear) {
-                                log.info("Deleting all the revisions of the Periodic Persistence of " +
-                                        "Active Node for " + siddhiAppName);
-
-                                siddhiAppRuntime.clearAllRevisionsOfSiddhiAppInPersistenceStore();
+                                siddhiAppRuntime.clearAllRevisions();
                             }
                         } else {
                             log.info(
@@ -230,17 +228,16 @@ public class StreamProcessorService {
                     String revision = null;
 
                     if (persistenceStoreClearEnabled) {
-
-                        if (siddhiApp != null && siddhiApp.equals(siddhiAppName)) {
-                            siddhiAppRuntime.clearAllRevisionsOfSiddhiAppInPersistenceStore();
-                            isSingleAppPersistenceClear = true;
+                        if (siddhiApp != null) {
+                            if (siddhiApp.equals(siddhiAppName)) {
+                                siddhiAppRuntime.clearAllRevisions();
+                                log.info("Deleting all the revisions of the Periodic Persistence of " +
+                                        "Active Node for " + siddhiAppName);
+                            }
+                        } else {
                             log.info("Deleting all the revisions of the Periodic Persistence of " +
                                     "Active Node for " + siddhiAppName);
-                        } else if (!isSingleAppPersistenceClear) {
-                            log.info("Deleting all the revisions of the Periodic Persistence of " +
-                                    "Active Node for " + siddhiAppName);
-
-                            siddhiAppRuntime.clearAllRevisionsOfSiddhiAppInPersistenceStore();
+                            siddhiAppRuntime.clearAllRevisions();
                         }
 
                     } else {

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/StreamProcessorService.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/StreamProcessorService.java
@@ -28,7 +28,6 @@ import org.wso2.carbon.stream.processor.core.ha.HACoordinationSinkHandler;
 import org.wso2.carbon.stream.processor.core.ha.HACoordinationSourceHandler;
 import org.wso2.carbon.stream.processor.core.ha.HAManager;
 import org.wso2.carbon.stream.processor.core.ha.RetryRecordTableConnection;
-import org.wso2.carbon.stream.processor.core.ha.exception.HAModeException;
 import org.wso2.carbon.stream.processor.core.internal.exception.SiddhiAppAlreadyExistException;
 import org.wso2.carbon.stream.processor.core.internal.exception.SiddhiAppConfigurationException;
 import org.wso2.carbon.stream.processor.core.internal.exception.SiddhiAppDeploymentException;
@@ -54,8 +53,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Timer;
-import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -71,11 +68,15 @@ public class StreamProcessorService {
     private Map<String, SiddhiAppData> siddhiAppMap = new ConcurrentHashMap<>();
     private BackoffRetryCounter backoffRetryCounter = new BackoffRetryCounter();
     private DistributionService distributionService = StreamProcessorDataHolder.getDistributionService();
+    private boolean isSingleAppPersistenceClear = false;
 
     public void deploySiddhiApp(String siddhiAppContent, String siddhiAppName) throws SiddhiAppConfigurationException,
             SiddhiAppAlreadyExistException, ConnectionUnavailableException {
 
         SiddhiAppData siddhiAppData = new SiddhiAppData(siddhiAppContent);
+        boolean persistenceStoreClearEnabled = Boolean.valueOf
+                (System.getProperty(SiddhiAppProcessorConstants.PERSISTENCE_STORE_CLEAR_ENABLED));
+        String siddhiApp = System.getProperty(SiddhiAppProcessorConstants.SIDDHI_APP);
 
         if (siddhiAppMap.containsKey(siddhiAppName)) {
             throw new SiddhiAppAlreadyExistException("There is a Siddhi App with name " + siddhiAppName +
@@ -115,19 +116,34 @@ public class StreamProcessorService {
                 if (haManager.isActiveNode()) {
                     //Active Node
                     if (StreamProcessorDataHolder.isPersistenceEnabled()) {
-                        log.info(
-                                "Periodic Persistence of Active Node Enabled. Restoring From Last Saved Snapshot " +
-                                        "for " + siddhiAppName);
-                        String revision = null;
-                        try {
-                            revision = siddhiAppRuntime.restoreLastRevision();
-                        } catch (CannotRestoreSiddhiAppStateException e) {
-                            log.error("Error in restoring Siddhi app " + siddhiAppRuntime.getName(), e);
-                        }
-                        if (revision != null) {
-                            log.info("Siddhi App " + siddhiAppName + " restored to revision " + revision);
-                        }
 
+                        if (persistenceStoreClearEnabled) {
+
+                            if (siddhiApp != null && siddhiApp.equals(siddhiAppName)) {
+                                siddhiAppRuntime.clearAllRevisionsOfSiddhiAppInPersistenceStore();
+                                isSingleAppPersistenceClear = true;
+                                log.info("Deleting all the revisions of the Periodic Persistence of " +
+                                        "Active Node for " + siddhiAppName);
+                            } else if (!isSingleAppPersistenceClear) {
+                                log.info("Deleting all the revisions of the Periodic Persistence of " +
+                                        "Active Node for " + siddhiAppName);
+
+                                siddhiAppRuntime.clearAllRevisionsOfSiddhiAppInPersistenceStore();
+                            }
+                        } else {
+                            log.info(
+                                    "Periodic Persistence of Active Node Enabled. Restoring From Last Saved Snapshot " +
+                                            "for " + siddhiAppName);
+                            String revision = null;
+                            try {
+                                revision = siddhiAppRuntime.restoreLastRevision();
+                            } catch (CannotRestoreSiddhiAppStateException e) {
+                                log.error("Error in restoring Siddhi app " + siddhiAppRuntime.getName(), e);
+                            }
+                            if (revision != null) {
+                                log.info("Siddhi App " + siddhiAppName + " restored to revision " + revision);
+                            }
+                        }
                     } else {
                         log.info(
                                 "Periodic Persistence is Disabled. It is recommended to enable this feature when " +
@@ -212,13 +228,30 @@ public class StreamProcessorService {
                     log.info("Periodic State persistence enabled. Restoring last persisted state of "
                             + siddhiAppName);
                     String revision = null;
-                    try {
-                        revision = siddhiAppRuntime.restoreLastRevision();
-                    } catch (CannotRestoreSiddhiAppStateException e) {
-                        log.error("Error in restoring Siddhi app " + siddhiAppRuntime.getName(), e);
-                    }
-                    if (revision != null) {
-                        log.info("Siddhi App " + siddhiAppName + " restored to revision " + revision);
+
+                    if (persistenceStoreClearEnabled) {
+
+                        if (siddhiApp != null && siddhiApp.equals(siddhiAppName)) {
+                            siddhiAppRuntime.clearAllRevisionsOfSiddhiAppInPersistenceStore();
+                            isSingleAppPersistenceClear = true;
+                            log.info("Deleting all the revisions of the Periodic Persistence of " +
+                                    "Active Node for " + siddhiAppName);
+                        } else if (!isSingleAppPersistenceClear) {
+                            log.info("Deleting all the revisions of the Periodic Persistence of " +
+                                    "Active Node for " + siddhiAppName);
+
+                            siddhiAppRuntime.clearAllRevisionsOfSiddhiAppInPersistenceStore();
+                        }
+
+                    } else {
+                        try {
+                            revision = siddhiAppRuntime.restoreLastRevision();
+                        } catch (CannotRestoreSiddhiAppStateException e) {
+                            log.error("Error in restoring Siddhi app " + siddhiAppRuntime.getName(), e);
+                        }
+                        if (revision != null) {
+                            log.info("Siddhi App " + siddhiAppName + " restored to revision " + revision);
+                        }
                     }
                 }
                 siddhiAppRuntime.start();

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/util/SiddhiAppProcessorConstants.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/util/SiddhiAppProcessorConstants.java
@@ -49,6 +49,9 @@ public class SiddhiAppProcessorConstants {
     public static final String IS_SIDDHI_APP_PREFIX = "IS_";
     public static final String EI_SIDDHI_APP_PREFIX = "EI_";
 
+    public static final String PERSISTENCE_STORE_CLEAR_ENABLED = "persistenceStoreClearEnabled";
+    public static final String SIDDHI_APP = "siddhiApp";
+
     /**
      * Runtime modes of Stream Processor engine
      */

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/persistence/DBPersistenceStore.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/persistence/DBPersistenceStore.java
@@ -23,13 +23,14 @@ import org.apache.log4j.Logger;
 import org.wso2.carbon.datasource.core.exception.DataSourceException;
 import org.wso2.carbon.stream.processor.core.ha.util.CompressionUtil;
 import org.wso2.carbon.stream.processor.core.internal.StreamProcessorDataHolder;
+import org.wso2.carbon.stream.processor.core.persistence.dto.RDBMSQueryConfigurationEntry;
 import org.wso2.carbon.stream.processor.core.persistence.exception.DatabaseUnsupportedException;
 import org.wso2.carbon.stream.processor.core.persistence.exception.DatasourceConfigurationException;
 import org.wso2.carbon.stream.processor.core.persistence.util.DBPersistenceStoreUtils;
 import org.wso2.carbon.stream.processor.core.persistence.util.ExecutionInfo;
 import org.wso2.carbon.stream.processor.core.persistence.util.PersistenceConstants;
 import org.wso2.carbon.stream.processor.core.persistence.util.RDBMSConfiguration;
-import org.wso2.carbon.stream.processor.core.persistence.dto.RDBMSQueryConfigurationEntry;
+import org.wso2.siddhi.core.exception.CannotClearSiddhiAppStateException;
 import org.wso2.siddhi.core.util.persistence.PersistenceStore;
 
 import java.io.IOException;
@@ -381,7 +382,9 @@ public class DBPersistenceStore implements PersistenceStore {
         } catch (SQLException e) {
             log.error("Cannot establish connection to data source " + datasourceName +
                     " to delete the persistence store", e);
-            return;
+            throw new CannotClearSiddhiAppStateException("Cannot establish connection" +
+                    " to data source " + datasourceName + " when deleting the revisions " +
+                    "of the persistence store of SiddhiApp: " + siddhiAppName, e);
         }
         try {
             stmt = con.prepareStatement(executionInfo.getPreparedDeleteAllRevisionsStatement());
@@ -390,7 +393,10 @@ public class DBPersistenceStore implements PersistenceStore {
             con.commit();
         } catch (SQLException e) {
             log.error("Error in deleting all the revisions of the persistence store of siddhiApp: " +
-                    siddhiAppName + "from the database with datasource " + datasourceName, e);
+                    siddhiAppName + " from the database with datasource " + datasourceName, e);
+
+            throw new CannotClearSiddhiAppStateException("Error in deleting all the revisions of the persistence " +
+                    "store of SiddhiApp: " + siddhiAppName + " from the database with datasource " + datasourceName, e);
         } finally {
             if (stmt != null) {
                 try {

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/persistence/FileSystemPersistenceStore.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/persistence/FileSystemPersistenceStore.java
@@ -22,6 +22,7 @@ import com.google.common.io.Files;
 import org.apache.log4j.Logger;
 import org.wso2.carbon.stream.processor.core.ha.util.CompressionUtil;
 import org.wso2.carbon.stream.processor.core.persistence.util.PersistenceConstants;
+import org.wso2.siddhi.core.exception.CannotClearSiddhiAppStateException;
 import org.wso2.siddhi.core.util.persistence.PersistenceStore;
 
 import java.io.File;
@@ -144,18 +145,15 @@ public class FileSystemPersistenceStore implements PersistenceStore {
             return;
         }
 
-        try {
-            for (File file : files) {
-                if (file.exists()) {
-                    if (!file.delete()) {
-                        log.error("file is not deleted successfully!");
-                    }
+        for (File file : files) {
+            if (file.exists()) {
+                if (!file.delete()) {
+                    log.error("file is not deleted successfully!");
+                    throw new CannotClearSiddhiAppStateException("Persistence state " +
+                            "file is not deleted : " + file.getPath());
                 }
-
             }
-        } catch (Exception e) {
-            log.error("Error deleting the revisions of the persistence store of Siddhi App " + siddhiAppName +
-                    " from file system.", e);
+
         }
     }
 

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/persistence/FileSystemPersistenceStore.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/persistence/FileSystemPersistenceStore.java
@@ -141,16 +141,16 @@ public class FileSystemPersistenceStore implements PersistenceStore {
         File[] files = targetDirectory.listFiles();
 
         if (files == null || files.length == 0) {
-            log.info("No revisions were found with the Siddhi App " + siddhiAppName);
+            log.info("No revisions were found to delete for the Siddhi App " + siddhiAppName);
             return;
         }
 
         for (File file : files) {
             if (file.exists()) {
                 if (!file.delete()) {
-                    log.error("file is not deleted successfully!");
+                    log.error("file is not deleted successfully : " + file.getName());
                     throw new CannotClearSiddhiAppStateException("Persistence state " +
-                            "file is not deleted : " + file.getPath());
+                            "file is not deleted : " + file.getPath() + file.getName());
                 }
             }
 

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/persistence/FileSystemPersistenceStore.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/persistence/FileSystemPersistenceStore.java
@@ -134,6 +134,31 @@ public class FileSystemPersistenceStore implements PersistenceStore {
         return lastRevision;
     }
 
+    @Override
+    public void clearAllRevisions(String siddhiAppName) {
+        File targetDirectory = new File(folder + File.separator + siddhiAppName);
+        File[] files = targetDirectory.listFiles();
+
+        if (files == null || files.length == 0) {
+            log.info("No revisions were found with the Siddhi App " + siddhiAppName);
+            return;
+        }
+
+        try {
+            for (File file : files) {
+                if (file.exists()) {
+                    if (!file.delete()) {
+                        log.error("file is not deleted successfully!");
+                    }
+                }
+
+            }
+        } catch (Exception e) {
+            log.error("Error deleting the revisions of the persistence store of Siddhi App " + siddhiAppName +
+                    " from file system.", e);
+        }
+    }
+
     /**
      * Method to remove revisions that are older than the user specified amount
      *

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/persistence/IncrementalDBPersistenceStore.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/persistence/IncrementalDBPersistenceStore.java
@@ -30,6 +30,7 @@ import org.wso2.carbon.stream.processor.core.persistence.util.DBPersistenceStore
 import org.wso2.carbon.stream.processor.core.persistence.util.ExecutionInfo;
 import org.wso2.carbon.stream.processor.core.persistence.util.PersistenceConstants;
 import org.wso2.carbon.stream.processor.core.persistence.util.RDBMSConfiguration;
+import org.wso2.siddhi.core.exception.CannotClearSiddhiAppStateException;
 import org.wso2.siddhi.core.util.persistence.IncrementalPersistenceStore;
 import org.wso2.siddhi.core.util.persistence.util.IncrementalSnapshotInfo;
 import org.wso2.siddhi.core.util.persistence.util.PersistenceHelper;
@@ -271,7 +272,9 @@ public class IncrementalDBPersistenceStore implements IncrementalPersistenceStor
         } catch (SQLException e) {
             log.error("Cannot establish connection to data source " + datasourceName +
                     " to clean all revisions", e);
-            return;
+            throw new CannotClearSiddhiAppStateException("Cannot establish connection" +
+                    " to data source " + datasourceName + " when deleting the revisions " +
+                    "of the persistence store of SiddhiApp: " + siddhiAppName, e);
         }
         try {
             stmt = con.prepareStatement(executionInfo.getPreparedDeleteAllRevisionsStatement());
@@ -281,6 +284,8 @@ public class IncrementalDBPersistenceStore implements IncrementalPersistenceStor
         } catch (SQLException e) {
             log.error("Error in deleting all revisions of siddhiApp: " +
                     siddhiAppName + "from the database with datasource " + datasourceName, e);
+            throw new CannotClearSiddhiAppStateException("Error in deleting all the revisions of the persistence " +
+                    "store of SiddhiApp: " + siddhiAppName + " from the database with datasource " + datasourceName, e);
         } finally {
             if (stmt != null) {
                 try {

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/persistence/IncrementalFileSystemPersistenceStore.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/persistence/IncrementalFileSystemPersistenceStore.java
@@ -185,15 +185,15 @@ public class IncrementalFileSystemPersistenceStore implements IncrementalPersist
         File dir = new File(folder + File.separator + siddhiAppName);
         File[] files = dir.listFiles();
         if (files == null || files.length == 0) {
-            log.info("No revisions were found with the Siddhi App " + siddhiAppName);
+            log.info("No revisions were found to delete for the Siddhi App " + siddhiAppName);
             return;
         }
         for (File file : files) {
             if (file.exists()) {
                 if (!file.delete()) {
-                    log.error("file is not deleted successfully!");
+                    log.error("file is not deleted successfully : " + file.getName());
                     throw new CannotClearSiddhiAppStateException("Persistence state " +
-                            "file is not deleted : " + file.getPath());
+                            "file is not deleted : " + file.getName());
                 }
             }
 

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/persistence/IncrementalFileSystemPersistenceStore.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/persistence/IncrementalFileSystemPersistenceStore.java
@@ -22,6 +22,7 @@ import com.google.common.io.Files;
 import org.apache.log4j.Logger;
 import org.wso2.carbon.stream.processor.core.ha.util.CompressionUtil;
 import org.wso2.carbon.stream.processor.core.persistence.util.PersistenceConstants;
+import org.wso2.siddhi.core.exception.CannotClearSiddhiAppStateException;
 import org.wso2.siddhi.core.util.persistence.IncrementalPersistenceStore;
 import org.wso2.siddhi.core.util.persistence.util.IncrementalSnapshotInfo;
 import org.wso2.siddhi.core.util.persistence.util.PersistenceHelper;
@@ -187,18 +188,15 @@ public class IncrementalFileSystemPersistenceStore implements IncrementalPersist
             log.info("No revisions were found with the Siddhi App " + siddhiAppName);
             return;
         }
-        try {
-            for (File file : files) {
-                if (file.exists()) {
-                    if (!file.delete()) {
-                        log.error("file is not deleted successfully!");
-                    }
+        for (File file : files) {
+            if (file.exists()) {
+                if (!file.delete()) {
+                    log.error("file is not deleted successfully!");
+                    throw new CannotClearSiddhiAppStateException("Persistence state " +
+                            "file is not deleted : " + file.getPath());
                 }
-
             }
-        } catch (Exception e) {
-            log.error("Error deleting all the revisions of the persistence store of Siddhi App " + siddhiAppName +
-                    " from file system.", e);
+
         }
     }
 

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/persistence/IncrementalFileSystemPersistenceStore.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/persistence/IncrementalFileSystemPersistenceStore.java
@@ -179,6 +179,29 @@ public class IncrementalFileSystemPersistenceStore implements IncrementalPersist
         return null;
     }
 
+    @Override
+    public void clearAllRevisions(String siddhiAppName) {
+        File dir = new File(folder + File.separator + siddhiAppName);
+        File[] files = dir.listFiles();
+        if (files == null || files.length == 0) {
+            log.info("No revisions were found with the Siddhi App " + siddhiAppName);
+            return;
+        }
+        try {
+            for (File file : files) {
+                if (file.exists()) {
+                    if (!file.delete()) {
+                        log.error("file is not deleted successfully!");
+                    }
+                }
+
+            }
+        } catch (Exception e) {
+            log.error("Error deleting all the revisions of the persistence store of Siddhi App " + siddhiAppName +
+                    " from file system.", e);
+        }
+    }
+
     private void cleanOldRevisions(IncrementalSnapshotInfo incrementalSnapshotInfo) {
         if (incrementalSnapshotInfo.getType() != IncrementalSnapshotInfo.SnapshotType.INCREMENT) {
             File dir = new File(folder + File.separator + incrementalSnapshotInfo.getSiddhiAppId());

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/persistence/dto/RDBMSQueryConfigurationEntry.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/persistence/dto/RDBMSQueryConfigurationEntry.java
@@ -32,6 +32,7 @@ public class RDBMSQueryConfigurationEntry {
     private String deleteQuery;
     private String deleteOldRevisionsQuery;
     private String countQuery;
+    private String deleteAllRevisionsQuery;
 
     public String getDatabaseName() {
         return databaseName;
@@ -111,6 +112,14 @@ public class RDBMSQueryConfigurationEntry {
 
     public void setCountQuery(String countQuery) {
         this.countQuery = countQuery;
+    }
+
+    public String getDeleteAllRevisionsQuery() {
+        return deleteAllRevisionsQuery;
+    }
+
+    public void setDeleteAllRevisionsQuery(String deleteAllRevisionsQuery) {
+        this.deleteAllRevisionsQuery = deleteAllRevisionsQuery;
     }
 
 }

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/persistence/util/ExecutionInfo.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/persistence/util/ExecutionInfo.java
@@ -32,6 +32,7 @@ public class ExecutionInfo {
     private String preparedDeleteStatement;
     private String preparedDeleteOldRevisionsStatement;
     private String preparedCountStatement;
+    private String preparedDeleteAllRevisionsStatement;
 
     private boolean tableExist = false;
 
@@ -113,6 +114,14 @@ public class ExecutionInfo {
 
     public void setTableExist(boolean tableExist) {
         this.tableExist = tableExist;
+    }
+
+    public String getPreparedDeleteAllRevisionsStatement() {
+        return preparedDeleteAllRevisionsStatement;
+    }
+
+    public void setPreparedDeleteAllRevisionsStatement(String preparedDeleteAllRevisionsStatement) {
+        this.preparedDeleteAllRevisionsStatement = preparedDeleteAllRevisionsStatement;
     }
 
 }

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/persistence/util/PersistenceConstants.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/persistence/util/PersistenceConstants.java
@@ -39,5 +39,6 @@ public class PersistenceConstants {
     public static final String DELETE_ROW_FROM_TABLE = "DELETE_ROW_FROM_TABLE";
     public static final String DELETE_OLD_REVISIONS = "DELETE_OLD_REVISIONS";
     public static final String COUNT_NUMBER_REVISIONS = "COUNT_NUMBER_REVISIONS";
+    public static final String DELETE_ALL_REVISIONS = "DELETE_ALL_REVISIONS";
 
 }

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/persistence/util/RDBMSConfiguration.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/persistence/util/RDBMSConfiguration.java
@@ -29,7 +29,7 @@ import org.wso2.carbon.stream.processor.core.persistence.query.QueryManager;
 import java.io.IOException;
 
 /**
- * Class used to get Database queries according to RDBMS type used
+ * Class used to get Database queries according to RDBMS type used.
  */
 public class RDBMSConfiguration {
 
@@ -68,6 +68,9 @@ public class RDBMSConfiguration {
             databaseQueryEntries.setDeleteOldRevisionsQuery(queryManager.getQuery(PersistenceConstants.DELETE_OLD_REVISIONS).
                     replace(PersistenceConstants.PLACEHOLDER_TABLE_NAME, tableName));
             databaseQueryEntries.setCountQuery(queryManager.getQuery(PersistenceConstants.COUNT_NUMBER_REVISIONS).
+                    replace(PersistenceConstants.PLACEHOLDER_TABLE_NAME, tableName));
+            databaseQueryEntries.setDeleteAllRevisionsQuery(queryManager.
+                    getQuery(PersistenceConstants.DELETE_ALL_REVISIONS).
                     replace(PersistenceConstants.PLACEHOLDER_TABLE_NAME, tableName));
 
         } catch (QueryMappingNotAvailableException | ConfigurationException | IOException e) {

--- a/components/org.wso2.carbon.stream.processor.core/src/main/resources/queries.yaml
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/resources/queries.yaml
@@ -10,6 +10,7 @@ queries:
       DELETE_ROW_FROM_TABLE:
       DELETE_OLD_REVISIONS:
       COUNT_NUMBER_REVISIONS:
+      DELETE_ALL_REVISIONS:
 
    type: default
    version: default
@@ -25,6 +26,7 @@ queries:
       DELETE_ROW_FROM_TABLE: DELETE FROM {{TABLE_NAME}} WHERE id IN (SELECT id FROM {{TABLE_NAME}} WHERE siddhiAppName = ? ORDER BY id ASC LIMIT ?)
       DELETE_OLD_REVISIONS: DELETE FROM {{TABLE_NAME}} WHERE revision IN (?) AND siddhiAppName = ?
       COUNT_NUMBER_REVISIONS: SELECT COUNT(*) FROM {{TABLE_NAME}} WHERE siddhiAppName = ?
+      DELETE_ALL_REVISIONS: DELETE FROM {{TABLE_NAME}} WHERE siddhiAppName = ?
 
    type: h2
    version: default
@@ -40,6 +42,7 @@ queries:
       DELETE_ROW_FROM_TABLE: DELETE FROM {{TABLE_NAME}} WHERE siddhiAppName = ? IS NOT NULL ORDER BY id ASC LIMIT ?
       DELETE_OLD_REVISIONS: DELETE FROM {{TABLE_NAME}} WHERE revision IN (?) AND siddhiAppName = ?
       COUNT_NUMBER_REVISIONS: SELECT COUNT(*) FROM {{TABLE_NAME}} WHERE siddhiAppName = ?
+      DELETE_ALL_REVISIONS: DELETE FROM {{TABLE_NAME}} WHERE siddhiAppName = ?
 
    type: mysql
    version: default
@@ -55,6 +58,7 @@ queries:
       DELETE_ROW_FROM_TABLE: DELETE FROM {{TABLE_NAME}} WHERE id IN (SELECT id FROM {{TABLE_NAME}} WHERE siddhiAppName = ? ORDER BY id ASC LIMIT ?)
       DELETE_OLD_REVISIONS: DELETE FROM {{TABLE_NAME}} WHERE revision IN (?) AND siddhiAppName = ?
       COUNT_NUMBER_REVISIONS: SELECT COUNT(*) FROM {{TABLE_NAME}} WHERE siddhiAppName = ?
+      DELETE_ALL_REVISIONS: DELETE FROM {{TABLE_NAME}} WHERE siddhiAppName = ?
 
    type: postgresql
    version: default
@@ -70,6 +74,7 @@ queries:
       DELETE_ROW_FROM_TABLE: DELETE FROM {{TABLE_NAME}} WHERE id IN (SELECT TOP (?) id FROM {{TABLE_NAME}} WHERE siddhiAppName = ? ORDER BY id ASC)
       DELETE_OLD_REVISIONS: DELETE FROM {{TABLE_NAME}} WHERE revision IN (?) AND siddhiAppName = ?
       COUNT_NUMBER_REVISIONS: SELECT COUNT(*) FROM {{TABLE_NAME}} WHERE siddhiAppName = ?
+      DELETE_ALL_REVISIONS: DELETE FROM {{TABLE_NAME}} WHERE siddhiAppName = ?
 
    type: microsoft sql server
    version: default
@@ -85,6 +90,7 @@ queries:
       DELETE_ROW_FROM_TABLE: DELETE {{TABLE_NAME}} WHERE revision in (SELECT revision FROM (SELECT * FROM {{TABLE_NAME}} WHERE siddhiAppName = ? ORDER BY revision ASC) WHERE rownum<=?)
       DELETE_OLD_REVISIONS: DELETE FROM {{TABLE_NAME}} WHERE revision in (?) AND siddhiAppName = ?
       COUNT_NUMBER_REVISIONS: SELECT COUNT(*) FROM {{TABLE_NAME}} WHERE siddhiAppName = ?
+      DELETE_ALL_REVISIONS: DELETE FROM {{TABLE_NAME}} WHERE siddhiAppName = ?
 
    type: oracle
    version: default

--- a/components/org.wso2.carbon.stream.processor.core/src/main/resources/siddhi-apps-api.yaml
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/resources/siddhi-apps-api.yaml
@@ -308,6 +308,71 @@ paths:
           description: An unexpected error occured.
           schema:
             $ref: '#/definitions/ApiResponseMessageWithCode'
+  '/siddhi-apps/{appName}/revisions':
+    delete:
+      x-wso2-curl: 'curl -k -X DELETE http://localhost:9090/siddhi-apps/TestSiddhiApp1/revisions'
+      x-wso2-request: 'DELETE http://localhost:9090/siddhi-apps/TestSiddhiApp1/revisions'
+      x-wso2-response: >-
+        HTTP/1.1 200 OK Content-Type: application/json
+        {"type":"success","message":"All revisions of periodic state deleted for Siddhi
+        App :TestSiddhiApp1"}
+      tags:
+      - State
+      summary: Deletes all revisions of the periodic state of a Siddhi Application.
+      description: |
+        Deletes all revisions of the periodic state of the specified Siddhi Application.
+      produces:
+      - application/json
+      parameters:
+      - name: appName
+        in: path
+        description: The name of the Siddhi Application.
+        required: true
+        type: string
+      - name: enabledRedeployment
+        in: query
+        description: Whether the redeployment enable or not
+        required: false
+        type: string
+      responses:
+        '200':
+          description: All revisions of the periodic state of the siddhi application are deleted succussfully.
+        '404':
+          description: The Siddhi Application is not found.
+          schema:
+            $ref: '#/definitions/ApiResponseMessageWithCode'
+        '500':
+          description: An unexpected error occured.
+          schema:
+            $ref: '#/definitions/ApiResponseMessageWithCode'
+  '/siddhi-apps/revisions':
+    delete:
+      x-wso2-curl: 'curl -k -X DELETE http://localhost:9090/siddhi-apps/revisions'
+      x-wso2-request: 'DELETE http://localhost:9090/siddhi-apps/revisions'
+      x-wso2-response: >-
+        HTTP/1.1 200 OK Content-Type: application/json
+        {"type":"success","message":"All revisions of periodic state deleted for all Siddhi
+        Apps"}
+      tags:
+      - State
+      summary: Deletes all revisions of the periodic state of all Siddhi Applications.
+      description: |
+        Deletes all revisions of the periodic state of all Siddhi Applications.
+      produces:
+      - application/json
+      parameters:
+      - name: enabledRedeployment
+        in: query
+        description: Whether the redeployment enable or not
+        required: false
+        type: string
+      responses:
+        '200':
+          description: All revisions of the periodic state of all the siddhi applicationa are deleted succussfully.
+        '500':
+          description: An unexpected error occured.
+          schema:
+            $ref: '#/definitions/ApiResponseMessageWithCode'
 definitions:
   SiddhiAppContent:
     type: object

--- a/components/org.wso2.carbon.stream.processor.core/src/test/resources/swagger.yaml
+++ b/components/org.wso2.carbon.stream.processor.core/src/test/resources/swagger.yaml
@@ -218,6 +218,71 @@ paths:
           description: An unexpected error occured.
           schema:
             $ref: '#/definitions/ApiResponseMessageWithCode'
+  '/siddhi-apps/{appName}/revisions':
+    delete:
+      x-wso2-curl: 'curl -k -X DELETE http://localhost:9090/siddhi-apps/TestSiddhiApp1/revisions'
+      x-wso2-request: 'DELETE http://localhost:9090/siddhi-apps/TestSiddhiApp1/revisions'
+      x-wso2-response: >-
+        HTTP/1.1 200 OK Content-Type: application/json
+        {"type":"success","message":"All revisions of periodic state deleted for Siddhi
+        App :TestSiddhiApp1"}
+      tags:
+      - State
+      summary: Deletes all revisions of the periodic state of a Siddhi Application.
+      description: |
+        Deletes all revisions of the periodic state of the specified Siddhi Application.
+      produces:
+      - application/json
+      parameters:
+      - name: appName
+        in: path
+        description: The name of the Siddhi Application.
+        required: true
+        type: string
+      - name: enabledRedeployment
+        in: query
+        description: Whether the redeployment enable or not
+        required: false
+        type: string
+      responses:
+        '200':
+          description: All revisions of the periodic state of the siddhi application are deleted succussfully.
+        '404':
+          description: The Siddhi Application is not found.
+          schema:
+            $ref: '#/definitions/ApiResponseMessageWithCode'
+        '500':
+          description: An unexpected error occured.
+          schema:
+            $ref: '#/definitions/ApiResponseMessageWithCode'
+  '/siddhi-apps/revisions':
+    delete:
+      x-wso2-curl: 'curl -k -X DELETE http://localhost:9090/siddhi-apps/revisions'
+      x-wso2-request: 'DELETE http://localhost:9090/siddhi-apps/revisions'
+      x-wso2-response: >-
+        HTTP/1.1 200 OK Content-Type: application/json
+        {"type":"success","message":"All revisions of periodic state deleted for all Siddhi
+        Apps"}
+      tags:
+      - State
+      summary: Deletes all revisions of the periodic state of all Siddhi Applications.
+      description: |
+        Deletes all revisions of the periodic state of all Siddhi Applications.
+      produces:
+      - application/json
+      parameters:
+      - name: enabledRedeployment
+        in: query
+        description: Whether the redeployment enable or not
+        required: false
+        type: string
+      responses:
+        '200':
+          description: All revisions of the periodic state of all the siddhi applicationa are deleted succussfully.
+        '500':
+          description: An unexpected error occured.
+          schema:
+            $ref: '#/definitions/ApiResponseMessageWithCode'
 definitions:
   SiddhiAppContent:
     type: object

--- a/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/DBPersistenceStoreTestcase.java
+++ b/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/DBPersistenceStoreTestcase.java
@@ -276,4 +276,55 @@ public class DBPersistenceStoreTestcase {
             }
         }
     }
+
+    @Test(dependsOnMethods = {"testPeriodicDBSystemPersistence"})
+    public void testPeriodicDBSystemPersistenceClear() {
+
+        Connection con = null;
+        PreparedStatement stmt = null;
+        try {
+            DataSource dataSource = (HikariDataSource) dataSourceService.getDataSource("WSO2_ANALYTICS_DB");
+            con = dataSource.getConnection();
+            int count = 0;
+
+            SiddhiManager siddhiManager = StreamProcessorDataHolder.getSiddhiManager();
+            SiddhiAppRuntime siddhiAppRuntime = siddhiManager.getSiddhiAppRuntime(SIDDHIAPP_NAME);
+
+            stmt = con.prepareStatement(selectLastQuery);
+            stmt.setString(1, siddhiManager.getSiddhiAppRuntime(SIDDHIAPP_NAME).getName());
+            ResultSet resultSet = stmt.executeQuery();
+            while (resultSet.next()) {
+                count++;
+            }
+            //check whether the data exists in the table
+            if (count == 0) {
+                Assert.fail("Already data does not exists in the database table");
+            }
+
+            siddhiAppRuntime.clearAllRevisionsOfSiddhiAppInPersistenceStore();
+
+            resultSet = stmt.executeQuery();
+            count = 0;
+            while (resultSet.next()) {
+                count++;
+            }
+            Assert.assertEquals(count, 0);
+
+        } catch (SQLException e) {
+            log.error("Error in processing query ", e);
+        } catch (DataSourceException e) {
+            log.error("Cannot establish connection to the data source ", e);
+        } finally {
+            try {
+                if (con != null) {
+                    con.close();
+                }
+                if (stmt != null) {
+                    stmt.close();
+                }
+            } catch (SQLException e) {
+                log.error("Error in closing connection to test datasource ", e);
+            }
+        }
+    }
 }

--- a/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/DBPersistenceStoreTestcase.java
+++ b/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/DBPersistenceStoreTestcase.java
@@ -301,7 +301,7 @@ public class DBPersistenceStoreTestcase {
                 Assert.fail("Already data does not exists in the database table");
             }
 
-            siddhiAppRuntime.clearAllRevisionsOfSiddhiAppInPersistenceStore();
+            siddhiAppRuntime.clearAllRevisions();
 
             resultSet = stmt.executeQuery();
             count = 0;

--- a/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/FileSystemPersistenceStoreTestcase.java
+++ b/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/FileSystemPersistenceStoreTestcase.java
@@ -164,7 +164,7 @@ public class FileSystemPersistenceStoreTestcase {
         }
 
         log.info("Deleting all the revisions of the persistence store of Siddhi App : " + SIDDHIAPP_NAME );
-        siddhiAppRuntime.clearAllRevisionsOfSiddhiAppInPersistenceStore();
+        siddhiAppRuntime.clearAllRevisions();
         Assert.assertEquals(file.list().length, 0, "All the revisions should be deleted");
     }
 

--- a/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/FileSystemPersistenceStoreTestcase.java
+++ b/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/FileSystemPersistenceStoreTestcase.java
@@ -152,4 +152,20 @@ public class FileSystemPersistenceStoreTestcase {
         Assert.assertEquals(file.list().length, 2, "There should be two revisions persisted");
     }
 
+    @Test(dependsOnMethods = {"testFileSystemPeriodicPersistence"})
+    public void testFileSystemClearPeriodicPersistence() {
+        File file = new File(PERSISTENCE_FOLDER + File.separator + SIDDHIAPP_NAME);
+
+        SiddhiManager siddhiManager = StreamProcessorDataHolder.getSiddhiManager();
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.getSiddhiAppRuntime(SIDDHIAPP_NAME);
+
+        if (file.list().length == 0) {
+            Assert.fail("File revisions are already deleted");
+        }
+
+        log.info("Deleting all the revisions of the persistence store of Siddhi App : " + SIDDHIAPP_NAME );
+        siddhiAppRuntime.clearAllRevisionsOfSiddhiAppInPersistenceStore();
+        Assert.assertEquals(file.list().length, 0, "All the revisions should be deleted");
+    }
+
 }

--- a/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/IncrementalDBPersistenceStoreTestcase.java
+++ b/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/IncrementalDBPersistenceStoreTestcase.java
@@ -250,7 +250,7 @@ public class IncrementalDBPersistenceStoreTestcase {
                 Assert.fail("Already data does not exists in the database table");
             }
 
-            siddhiAppRuntime.clearAllRevisionsOfSiddhiAppInPersistenceStore();
+            siddhiAppRuntime.clearAllRevisions();
 
             resultSet = stmt.executeQuery();
             count = 0;

--- a/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/IncrementalDBPersistenceStoreTestcase.java
+++ b/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/IncrementalDBPersistenceStoreTestcase.java
@@ -225,4 +225,55 @@ public class IncrementalDBPersistenceStoreTestcase {
         Assert.assertEquals(SiddhiAppUtil.outputElementsArray, Arrays.asList("500", "500", "500", "500", "500",
                 "300", "300", "280", "280", "280"));
     }
+
+    @Test(dependsOnMethods = {"testRestoreFromDBSystem"})
+    public void testPeriodicDBSystemPersistenceClear() throws InterruptedException {
+
+        Connection con = null;
+        PreparedStatement stmt = null;
+        try {
+            DataSource dataSource = (HikariDataSource) dataSourceService.getDataSource("WSO2_ANALYTICS_DB");
+            con = dataSource.getConnection();
+            int count = 0;
+
+            SiddhiManager siddhiManager = StreamProcessorDataHolder.getSiddhiManager();
+            SiddhiAppRuntime siddhiAppRuntime = siddhiManager.getSiddhiAppRuntime(SIDDHIAPP_NAME);
+
+            stmt = con.prepareStatement(selectLastQuery);
+            stmt.setString(1, siddhiManager.getSiddhiAppRuntime(SIDDHIAPP_NAME).getName());
+            ResultSet resultSet = stmt.executeQuery();
+            while (resultSet.next()) {
+                count++;
+            }
+            //check whether the data exists in the table
+            if (count == 0) {
+                Assert.fail("Already data does not exists in the database table");
+            }
+
+            siddhiAppRuntime.clearAllRevisionsOfSiddhiAppInPersistenceStore();
+
+            resultSet = stmt.executeQuery();
+            count = 0;
+            while (resultSet.next()) {
+                count++;
+            }
+            Assert.assertEquals(count, 0);
+
+        } catch (SQLException e) {
+            log.error("Error in processing query ", e);
+        } catch (DataSourceException e) {
+            log.error("Cannot establish connection to the data source ", e);
+        } finally {
+            try {
+                if (con != null) {
+                    con.close();
+                }
+                if (stmt != null) {
+                    stmt.close();
+                }
+            } catch (SQLException e) {
+                log.error("Error in closing connection to test datasource ", e);
+            }
+        }
+    }
 }

--- a/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/IncrementalFileSystemPersistenceStoreTestcase.java
+++ b/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/IncrementalFileSystemPersistenceStoreTestcase.java
@@ -151,7 +151,7 @@ public class IncrementalFileSystemPersistenceStoreTestcase {
         }
 
         log.info("Deleting all the revisions of the persistence store of Siddhi App : " + SIDDHIAPP_NAME );
-        siddhiAppRuntime.clearAllRevisionsOfSiddhiAppInPersistenceStore();
+        siddhiAppRuntime.clearAllRevisions();
         Assert.assertEquals(file.list().length, 0, "All the revisions should be cleared");
     }
 }

--- a/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/IncrementalFileSystemPersistenceStoreTestcase.java
+++ b/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/IncrementalFileSystemPersistenceStoreTestcase.java
@@ -138,4 +138,20 @@ public class IncrementalFileSystemPersistenceStoreTestcase {
         Assert.assertEquals(SiddhiAppUtil.outputElementsArray, Arrays.asList("500", "500", "500", "500", "500",
                 "300", "300", "280", "280", "280"));
     }
+
+    @Test(dependsOnMethods = {"testRestoreFromFileSystem"})
+    public void testFileSystemClearPeriodicPersistence() {
+        File file = new File(PERSISTENCE_FOLDER + File.separator + SIDDHIAPP_NAME);
+
+        SiddhiManager siddhiManager = StreamProcessorDataHolder.getSiddhiManager();
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.getSiddhiAppRuntime(SIDDHIAPP_NAME);
+
+        if (file.list().length == 0) {
+            Assert.fail("File revisions are already deleted");
+        }
+
+        log.info("Deleting all the revisions of the persistence store of Siddhi App : " + SIDDHIAPP_NAME );
+        siddhiAppRuntime.clearAllRevisionsOfSiddhiAppInPersistenceStore();
+        Assert.assertEquals(file.list().length, 0, "All the revisions should be cleared");
+    }
 }

--- a/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/SiddhiAsAPITestcase.java
+++ b/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/SiddhiAsAPITestcase.java
@@ -29,6 +29,7 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.analytics.test.osgi.util.TestUtil;
 import org.wso2.carbon.analytics.test.osgi.util.HTTPResponseMessage;
 import org.wso2.carbon.container.CarbonContainerFactory;
+import org.wso2.carbon.container.options.CarbonDistributionOption;
 import org.wso2.carbon.kernel.CarbonServerInfo;
 import org.wso2.carbon.stream.processor.common.EventStreamService;
 import org.wso2.carbon.stream.processor.common.SiddhiAppRuntimeService;
@@ -74,8 +75,8 @@ public class SiddhiAsAPITestcase {
                 copySiddhiFileOption(),
                 carbonDistribution(
                         Paths.get("target", "wso2das-" + System.getProperty("carbon.analytic.version")),
-                        "worker")
-                //CarbonDistributionOption.debug(5005)
+                        "worker"),
+                CarbonDistributionOption.debug(5005)
         };
     }
 
@@ -714,6 +715,68 @@ public class SiddhiAsAPITestcase {
         HTTPResponseMessage httpResponseMessage = sendHRequest(null, baseURI, path, contentType, method,
                 true, DEFAULT_USER_NAME, "admin2");
         Assert.assertEquals(httpResponseMessage.getResponseCode(), 401);
+    }
+
+    /**
+     * Persistence clearing of existing Siddhi App
+     */
+    @Test (dependsOnMethods = {"testValidSiddhiAPPDeployment"})
+    public void testSiddhiAppPersistenceStoreClear() throws Exception {
+
+        URI baseURI = URI.create(String.format("http://%s:%d", "localhost", 9090));
+        String path = "/siddhi-apps/SiddhiApp1/revisions";
+        String contentType = "text/plain";
+        String method = "DELETE";
+
+        logger.info("Deleting the persistence store through REST API");
+        HTTPResponseMessage httpResponseMessage = sendHRequest("", baseURI, path, contentType, method,
+                true, DEFAULT_USER_NAME, DEFAULT_PASSWORD);
+        Assert.assertEquals(httpResponseMessage.getResponseCode(), 200);
+        Assert.assertEquals(httpResponseMessage.getContentType(), "application/json");
+        Thread.sleep(2000);
+
+    }
+
+    /**
+     *
+     * Persistence clearing of all Siddhi Applications
+     */
+    @Test (dependsOnMethods = {"testValidSiddhiAPPDeployment"})
+    public void testAllSiddhiAppsPersistenceStoreClear() throws Exception {
+
+        URI baseURI = URI.create(String.format("http://%s:%d", "localhost", 9090));
+        String path = "/siddhi-apps/revisions";
+        String contentType = "text/plain";
+        String method = "DELETE";
+
+        logger.info("Deleting the persistence store through REST API");
+        HTTPResponseMessage httpResponseMessage = sendHRequest("", baseURI, path, contentType, method,
+                true, DEFAULT_USER_NAME, DEFAULT_PASSWORD);
+        Assert.assertEquals(httpResponseMessage.getResponseCode(), 200);
+        Assert.assertEquals(httpResponseMessage.getContentType(), "application/json");
+        Thread.sleep(2000);
+
+    }
+
+    /**
+     *
+     * Persistence clearing of non-existing Siddhi App
+     */
+    @Test (dependsOnMethods = {"testValidSiddhiAPPDeployment"})
+    public void testInvalidSiddhiAppPersistenceStoreClear() throws Exception {
+
+        URI baseURI = URI.create(String.format("http://%s:%d", "localhost", 9090));
+        String path = "/siddhi-apps/SiddhiAppInvalid/revisions";
+        String contentType = "text/plain";
+        String method = "DELETE";
+
+        logger.info("Deleting the persistence store through REST API");
+        HTTPResponseMessage httpResponseMessage = sendHRequest("", baseURI, path, contentType, method,
+                true, DEFAULT_USER_NAME, DEFAULT_PASSWORD);
+        Assert.assertEquals(httpResponseMessage.getResponseCode(), 404);
+        Assert.assertEquals(httpResponseMessage.getContentType(), "application/json");
+        Thread.sleep(2000);
+
     }
 
     private HTTPResponseMessage sendHRequest(String body, URI baseURI, String path, String contentType,

--- a/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/SiddhiAsAPITestcase.java
+++ b/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/SiddhiAsAPITestcase.java
@@ -29,7 +29,6 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.analytics.test.osgi.util.TestUtil;
 import org.wso2.carbon.analytics.test.osgi.util.HTTPResponseMessage;
 import org.wso2.carbon.container.CarbonContainerFactory;
-import org.wso2.carbon.container.options.CarbonDistributionOption;
 import org.wso2.carbon.kernel.CarbonServerInfo;
 import org.wso2.carbon.stream.processor.common.EventStreamService;
 import org.wso2.carbon.stream.processor.common.SiddhiAppRuntimeService;
@@ -75,8 +74,8 @@ public class SiddhiAsAPITestcase {
                 copySiddhiFileOption(),
                 carbonDistribution(
                         Paths.get("target", "wso2das-" + System.getProperty("carbon.analytic.version")),
-                        "worker"),
-                CarbonDistributionOption.debug(5005)
+                        "worker")
+                //CarbonDistributionOption.debug(5005)
         };
     }
 

--- a/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/SiddhiAsAPITestcase.java
+++ b/components/osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/SiddhiAsAPITestcase.java
@@ -738,27 +738,6 @@ public class SiddhiAsAPITestcase {
 
     /**
      *
-     * Persistence clearing of all Siddhi Applications
-     */
-    @Test (dependsOnMethods = {"testValidSiddhiAPPDeployment"})
-    public void testAllSiddhiAppsPersistenceStoreClear() throws Exception {
-
-        URI baseURI = URI.create(String.format("http://%s:%d", "localhost", 9090));
-        String path = "/siddhi-apps/revisions";
-        String contentType = "text/plain";
-        String method = "DELETE";
-
-        logger.info("Deleting the persistence store through REST API");
-        HTTPResponseMessage httpResponseMessage = sendHRequest("", baseURI, path, contentType, method,
-                true, DEFAULT_USER_NAME, DEFAULT_PASSWORD);
-        Assert.assertEquals(httpResponseMessage.getResponseCode(), 200);
-        Assert.assertEquals(httpResponseMessage.getContentType(), "application/json");
-        Thread.sleep(2000);
-
-    }
-
-    /**
-     *
      * Persistence clearing of non-existing Siddhi App
      */
     @Test (dependsOnMethods = {"testValidSiddhiAPPDeployment"})

--- a/pom.xml
+++ b/pom.xml
@@ -1536,8 +1536,8 @@
 
     <properties>
         <carbon.analytics.version>2.0.477-SNAPSHOT</carbon.analytics.version>
-        <siddhi.version>4.3.3</siddhi.version>
-        <siddhi.bundle.version>4.3.3</siddhi.bundle.version>
+        <siddhi.version>4.3.12</siddhi.version>
+        <siddhi.bundle.version>4.3.12</siddhi.bundle.version>
         <siddhi.version.range>[4.0.0, 5.0.0)</siddhi.version.range>
         <carbon.analytics-common.version>6.0.72</carbon.analytics-common.version>
         <carbon.analytics-common.version.range>[6.0.66, 6.1.0)</carbon.analytics-common.version.range>


### PR DESCRIPTION
## Purpose
> Provide the ability to delete the periodic persistence store of a specific Siddhi app or all Siddhi apps

## Approach
> Two approaches were implemented. Through REST end points is one way of deleting periodic persistence store, and the other way is through worker.sh, i.e. when deploying the Siddhi apps.

## Documentation
> You can find the relevant deployment configurations from the [doc](https://docs.google.com/document/d/1x7dHz4DENhhlWVUdoqlAQeVtoLSiEhBJN_gefMjoOik/edit#).

## Automation tests
 - Integration tests
   > Integration tests included. (85 % coverage)

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> JDK version: 1.8
Operating system: MacOS 10.14, Windows 10
Database system: mysql, oracle
