### PR TITLE
Add a parent checkbox for single simulator form

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/event-simulator/simulator.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/event-simulator/simulator.js
@@ -186,6 +186,8 @@ define(['jquery', 'log', './constants', './simulator-rest-client', 'lodash', './
             } else {
                 $inputField
                     .prop('disabled', false);
+                $('input[name="check-box"]')
+                    .prop("checked", false);
                 self.addRuleForAttribute($inputField);
             }
 
@@ -664,7 +666,7 @@ define(['jquery', 'log', './constants', './simulator-rest-client', 'lodash', './
             '<table class="table table-responsive"> ' +
             '   <thead>' +
             '    <tr>' +
-            '       <th width="90%">' +
+            '       <th width="80%">' +
             '           <label>' +
             '               Attributes<span class="requiredAstrix"> *</span>' +
             '           </label> ' +
@@ -673,6 +675,9 @@ define(['jquery', 'log', './constants', './simulator-rest-client', 'lodash', './
             '           <label>' +
             '            Is Null' +
             '           </label>' +
+            '       </th>' +
+            '       <th width="10%">' +
+            '           <input type="checkbox" name="check-box" style="margin-bottom:7px" >' +
             '       </th>' +
             '    </tr>' +
             '   </thead>' +
@@ -711,7 +716,25 @@ define(['jquery', 'log', './constants', './simulator-rest-client', 'lodash', './
             $(this)
                 .prop('selectedIndex', -1);
         });
+        parentCheckboxEventListener();
     };
+
+//add an eventlistener to parent checkbox for disabling all the attributes
+    var parentCheckboxEventListener = function() {
+        $('div[data-name="attributes"]').on('click', 'input[name="check-box"]', function () {
+            if ($(this).is(':checked')) {
+                $('div[data-name="attributes"]')
+                    .find('input[data-input="null"]' && 'input[data-element-type="attribute"]')
+                    .each(function () {
+                        $('input[data-input="null"]').prop("checked", true);
+                        $('input[data-element-type="attribute"]').val("").prop("disabled", true);
+                    });
+            } else {
+                $('input[data-element-type="attribute"]').val("").prop("disabled", false);
+                $('input[data-input="null"]').prop("checked", false);
+            }
+        });
+    }
 
 // create input fields for attributes
     self.generateAttributes = function (attributes, $form) {

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/event-simulator/simulator.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/event-simulator/simulator.js
@@ -186,8 +186,7 @@ define(['jquery', 'log', './constants', './simulator-rest-client', 'lodash', './
             } else {
                 $inputField
                     .prop('disabled', false);
-                $('input[name="check-box"]')
-                    .prop("checked", false);
+                $('.parent-checkbox').prop("checked", false);
                 self.addRuleForAttribute($inputField);
             }
 
@@ -677,7 +676,7 @@ define(['jquery', 'log', './constants', './simulator-rest-client', 'lodash', './
             '           </label>' +
             '       </th>' +
             '       <th width="10%">' +
-            '           <input type="checkbox" name="check-box" style="margin-bottom:7px" >' +
+            '           <input type="checkbox" class="parent-checkbox" style="margin-bottom:7px" >' +
             '       </th>' +
             '    </tr>' +
             '   </thead>' +
@@ -721,20 +720,15 @@ define(['jquery', 'log', './constants', './simulator-rest-client', 'lodash', './
 
 //add an eventlistener to parent checkbox for disabling all the attributes
     var parentCheckboxEventListener = function() {
-        $('div[data-name="attributes"]').on('click', 'input[name="check-box"]', function () {
-            if ($(this).is(':checked')) {
-                $('div[data-name="attributes"]')
-                    .find('input[data-input="null"]' && 'input[data-element-type="attribute"]')
-                    .each(function () {
-                        $('input[data-input="null"]').prop("checked", true);
-                        $('input[data-element-type="attribute"]').val("").prop("disabled", true);
-                    });
-            } else {
-                $('input[data-element-type="attribute"]').val("").prop("disabled", false);
-                $('input[data-input="null"]').prop("checked", false);
-            }
-        });
-    }
+        $(".form-group").on("click", ".parent-checkbox", function() {
+            var checkStatus = $(this).is(":checked");
+            var parent = $(this).parents(".form-group");
+                parent.find(".attribtes-checkbox" && ".form-control").each(function() {
+                    parent.find(".attributes-checkbox").prop("checked", checkStatus);
+                    parent.find(".form-control").val("").prop("disabled", checkStatus);
+                });
+         });
+    };
 
 // create input fields for attributes
     self.generateAttributes = function (attributes, $form) {
@@ -751,7 +745,7 @@ define(['jquery', 'log', './constants', './simulator-rest-client', 'lodash', './
             '           </select>' +
             '   </td>' +
             '   <td width="15%" class="align-middle">' +
-            '       <input type="checkbox" name="{{attributeName}}-null" data-attribute-name="{{attributeName}}-attr"' +
+            '       <input type="checkbox" class="attributes-checkbox"  name="{{attributeName}}-null" data-attribute-name="{{attributeName}}-attr"' +
             '       data-input="null">' +
             '   </td>' +
             '</tr>';
@@ -766,7 +760,7 @@ define(['jquery', 'log', './constants', './simulator-rest-client', 'lodash', './
             '           name="{{attributeName}}-attr" data-type ="{{attributeType}}">' +
             '   </td>' +
             '   <td width="15%" class="align-middle">' +
-            '       <input align="center" type="checkbox" name="{{attributeName}}-null"' +
+            '       <input align="center" type="checkbox" class="attributes-checkbox" name="{{attributeName}}-null"' +
             '       data-attribute-name="{{attributeName}}-attr" data-input="null">' +
             '   </td>' +
             '</tr>';


### PR DESCRIPTION
## Purpose
One should be able to disable all the attributes from one checkbox and enable whatever he wants
Fixes :#481

## Approach
![screen123](https://user-images.githubusercontent.com/23412365/51301653-f7983300-1a55-11e9-9d13-cd1ef1efb952.png)

## Security checks
Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
Ran FindSecurityBugs plugin and verified report? yes
Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
Tested on Oracle JDK 1.8