### PR TITLE
Adding configuration to select job manager application creator class

### DIFF
--- a/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/bean/DeploymentConfig.java
+++ b/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/bean/DeploymentConfig.java
@@ -49,11 +49,11 @@ public class DeploymentConfig implements Serializable {
      * @deprecated zooKeeperURLs is moved to {@link ZooKeeperConfig} bean
      */
     @Deprecated
-    @Element(description = "ZooKeeper urls of Kafka cluster", required = true)
+    @Element(description = "ZooKeeper urls of Kafka cluster")
     private String zooKeeperURLs;
-    @Element(description = "ZooKeeper configurations", required = true)
+    @Element(description = "ZooKeeper configurations")
     private ZooKeeperConfig zooKeeperConfig;
-    @Element(description = "JMS Factory initial configuration", required = true)
+    @Element(description = "JMS Factory initial configuration")
     private String factoryInitial;
     @Element(description = "provider url configuration for siddhi-jms-io")
     private String providerUrl;
@@ -63,6 +63,8 @@ public class DeploymentConfig implements Serializable {
     private String natsServerUrl;
     @Element(description = "Id of the created nats cluster")
     private String clusterId;
+    @Element(description = "Siddhi App Creator based on the distribute implementation")
+    private String appCreatorClass = "org.wso2.carbon.sp.jobmanager.core.appcreator.KafkaSiddhiAppCreator";
 
     public String getNatsServerUrl() {
         return natsServerUrl;
@@ -185,4 +187,11 @@ public class DeploymentConfig implements Serializable {
         this.queries = queries;
     }
 
+    public String getAppCreatorClass() {
+        return appCreatorClass;
+    }
+
+    public void setAppCreatorClass(String appCreatorClass) {
+        this.appCreatorClass = appCreatorClass;
+    }
 }

--- a/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/internal/ServiceComponent.java
+++ b/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/internal/ServiceComponent.java
@@ -85,10 +85,8 @@ public class ServiceComponent {
                 AbstractSiddhiAppCreator siddhiAppCreator = (AbstractSiddhiAppCreator)
                         Class.forName(siddhiAppCreatorClassName).newInstance();
                 distributionServiceRegistration = bundleContext.registerService(
-                        DistributionService.class.getName(),
-                        new DistributionManagerServiceImpl(siddhiAppCreator,
-                                ServiceDataHolder.getDeploymentManager()),
-                        null);
+                        DistributionService.class.getName(), new DistributionManagerServiceImpl(siddhiAppCreator,
+                                ServiceDataHolder.getDeploymentManager()), null);
                 if (log.isDebugEnabled()) {
                     log.debug(siddhiAppCreatorClassName + " chosen as Siddhi Distributed App Creator");
                 }

--- a/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/internal/ServiceComponent.java
+++ b/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/internal/ServiceComponent.java
@@ -36,7 +36,7 @@ import org.wso2.carbon.datasource.core.api.DataSourceService;
 import org.wso2.carbon.sp.jobmanager.core.CoordinatorChangeListener;
 import org.wso2.carbon.sp.jobmanager.core.allocation.ResourceAllocationAlgorithm;
 import org.wso2.carbon.sp.jobmanager.core.api.ResourceManagerApi;
-import org.wso2.carbon.sp.jobmanager.core.appcreator.KafkaSiddhiAppCreator;
+import org.wso2.carbon.sp.jobmanager.core.appcreator.AbstractSiddhiAppCreator;
 import org.wso2.carbon.stream.processor.common.utils.config.ClusterConfig;
 import org.wso2.carbon.sp.jobmanager.core.bean.DeploymentConfig;
 import org.wso2.carbon.sp.jobmanager.core.deployment.DeploymentManagerImpl;
@@ -80,11 +80,23 @@ public class ServiceComponent {
             ServiceDataHolder.setDeploymentManager(new DeploymentManagerImpl());
             resourceManagerAPIServiceRegistration = bundleContext.registerService(Microservice.class.getName(),
                     new ResourceManagerApi(), null);
-            distributionServiceRegistration = bundleContext.registerService(
-                    DistributionService.class.getName(),
-                    new DistributionManagerServiceImpl(new KafkaSiddhiAppCreator(),
-                            ServiceDataHolder.getDeploymentManager()),
-                    null);
+            String siddhiAppCreatorClassName = ServiceDataHolder.getDeploymentConfig().getAppCreatorClass();
+            try {
+                AbstractSiddhiAppCreator siddhiAppCreator = (AbstractSiddhiAppCreator)
+                        Class.forName(siddhiAppCreatorClassName).newInstance();
+                distributionServiceRegistration = bundleContext.registerService(
+                        DistributionService.class.getName(),
+                        new DistributionManagerServiceImpl(siddhiAppCreator,
+                                ServiceDataHolder.getDeploymentManager()),
+                        null);
+                if (log.isDebugEnabled()) {
+                    log.debug(siddhiAppCreatorClassName + " chosen as Siddhi Distributed App Creator");
+                }
+            } catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
+                throw new ResourceManagerException("Error while initializing Manager node in distributed mode, " +
+                        " Siddhi Distributed App creator class '" + siddhiAppCreatorClassName + "' is " +
+                        "specified in deployment.yaml not found.", e);
+            }
         }
     }
 


