### PR TITLE
Reinitialize Spark Context during failure scenarios

### DIFF
--- a/components/analytics-processors/org.wso2.carbon.analytics.spark.core/src/main/java/org/wso2/carbon/analytics/spark/core/internal/JavaSparkApplicationListener.java
+++ b/components/analytics-processors/org.wso2.carbon.analytics.spark.core/src/main/java/org/wso2/carbon/analytics/spark/core/internal/JavaSparkApplicationListener.java
@@ -1,0 +1,26 @@
+package org.wso2.carbon.analytics.spark.core.internal;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.spark.JavaSparkListener;
+import org.apache.spark.scheduler.SparkListenerApplicationEnd;
+import org.apache.spark.scheduler.SparkListenerApplicationStart;
+
+public class JavaSparkApplicationListener extends JavaSparkListener {
+    private static final Log log = LogFactory.getLog(JavaSparkApplicationListener.class);
+    private String applicationName;
+
+    @Override
+    public void onApplicationStart(SparkListenerApplicationStart arg0) {
+        applicationName = arg0.appName();
+        log.info("Spark application '" + arg0.appName() + "' with id '"
+                + arg0.appId().get() + "' started successfully");
+        ServiceHolder.setSparkContextRestartRequired(false);
+    }
+
+    @Override
+    public void onApplicationEnd(SparkListenerApplicationEnd arg0) {
+        log.error("Spark application '" + applicationName + "' ended.");
+        ServiceHolder.setSparkContextRestartRequired(true);
+    }
+}

--- a/components/analytics-processors/org.wso2.carbon.analytics.spark.core/src/main/java/org/wso2/carbon/analytics/spark/core/internal/ServiceHolder.java
+++ b/components/analytics-processors/org.wso2.carbon.analytics.spark.core/src/main/java/org/wso2/carbon/analytics/spark/core/internal/ServiceHolder.java
@@ -81,6 +81,8 @@ public class ServiceHolder {
 
     private static JavaSparkContext javaSparkContext;
 
+    private static boolean sparkContextRestartRequired = false;
+
     public static void setTaskService(TaskService taskService) {
         ServiceHolder.taskService = taskService;
     }
@@ -226,4 +228,11 @@ public class ServiceHolder {
         ServiceHolder.javaSparkContext = javaSparkContext;
     }
 
+    public static boolean isSparkContextRestartRequired() {
+        return sparkContextRestartRequired;
+    }
+
+    public static void setSparkContextRestartRequired(boolean sparkContextRestartRequired) {
+        ServiceHolder.sparkContextRestartRequired = sparkContextRestartRequired;
+    }
 }

--- a/components/analytics-processors/org.wso2.carbon.analytics.spark.core/src/main/java/org/wso2/carbon/analytics/spark/core/util/AnalyticsConstants.java
+++ b/components/analytics-processors/org.wso2.carbon.analytics.spark.core/src/main/java/org/wso2/carbon/analytics/spark/core/util/AnalyticsConstants.java
@@ -129,6 +129,7 @@ public class AnalyticsConstants {
     public static final String SPARK_UI_PORT = "spark.ui.port";
     public static final String SPARK_RECOVERY_MODE = "spark.deploy.recoveryMode";
     public static final String SPARK_RECOVERY_MODE_FACTORY = "spark.deploy.recoveryMode.factory";
+    public static final String SPARK_EXTRA_LISTENERS = "spark.extraListeners";
 
     public static final String SPARK_LOCAL_IP_PROP = "SPARK_LOCAL_IP";
     


### PR DESCRIPTION
## Goals
> Reinitialize Spark Context during failure scenarios

## Approach
> Registers a Spark extra listener to catch when Spark application ends.
> Restarts the Spark context at the time when new query is submitted.