### PR TITLE
Fix getting node status from partially deployment business rule

### DIFF
--- a/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/services/TemplateManagerService.java
+++ b/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/services/TemplateManagerService.java
@@ -403,14 +403,8 @@ public class TemplateManagerService implements BusinessRulesService {
             }
             return TemplateManagerConstants.SIDDHI_APP_NOT_DEPLOYED;
         } catch (SiddhiAppsApiHelperException e) {
-           if (businessRuleStatus == TemplateManagerConstants.PARTIALLY_DEPLOYED && e.getStatus() == 404) {
-               return TemplateManagerConstants.SIDDHI_APP_DEPLOYED;
-           }
-           if (businessRuleStatus == TemplateManagerConstants.PARTIALLY_UNDEPLOYED && e.getStatus() == 404) {
-               return TemplateManagerConstants.SIDDHI_APP_NOT_DEPLOYED;
-            }
-           if (businessRuleStatus == TemplateManagerConstants.DEPLOYED && e.getStatus() == 404) {
-               return TemplateManagerConstants.SIDDHI_APP_NOT_DEPLOYED;
+           if ( e.getStatus() == 404) {
+             return TemplateManagerConstants.SIDDHI_APP_NOT_DEPLOYED;
             }
             return TemplateManagerConstants.SIDDHI_APP_UNREACHABLE;
         }


### PR DESCRIPTION
## Purpose
> This is the fix getting each node deployment status when the business rule is in the "partially deployment" state
## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.
