### PR TITLE
Keep the workspace collapsed in "export as docker" feature

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/dialog/docker-export-dialog.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/dialog/docker-export-dialog.js
@@ -51,6 +51,9 @@ define(['require', 'jquery', 'log', 'backbone', 'file_browser'],
 
                     var fileBrowser = new FileBrowser({container: treeContainer, application: self.app, fetchFiles: true,
                         showWorkspace: true, multiSelect: true});
+                    $(treeContainer).on('ready.jstree', function () {
+                        $(treeContainer).jstree("open_all");
+                    });
                     fileBrowser.render();
                     this.fileBrowser = fileBrowser;
 

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/dialog/docker-export-dialog.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/dialog/docker-export-dialog.js
@@ -52,7 +52,7 @@ define(['require', 'jquery', 'log', 'backbone', 'file_browser'],
                     var fileBrowser = new FileBrowser({container: treeContainer, application: self.app, fetchFiles: true,
                         showWorkspace: true, multiSelect: true});
                     $(treeContainer).on('ready.jstree', function () {
-                        $(treeContainer).jstree("open_all");
+                        $(this).jstree('open_all');
                     });
                     fileBrowser.render();
                     this.fileBrowser = fileBrowser;

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/css/styles.css
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/css/styles.css
@@ -574,9 +574,11 @@ body.sticky-footer {
 
 .docker-export-file-tree {
   border: 1px solid #444;
-  height: 200px;
   padding: 5px;
   background-color: #2C2C2C;
+  overflow: auto;
+  min-height: 200px;
+  max-height: 550px;
 }
 
 /*Popover element changes*/

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
@@ -1491,12 +1491,11 @@
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                     <i class="fw fw-cancel about-dialog-close"></i></button>
-                <h3 class="modal-title" id="aboutDockerExportLabel">Export as Docker</h3>
+                <h4 class="modal-title file-dialog-title" id="aboutDockerExportLabel">Save To Workspace</h4>
+                <hr class="style1">
             </div>
             <div class="modal-body add-margin-top-2x add-margin-bottom-2x">
                 <form>
-                    <h4>Export as Docker</h4>
-                    <hr/>
                     <div class="form-group">
                         <label for="dockerProfile">Profile:</label>
                         <select class="form-control" id="dockerProfile">

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
@@ -1491,7 +1491,7 @@
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                     <i class="fw fw-cancel about-dialog-close"></i></button>
-                <h4 class="modal-title file-dialog-title" id="aboutDockerExportLabel">Save To Workspace</h4>
+                <h4 class="modal-title file-dialog-title" id="aboutDockerExportLabel">Export as Docker</h4>
                 <hr class="style1">
             </div>
             <div class="modal-body add-margin-top-2x add-margin-bottom-2x">


### PR DESCRIPTION
## Purpose
> To keep the workspace tree collapsed when the export as docker option is chosen

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

![screenshot from 2019-01-18 15-19-02](https://user-images.githubusercontent.com/23395897/51379768-330a2e80-1b36-11e9-839c-fd7eded24965.png)