### PR DESCRIPTION
## Purpose
> The purpose of this PR is to give a configuration to select job manager application creator class. In the existing implementation, only the 'KafkaSiddhiAppCreator' used as default by the job manager service, but with the new configuration **'appCreatorClass' ** a user can specify the Siddhi App creator class in the deployment.yaml configuration:

e.g:
```
deployment.config:
  type: distributed
  httpsInterface:
   host: ${NODE_ID}
   port: 9543
  heartbeatInterval: 2000
  heartbeatMaxRetry: 4
  datasource: SP_MGT_DB # define a mysql datasource in datasources and refer it from here.
  minResourceCount: 1
  natsServerUrl: nats://sp-nats:4222
  clusterId: test-cluster
  appCreatorClass: org.wso2.carbon.sp.jobmanager.core.appcreator.NatsSiddhiAppCreator
```

## Goals
> Adding configuration to select job manager application creator class.

## Approach
> Based on the user define configuration, Siddhi App Creator instantiate with 'appCreatorClass' name. And the 'org.wso2.carbon.sp.jobmanager.core.appcreator.KafkaSiddhiAppCreator' use as default app creator implementation.  

## User stories
> As a user, I would be able to select the siddhi app creator implementation in a distributed deployment.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> This fix will be added into the product via WUM, at that time we need to update the relevant document with the new configuration.
```
@Element(description = "Siddhi App Creator based on the distribute implementation")
    private String appCreatorClass = "org.wso2.carbon.sp.jobmanager.core.appcreator.KafkaSiddhiAppCreator";
```

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A
## Automation tests
 - N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A, default value taken as Kafka(if the user not given this new configuration, then the default value applies)

## Test environment
> Tested with Docker Compose setup ( Nats + 2 Manager + 4 Worker + Mysql)
Tested App:
```
@App:name('TestPlan4')
@Source(type = 'http', receiver.url='http://0.0.0.0:9055/productionStream', basic.auth.enabled='false',
    @map(type='json'))
define stream ProductionStreamInput (name string, amount double);
@sink(type='log')
define stream LowProductionAlertStream (name string, amount double);
@dist(parallel = '1', execGroup = 'gp1')
from ProductionStreamInput 
select * 
insert into ProductionStream;
@dist(parallel = '4', execGroup = 'gp2')
@info(name='query1')
from ProductionStream 
select *
insert into LowProductionAlertStream;
```
Tested Event:
```
curl -X POST -d "{\"event\": {\"name\":\"sugar\",\"amount\": 20.5}}"  http://0.0.0.0:9058/productionStream --header "Content-Type:application/json"
```
## Learning
> N/A