### PR TITLE
Add pagination support for Siddhi Data Provider

### DIFF
--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/AbstractDataProvider.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/AbstractDataProvider.java
@@ -44,7 +44,7 @@ public abstract class AbstractDataProvider implements DataProvider {
     private long publishingInterval;
     private long purgingInterval;
     private boolean isPurgingEnable;
-    private boolean isPaginationEnable;
+    private boolean isPaginationEnabled;
 
     public DataProvider init(String topic, String sessionId, ProviderConfig providerConfig)
             throws DataProviderException {
@@ -54,7 +54,7 @@ public abstract class AbstractDataProvider implements DataProvider {
             this.publishingInterval = providerConfig.getPublishingInterval();
             this.purgingInterval = providerConfig.getPurgingInterval();
             this.isPurgingEnable = providerConfig.isPurgingEnable();
-            this.isPaginationEnable = providerConfig.isPaginationEnable();
+            this.isPaginationEnabled = providerConfig.isPaginationEnabled();
             this.setProviderConfig(providerConfig);
             return this;
         } else {
@@ -71,7 +71,7 @@ public abstract class AbstractDataProvider implements DataProvider {
 
     @Override
     public void start() {
-        if (!this.isPaginationEnable) {
+        if (!this.isPaginationEnabled) {
             this.dataPublishingExecutorService.scheduleAtFixedRate(() -> {
                 this.publish(this.topic, this.sessionId);
             }, 0L, this.publishingInterval, TimeUnit.SECONDS);

--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/AbstractDataProvider.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/AbstractDataProvider.java
@@ -44,16 +44,18 @@ public abstract class AbstractDataProvider implements DataProvider {
     private long publishingInterval;
     private long purgingInterval;
     private boolean isPurgingEnable;
+    private boolean isPaginationEnable;
 
     public DataProvider init(String topic, String sessionId, ProviderConfig providerConfig)
             throws DataProviderException {
-        if (configValidator(providerConfig)) {
+        if (this.configValidator(providerConfig)) {
             this.topic = topic;
             this.sessionId = sessionId;
             this.publishingInterval = providerConfig.getPublishingInterval();
             this.purgingInterval = providerConfig.getPurgingInterval();
             this.isPurgingEnable = providerConfig.isPurgingEnable();
-            setProviderConfig(providerConfig);
+            this.isPaginationEnable = providerConfig.isPaginationEnable();
+            this.setProviderConfig(providerConfig);
             return this;
         } else {
             throw new DataProviderException("Invalid configuration provided. Unable to complete initialization " +
@@ -69,10 +71,11 @@ public abstract class AbstractDataProvider implements DataProvider {
 
     @Override
     public void start() {
-        dataPublishingExecutorService.scheduleAtFixedRate(() -> {
-
-            publish(this.topic, this.sessionId);
-        }, 0, publishingInterval, TimeUnit.SECONDS);
+        if (!this.isPaginationEnable) {
+            this.dataPublishingExecutorService.scheduleAtFixedRate(() -> {
+                this.publish(this.topic, this.sessionId);
+            }, 0L, this.publishingInterval, TimeUnit.SECONDS);
+        }
         if (isPurgingEnable) {
             dataPublishingExecutorService.scheduleAtFixedRate(() -> {
                 purging();

--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/ProviderConfig.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/ProviderConfig.java
@@ -48,5 +48,5 @@ public interface ProviderConfig {
      *
      * @return enable or disable state as boolean value.
      */
-    boolean isPaginationEnable();
+    boolean isPaginationEnabled();
 }

--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/ProviderConfig.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/ProviderConfig.java
@@ -42,4 +42,11 @@ public interface ProviderConfig {
      * @return enable or disable state as boolean value.
      */
     boolean isPurgingEnable();
+
+    /**
+     * Get pagination enable or disable state.
+     *
+     * @return enable or disable state as boolean value.
+     */
+    boolean isPaginationEnable();
 }

--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/bean/DataProviderConfigRoot.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/bean/DataProviderConfigRoot.java
@@ -30,10 +30,10 @@ public class DataProviderConfigRoot {
     private JsonElement dataProviderConfiguration;
 
     /**
-     * enum for define the supportive data column types.
+     * Enum for define the supportive data provider action types.
      */
     public enum Types {
-        SUBSCRIBE, UNSUBSCRIBE
+        SUBSCRIBE, UNSUBSCRIBE, POLLING
     }
 
     public DataProviderConfigRoot() {

--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/endpoint/DataProviderEndPoint.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/endpoint/DataProviderEndPoint.java
@@ -115,7 +115,7 @@ public class DataProviderEndPoint implements WebSocketEndpoint {
                         dataProvider);
                 if (dataProvider instanceof SiddhiProvider) {
                     SiddhiProvider siddhiProvider = (SiddhiProvider)dataProvider;
-                    if(siddhiProvider.getSiddhiDataProviderConfig().isPaginationEnable()){
+                    if(siddhiProvider.getSiddhiDataProviderConfig().isPaginationEnabled()){
                         siddhiProvider.publishWithPagination(dataProviderConfigRoot.getDataProviderConfiguration(),
                                 dataProviderConfigRoot.getTopic(), session.getId());
                     }
@@ -127,25 +127,22 @@ public class DataProviderEndPoint implements WebSocketEndpoint {
                     .toString())){
                 Map<String, DataProvider> topicDataProviderMap =  getDataProviderHelper().
                         getTopicDataProviderMap(session.getId());
-                if(topicDataProviderMap != null){
+                if (topicDataProviderMap != null) {
                     DataProvider dataProvider = topicDataProviderMap.get(dataProviderConfigRoot.getTopic());
-                    if (dataProvider != null) {
-                        AbstractDataProvider abstractDataProvider = (AbstractDataProvider) dataProvider;
-                        if (abstractDataProvider instanceof SiddhiProvider) {
-                            SiddhiProvider siddhiProvider = (SiddhiProvider)abstractDataProvider;
-                            if(siddhiProvider.getSiddhiDataProviderConfig().isPaginationEnable()){
-                                siddhiProvider.publishWithPagination(dataProviderConfigRoot
-                                                .getDataProviderConfiguration(), dataProviderConfigRoot.getTopic(),
-                                                    session.getId());
-                            } else {
-                                siddhiProvider.publish(dataProviderConfigRoot.getTopic(), session.getId());
-                            }
-                        } else {
-                            abstractDataProvider.publish(dataProviderConfigRoot.getTopic(), session.getId());
-                        }
-                    } else {
+                    if (dataProvider == null) {
                         throw new Exception("Error while performing action: " + dataProviderConfigRoot.getAction() +
                                 ", data provider for session id: " + session.getId() + " not found.");
+                    } else if (dataProvider instanceof SiddhiProvider) {
+                        SiddhiProvider siddhiProvider = (SiddhiProvider)dataProvider;
+                        if (siddhiProvider.getSiddhiDataProviderConfig().isPaginationEnabled()) {
+                            siddhiProvider.publishWithPagination(dataProviderConfigRoot.getDataProviderConfiguration(),
+                                    dataProviderConfigRoot.getTopic(), session.getId());
+                        } else {
+                            siddhiProvider.publish(dataProviderConfigRoot.getTopic(), session.getId());
+                        }
+                    } else {
+                        AbstractDataProvider abstractDataProvider = (AbstractDataProvider) dataProvider;
+                        abstractDataProvider.publish(dataProviderConfigRoot.getTopic(), session.getId());
                     }
                 } else {
                     throw new Exception("Error while performing action: " + dataProviderConfigRoot.getAction() +

--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/endpoint/DataProviderEndPoint.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/endpoint/DataProviderEndPoint.java
@@ -17,7 +17,6 @@
  */
 package org.wso2.carbon.data.provider.endpoint;
 
-
 import com.google.gson.Gson;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -112,6 +111,13 @@ public class DataProviderEndPoint implements WebSocketEndpoint {
                         dataProviderConfigRoot.getDataProviderConfiguration()).start();
                 getDataProviderHelper().addDataProviderToSessionMap(session.getId(), dataProviderConfigRoot.getTopic(),
                         dataProvider);
+                if (dataProvider instanceof SiddhiProvider) {
+                    SiddhiProvider siddhiProvider = (SiddhiProvider)dataProvider;
+                    if(siddhiProvider.getSiddhiDataProviderConfig().isPaginationEnable()){
+                        siddhiProvider.publishWithPagination(dataProviderConfigRoot.getDataProviderConfiguration(),
+                                dataProviderConfigRoot.getTopic(), session.getId());
+                    }
+                }
             } else if (dataProviderConfigRoot.getAction().equalsIgnoreCase(DataProviderConfigRoot.Types.UNSUBSCRIBE
                     .toString())) {
                 getDataProviderHelper().removeTopicIfExist(session.getId(), dataProviderConfigRoot.getTopic());

--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/endpoint/DataProviderEndPoint.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/endpoint/DataProviderEndPoint.java
@@ -25,8 +25,10 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.config.provider.ConfigProvider;
+import org.wso2.carbon.data.provider.AbstractDataProvider;
 import org.wso2.carbon.data.provider.DataProvider;
 import org.wso2.carbon.data.provider.bean.DataProviderConfigRoot;
+import org.wso2.carbon.data.provider.siddhi.SiddhiProvider;
 import org.wso2.carbon.datasource.core.api.DataSourceService;
 import org.wso2.msf4j.websocket.WebSocketEndpoint;
 
@@ -121,13 +123,41 @@ public class DataProviderEndPoint implements WebSocketEndpoint {
             } else if (dataProviderConfigRoot.getAction().equalsIgnoreCase(DataProviderConfigRoot.Types.UNSUBSCRIBE
                     .toString())) {
                 getDataProviderHelper().removeTopicIfExist(session.getId(), dataProviderConfigRoot.getTopic());
+            } else if (dataProviderConfigRoot.getAction().equalsIgnoreCase(DataProviderConfigRoot.Types.POLLING
+                    .toString())){
+                Map<String, DataProvider> topicDataProviderMap =  getDataProviderHelper().
+                        getTopicDataProviderMap(session.getId());
+                if(topicDataProviderMap != null){
+                    DataProvider dataProvider = topicDataProviderMap.get(dataProviderConfigRoot.getTopic());
+                    if (dataProvider != null) {
+                        AbstractDataProvider abstractDataProvider = (AbstractDataProvider) dataProvider;
+                        if (abstractDataProvider instanceof SiddhiProvider) {
+                            SiddhiProvider siddhiProvider = (SiddhiProvider)abstractDataProvider;
+                            if(siddhiProvider.getSiddhiDataProviderConfig().isPaginationEnable()){
+                                siddhiProvider.publishWithPagination(dataProviderConfigRoot
+                                                .getDataProviderConfiguration(), dataProviderConfigRoot.getTopic(),
+                                                    session.getId());
+                            } else {
+                                siddhiProvider.publish(dataProviderConfigRoot.getTopic(), session.getId());
+                            }
+                        } else {
+                            abstractDataProvider.publish(dataProviderConfigRoot.getTopic(), session.getId());
+                        }
+                    } else {
+                        throw new Exception("Error while performing action: " + dataProviderConfigRoot.getAction() +
+                                ", data provider for session id: " + session.getId() + " not found.");
+                    }
+                } else {
+                    throw new Exception("Error while performing action: " + dataProviderConfigRoot.getAction() +
+                            ", data provider map for session id: " + session.getId() + " not initialized.");
+                }
             } else {
                 throw new Exception("Invalid action " + dataProviderConfigRoot.getAction() + " given in the message." +
                         "Valid actions are : " + Arrays.toString(DataProviderConfigRoot.Types.values()));
             }
         } catch (Exception e) {
             try {
-                sendText(session.getId(), "Error initializing the data provider endpoint.");
+                sendText(session.getId(), e.getMessage());
             } catch (IOException e1) {
                 //ignore
             }

--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/rdbms/config/RDBMSDataProviderConf.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/rdbms/config/RDBMSDataProviderConf.java
@@ -91,7 +91,7 @@ public class RDBMSDataProviderConf implements ProviderConfig {
     }
 
     @Override
-    public boolean isPaginationEnable() {
+    public boolean isPaginationEnabled() {
         return false;
     }
 }

--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/rdbms/config/RDBMSDataProviderConf.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/rdbms/config/RDBMSDataProviderConf.java
@@ -89,4 +89,9 @@ public class RDBMSDataProviderConf implements ProviderConfig {
     public boolean isPurgingEnable() {
         return isPurgingEnable;
     }
+
+    @Override
+    public boolean isPaginationEnable() {
+        return false;
+    }
 }

--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/rdbms/config/RDBMSDataProviderConf.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/rdbms/config/RDBMSDataProviderConf.java
@@ -16,7 +16,6 @@
 package org.wso2.carbon.data.provider.rdbms.config;
 
 import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.wso2.carbon.data.provider.ProviderConfig;
 

--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/siddhi/config/SiddhiDataProviderConfig.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/siddhi/config/SiddhiDataProviderConfig.java
@@ -18,13 +18,9 @@
 
 package org.wso2.carbon.data.provider.siddhi.config;
 
-import com.google.gson.Gson;
 import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.wso2.carbon.data.provider.ProviderConfig;
-
-import java.util.List;
 
 public class SiddhiDataProviderConfig implements ProviderConfig {
 
@@ -32,6 +28,9 @@ public class SiddhiDataProviderConfig implements ProviderConfig {
     private JsonElement queryData;
     private int publishingInterval;
     private String timeColumns;
+    private int currentPage;
+    private int pageSize;
+    private boolean paginationEnable;
 
 
     public SiddhiDataProviderConfig() {
@@ -41,6 +40,29 @@ public class SiddhiDataProviderConfig implements ProviderConfig {
                 "define table TRANSACTIONS_TABLE (CREDITCARDNO string, COUNTRY string, TRANSACTION string, AMOUNT int);";
         this.publishingInterval = 5;
         this.timeColumns = "";
+        this.currentPage = 0;
+        this.pageSize = 0;
+        this.paginationEnable = false;
+    }
+
+    public int getCurrentPage() {
+        return currentPage;
+    }
+
+    public void setCurrentPage(int currentPage) {
+        this.currentPage = currentPage;
+    }
+
+    public int getPageSize() {
+        return pageSize;
+    }
+
+    public void setPageSize(int pageSize) {
+        this.pageSize = pageSize;
+    }
+
+    public void setPaginationEnable(boolean paginationEnable) {
+        this.paginationEnable = paginationEnable;
     }
 
     public JsonElement getQueryData() {
@@ -72,6 +94,11 @@ public class SiddhiDataProviderConfig implements ProviderConfig {
     @Override
     public boolean isPurgingEnable() {
         return false;
+    }
+
+    @Override
+    public boolean isPaginationEnable() {
+        return paginationEnable;
     }
 
     public String getTimeColumns() {

--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/siddhi/config/SiddhiDataProviderConfig.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/siddhi/config/SiddhiDataProviderConfig.java
@@ -30,7 +30,7 @@ public class SiddhiDataProviderConfig implements ProviderConfig {
     private String timeColumns;
     private int currentPage;
     private int pageSize;
-    private boolean paginationEnable;
+    private boolean isPaginationEnabled;
 
 
     public SiddhiDataProviderConfig() {
@@ -42,7 +42,7 @@ public class SiddhiDataProviderConfig implements ProviderConfig {
         this.timeColumns = "";
         this.currentPage = 0;
         this.pageSize = 0;
-        this.paginationEnable = false;
+        this.isPaginationEnabled = false;
     }
 
     public int getCurrentPage() {
@@ -61,8 +61,8 @@ public class SiddhiDataProviderConfig implements ProviderConfig {
         this.pageSize = pageSize;
     }
 
-    public void setPaginationEnable(boolean paginationEnable) {
-        this.paginationEnable = paginationEnable;
+    public void setPaginationEnabled(boolean isPaginationEnabled) {
+        this.isPaginationEnabled = isPaginationEnabled;
     }
 
     public JsonElement getQueryData() {
@@ -97,8 +97,8 @@ public class SiddhiDataProviderConfig implements ProviderConfig {
     }
 
     @Override
-    public boolean isPaginationEnable() {
-        return paginationEnable;
+    public boolean isPaginationEnabled() {
+        return isPaginationEnabled;
     }
 
     public String getTimeColumns() {


### PR DESCRIPTION
## Purpose
> $subject

## Approach
> Add poll method to the data provider.
> Get currentPage, pageSize from the provider config and calculate newLimit and newOffset.
> Manipulate the query with newLimit and newOffset values.

## Documentation
>To use pagination, 
>currentPage, pageSize values should be added and isPaginationEnabled should be set true in the provider config.

>Example:
> "currentPage": 0,
> "pageSize": 5,
> "isPaginationEnabled": true

> First time, the user has to use subscribe method to initialize the data provider.
> After that user can use poll method to get the data.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
