### PR TITLE
[Editor] Add Operator Finder feature

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/css/operator-finder.css
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/css/operator-finder.css
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* Styles for operator finder */
+.operator-finder > .content {
+    height: 100%;
+}
+
+/* Operator search results */
+.operator-finder .results {
+    height: calc(100% - 77px);
+}
+
+.operator-finder .result {
+    margin-bottom: 10px;
+    padding: 10px;
+    background-color: #373737;
+}
+
+.operator-finder .result .heading {
+    overflow: hidden;
+}
+
+.operator-finder .result .heading h4 {
+    float: left;
+    font: 14px Monaco, Menlo, 'Ubuntu Mono', Consolas, source-code-pro, monospace;
+    width: calc(100% - 25px);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.operator-finder .result .heading .more-info {
+    display: inline-block;
+    padding-top: 12px;
+}
+
+.operator-finder .result .description {
+    color: #c8c7c7;
+}
+
+.operator-finder .result.less .description {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.operator-finder .icon-bar a.expand-description {
+    display: inline-block;
+    padding-top: 3px;
+}
+
+.operator-finder .icon-bar a.add-to-source.disabled {
+    cursor: pointer;
+    pointer-events: none;
+    color: #6b6969;
+}
+
+.operator-finder .icon-bar ul {
+    float: right;
+    padding-right: 10px;
+}
+
+.operator-finder .icon-bar li {
+    display: inline-block;
+    margin-left: 10px;
+}
+
+.operator-finder a.namespace-entry {
+    display: block;
+    background-color: #373737;
+    padding: 5px 10px;
+    margin-bottom: 10px;
+}
+
+.operator-finder .alert-danger {
+    background-color: #d9534f !important;
+}
+
+.operator-finder mark {
+    background-color: yellow;
+}
+
+/* More operator details modal dialog */
+.modal-operator-details .modal-header h3 {
+    padding: 0 0 10px 20px;
+}
+
+.modal-operator-details .modal-header hr {
+    border-top: 1px solid #2c2c2c;
+    width: 100%;
+    padding: 0 0 5px;
+}
+
+.modal-operator-details .modal-body thead td:nth-child(1) {
+    width: 20%;
+}
+
+.modal-operator-details .modal-body thead td:nth-child(2) {
+    width: 15%;
+}
+
+.modal-operator-details .modal-body tbody td:nth-child(1),
+.modal-operator-details .modal-body tbody td:nth-child(2) {
+    font: 14px Monaco, Menlo, 'Ubuntu Mono', Consolas, source-code-pro, monospace;
+}
+
+.modal-operator-details .operator-details-content {
+    max-height: 400px;
+}
+
+/* Copy to clipboard */
+.copyable-text {
+    width: 1px;
+    height: 1px;
+    opacity: 0;
+    border: none;
+    padding: 0;
+}
+
+.copy-status-msg {
+    display: inline-block;
+    color: #06c706;
+    padding-right: 10px;
+}

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/css/operator-finder.css
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/css/operator-finder.css
@@ -138,3 +138,10 @@
     color: #06c706;
     padding-right: 10px;
 }
+
+.info-text {
+    color: #009DA7;
+    font-weight: bold;
+    padding: 5px 0;
+    margin-bottom: 15px;
+}

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
@@ -23,6 +23,7 @@
     <link href="/editor/commons/css/fileDialog.css" rel="stylesheet" type="text/css"/>
     <link rel="stylesheet" type="text/css" href="/editor/commons/css/left-tool-bar.css"/>
     <link rel="stylesheet" type="text/css" href="/editor/commons/css/workspace-explorer.css"/>
+    <link rel="stylesheet" type="text/css" href="/editor/commons/css/operator-finder.css"/>
     <link href="/editor/commons/css/jquery-ui-timepicker-addon.css" rel="stylesheet" type="text/css"/>
     <link href="/editor/commons/css/simulator.css" rel="stylesheet" type="text/css"/>
     <link rel="stylesheet" type="text/css" href="/editor/commons/css/notification.css"/>
@@ -118,6 +119,12 @@
                         <li>
                             <a href="#output-console" class="output-console-activate-btn">
                                 <i class="fw fw-console fw-lg"></i>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="#operator-finder" class="operator-finder-activate-btn" role="tab"
+                               data-toggle="tab" data-placement="right" data-container="body">
+                                <i class="fw fw-extensions fw-lg"></i>
                             </a>
                         </li>
                     </ul>
@@ -1483,7 +1490,6 @@
     </div>
 </div>
 
-
 <!--Start: Docker Export Modal-->
 <div class="modal fade modalDockerExport" id="modalDockerExport" tabindex="-1" role="dialog">
     <div class="modal-dialog" role="document">
@@ -1570,6 +1576,146 @@
         </div>
     </div>
 </div>
+
+<!-- More info modal for operator finder -->
+<div class="modal fade modal-operator-details" id="modalOperatorDetails" tabindex="-1" role="dialog">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content clearfix"></div>
+    </div>
+</div>
+
+<!-- Handlebar template for operator finder side-panel content -->
+<script id="operators-side-panel-template" type="text/x-handlebars-template">
+    <div id="operator-finder" role="tabpanel" class="tab-pane operator-finder">
+        <div class="content">
+            <h3>Operators</h3>
+            <div class="form-group">
+                <input type="text" class="form-control" id="operator-search-input-field"
+                       placeholder="Search operators..." />
+            </div>
+            <div class="results nano">
+                <div class="result-content nano-content"></div>
+            </div>
+        </div>
+        <input type="text" class="copyable-text" />
+    </div>
+</script>
+
+<!-- Handlebar template for operator finder search results -->
+<script id="operators-search-results-template" type="text/x-handlebars-template">
+    {{#if hasQuery}}
+    {{#if hasResults}}
+    {{#each results}}
+    <div class="result less" data-index="{{index}}">
+        <div class="heading">
+            <h4 data-placement="right" data-container="body" title="{{fqn}}">
+                <i class="fw fw-extensions" title="{{type}}"></i> {{{htmlFqn}}}
+            </h4>
+            <a href="#" class="more-info">
+                <i class="fw fw-info"></i>
+            </a>
+        </div>
+        <p class="description">{{{description}}}</p>
+        <div class="icon-bar">
+            <a href="#" class="expand-description">More...</a>
+            <ul>
+                <li>
+                    <span class="copy-status-msg" style="display: none">Copied to Clipboard!</span>
+                    <a href="#" title="Copy to Clipboard" class="copy-to-clipboard">
+                        <i class="fw fw-copy"></i>
+                    </a>
+                </li>
+                <li>
+                    <a href="#" title="Add to Source" class="add-to-source">
+                        <i class="fw fw-add"></i>
+                    </a>
+                </li>
+            </ul>
+        </div>
+    </div>
+    {{/each}}
+    {{else}}
+    <div class="alert alert-danger">
+        Sorry! No results found.
+    </div>
+    {{/if}}
+    {{else}}
+    <ul>
+        {{#each namespaces}}
+        <li><a href="#" class="namespace-entry">{{this}}</a></li>
+        {{/each}}
+    </ul>
+    {{/if}}
+</script>
+
+<!-- Handlebar template for operator finder's operator more details -->
+<script id="operator-details-template" type="text/x-handlebars-template">
+    <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <i class="fw fw-cancel about-dialog-close"></i>
+        </button>
+        <h3 class="modal-title" id="operator-name" data-index="{{index}}">{{fqn}}</h3>
+        <hr />
+    </div>
+    <div class="modal-body add-margin-top-2x add-margin-bottom-2x">
+        <div class="operator-details-content nano">
+            <div class="nano-content">
+                <h4>Parameters: </h4>
+                <table class="table table-striped table-dark table-hover">
+                    <thead>
+                    <tr>
+                        <td>Name</td>
+                        <td>Type</td>
+                        <td>Description</td>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {{#each parameters}}
+                    <tr>
+                        <td>{{name}}</td>
+                        <td>{{{dataTypes}}}</td>
+                        <td>{{description}}</td>
+                    </tr>
+                    {{/each}}
+                    </tbody>
+                </table>
+
+                <h4>Return Attributes: </h4>
+                <table class="table table-striped table-dark table-hover">
+                    <thead>
+                    <tr>
+                        <td>Name</td>
+                        <td>Type</td>
+                        <td>Description</td>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {{#each returnAttributes}}
+                    <tr>
+                        <td>{{name}}</td>
+                        <td>{{{dataTypes}}}</td>
+                        <td>{{description}}</td>
+                    </tr>
+                    {{/each}}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+    <div class="modal-footer">
+        <input type="text" class="copyable-text" />
+        <span class="copy-status-msg" style="display: none">Copied to Clipboard!</span>
+        <button type="button" class="btn btn-primary" id="btn-copy-to-clipboard">
+            <i class="fw fw-copy"></i> Copy to Clipboard
+        </button>
+        {{#if enableAddToSource}}
+        <button type="button" class="btn btn-primary" id="btn-add-to-source">
+            <i class="fw fw-add"></i> Add to Source
+        </button>
+        {{/if}}
+        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+    </div>
+</script>
 
 <script src="/editor/commons/lib/requirejs-2.3.2/require.js"></script>
 <script type="text/javascript">
@@ -1741,6 +1887,11 @@
             {
                 name: 'event_simulator',
                 location: 'js/event-simulator',
+                main: 'module'
+            },
+            {
+                name: 'operator_finder',
+                location: 'js/operator-finder',
                 main: 'module'
             }
         ]
@@ -1924,6 +2075,33 @@
                 },
                 commandAddSingleSimulatorForm: {
                     id: "add-single-simulator"
+                }
+            },
+            operator_finder : {
+                container: '.sidebar-left',
+                activateBtn: '.operator-finder-activate-btn',
+                separator: '.sidebar-left-separator',
+                containerToAdjust: '#right-container',
+                leftOffset: 40,
+                separatorOffset: 5,
+                defaultWidth: 380,
+                resizeLimits:{
+                    minX: 200,
+                    maxX: 800
+                },
+                containerId: 'operator-finder',
+                command: {
+                    id: 'toggle-operator-finder',
+                    shortcuts: {
+                        mac: {
+                            key: 'command+shift+x',
+                            label: '\u2318\u21E7X'
+                        },
+                        other: {
+                            key: 'ctrl+shift+x',
+                            label: 'Ctrl+Shift+X'
+                        }
+                    }
                 }
             },
             workspace_explorer: {

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
@@ -1661,6 +1661,7 @@
         <div class="operator-details-content nano">
             <div class="nano-content">
                 <h4>Parameters: </h4>
+                {{#if hasParameters}}
                 <table class="table table-striped table-dark table-hover">
                     <thead>
                     <tr>
@@ -1679,8 +1680,12 @@
                     {{/each}}
                     </tbody>
                 </table>
+                {{else}}
+                <p class="info-text">No parameters available.</p>
+                {{/if}}
 
                 <h4>Return Attributes: </h4>
+                {{#if hasReturnAttributes}}
                 <table class="table table-striped table-dark table-hover">
                     <thead>
                     <tr>
@@ -1699,6 +1704,9 @@
                     {{/each}}
                     </tbody>
                 </table>
+                {{else}}
+                <p class="info-text">No return attributes available.</p>
+                {{/if}}
             </div>
         </div>
     </div>

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/main.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/main.js
@@ -17,11 +17,11 @@
  */
 
 define(['require', 'log', 'jquery', 'lodash', 'backbone', 'menu_bar', 'tool_bar', 'command', 'workspace',
-        'app/tab/service-tab-list', 'event_simulator', 'app/output-console/service-console-list-manager',
+        'app/tab/service-tab-list', 'event_simulator', 'operator_finder', 'app/output-console/service-console-list-manager',
         'nano_scroller'],
 
     function (require, log, $, _, Backbone, MenuBar, ToolBar, CommandManager, Workspace, TabController,
-              EventSimulator, OutputController) {
+              EventSimulator, OperatorFinder, OutputController) {
 
         var Application = Backbone.View.extend(
             /** @lends Application.prototype */
@@ -87,6 +87,11 @@ define(['require', 'log', 'jquery', 'lodash', 'backbone', 'menu_bar', 'tool_bar'
                     _.set(eventSimulatorOpts, 'application', this);
                     this.eventSimulator = new EventSimulator(eventSimulatorOpts);
                     this.eventSimulator.stopRunningSimulations();
+
+                    // Initialize operator finder.
+                    var operatorFinderOpts = _.get(this.config, 'operator_finder');
+                    _.set(operatorFinderOpts, 'application', this);
+                    this.operatorFinder = new OperatorFinder.OperatorFinder(operatorFinderOpts);
                 },
 
                 render: function () {
@@ -109,6 +114,10 @@ define(['require', 'log', 'jquery', 'lodash', 'backbone', 'menu_bar', 'tool_bar'
                     log.debug("start: rendering event simulator control");
                     this.eventSimulator.render();
                     log.debug("end: rendering event simulator control");
+
+                    log.debug("start: rendering operator finder");
+                    this.operatorFinder.render();
+                    log.debug("end: rendering operator finder");
                 },
 
                 getOperatingSystem: function(){

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/operator-finder/module.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/operator-finder/module.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+define(['./operator-finder'],
+    function (OperatorFinder) {
+        return  {
+            OperatorFinder: OperatorFinder.OperatorFinder,
+            Utils: {
+                toggleAddToSource: OperatorFinder.toggleAddToSource,
+            }
+        };
+    });
+

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/operator-finder/operator-finder.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/operator-finder/operator-finder.js
@@ -1,0 +1,443 @@
+/**
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+define(['jquery', 'lodash', 'log', 'handlebar', 'designViewUtils'],
+    function ($, _, log, Handlebars, DesignViewUtils) {
+
+        /**
+         * Loads operators from the endpoint.
+         *
+         * @param onSuccess Callback for success handler
+         * @param onError Callback for error handler
+         */
+        var loadOperators = function (onSuccess, onError) {
+            var operators = [];
+            var namespaces = [];
+            $.ajax({
+                type: 'GET',
+                url: window.location.protocol + '//' + window.location.host + '/editor/metadata',
+                async: false,
+                success: function (data, status, xhr) {
+                    if (xhr.status === 200) {
+                        // Flatten operator metadata into an array.
+                        operators = flattenOperators(data);
+                        // Get all extension namespaces.
+                        for (var extension in data.extensions) {
+                            if (data.extensions.hasOwnProperty(extension)) {
+                                namespaces.push(extension);
+                            }
+                        }
+                        namespaces.sort();
+                        onSuccess(namespaces, operators);
+                    } else {
+                        onError('Failed retrieving operators.');
+                    }
+                },
+                error: function () {
+                    onError('Failed retrieving operators.');
+                }
+            });
+        };
+
+        /**
+         * Builds operator syntax
+         *
+         * @param entry Operator
+         * @returns {string} Syntax
+         */
+        var buildSyntax = function (entry) {
+            var params = '';
+            if (entry.parameters) {
+                entry.parameters.forEach(function (p) {
+                    if (!p.optional) {
+                        params += ', ' + p.name;
+                    }
+                });
+            }
+            return (entry.namespace.length > 0 ? entry.namespace + ':' : '') + entry.name
+                + '(' + params.substr(2) + ')';
+        };
+
+        /**
+         * Checks if the content contains the token. If so returns the highlighted HTML text.
+         *
+         * @param content Content to be searched
+         * @param tokens Array of tokens
+         * @returns {*} Status with modified content
+         */
+        var hasToken = function (content, tokens) {
+            var regex = new RegExp('(' + tokens.join('|') + ')', 'gi');
+            var text = _.clone(content);
+            if (regex.test(text)) {
+                return {
+                    status: true,
+                    text: text.replace(regex, '<mark>$1</mark>')
+                };
+            }
+            return {
+                status: false,
+                text: text
+            };
+        };
+
+        /**
+         * Flashes copied to clipboard message.
+         *
+         * @param messageBox Message box element.
+         */
+        var alertCopyToClipboardMessage = function (messageBox) {
+            messageBox.show();
+            setTimeout(function () {
+                messageBox.fadeOut();
+            }, 2000);
+        };
+
+        /**
+         * Flattens the metadata structure into an array ti reduce the search complexity.
+         *
+         * @param meta Operator metadata
+         * @returns {*[]} Array of operators
+         */
+        var flattenOperators = function (meta) {
+            // Flatten in-built operators.
+            var operators = [];
+            var type;
+            for (type in meta.inBuilt) {
+                if (meta.inBuilt.hasOwnProperty(type)) {
+                    meta.inBuilt[type].forEach(function (operator) {
+                        var op = _.clone(operator);
+                        op.fqn = op.name;
+                        op.type = type;
+                        operators.push(op);
+                    });
+                }
+            }
+            operators.sort(function (a, b) {
+                return a.fqn < b.fqn ? -1 : a.fqn > b.fqn ? 1 : 0;
+            });
+
+            // Flatten extensions.
+            var extensions = []
+            for (var extension in meta.extensions) {
+                if (meta.extensions.hasOwnProperty(extension)) {
+                    for (type in meta.extensions[extension]) {
+                        if (meta.extensions[extension].hasOwnProperty(type)) {
+                            meta.extensions[extension][type].forEach(function (operator) {
+                                var op = _.clone(operator);
+                                op.fqn = op.namespace + ':' + op.name;
+                                op.type = type;
+                                extensions.push(op)
+                            });
+                        }
+                    }
+                }
+            }
+            extensions.sort(function (a, b) {
+                return a.fqn < b.fqn ? -1 : a.fqn > b.fqn ? 1 : 0;
+            });
+            return operators.concat(extensions);
+        };
+
+        /**
+         * Checks if the source view is active.
+         *
+         * @returns {jQuery} Status
+         */
+        var isSourceView = function () {
+            return $('.source-container').is(':visible');
+        };
+
+        /**
+         * Toggles add to source button in the result pane.
+         *
+         * @param disable Is disabled
+         */
+        var toggleAddToSource = function (disable) {
+            var elements = $('#operator-finder').find('.result-content a.add-to-source');
+            if (disable) {
+                elements.addClass('disabled');
+            } else {
+                elements.removeClass('disabled');
+            }
+        };
+
+        /**
+         * Initializes the module.
+         *
+         * @param options Options
+         * @constructor
+         */
+        var OperatorFinder = function (options) {
+            this._options = options;
+            this._application = options.application;
+            this._activateBtn = $(options.activateBtn);
+            this._container = $(options.container);
+            this._containerToAdjust = $(this._options.containerToAdjust);
+            this._verticalSeparator = $(this._options.separator);
+            // Register event handler to toggle operator finder.
+            this._application.commandManager.registerCommand(options.command.id, { shortcuts: options.command.shortcuts });
+            this._application.commandManager.registerHandler(options.command.id, this.toggleOperatorFinder, this);
+            // Compile Handlebar templates.
+            this._templates = {
+                container: Handlebars.compile($('#operators-side-panel-template').html()),
+                searchResults: Handlebars.compile($('#operators-search-results-template').html()),
+                moreDetails: Handlebars.compile($('#operator-details-template').html())
+            };
+        };
+
+        /**
+         * Checks if the welcome page is active.
+         *
+         * @returns {boolean} Status
+         */
+        OperatorFinder.prototype.isWelcomePageSelected = function () {
+            if (!this._activeTab) {
+                this._activeTab = this._application.tabController.getActiveTab();
+            }
+            return !this._activeTab || this._activeTab.getTitle() === 'welcome-page';
+        };
+
+        /**
+         * Toggles operator finder side panel.
+         */
+        OperatorFinder.prototype.toggleOperatorFinder = function () {
+            if (this._activateBtn.parent('li').hasClass('active')) {
+                this._container.parent().width('0px');
+                this._containerToAdjust.css('padding-left', this._options.leftOffset);
+                this._verticalSeparator.css('left', this._options.leftOffset - this._options.separatorOffset);
+                this._activateBtn.parent('li').removeClass("active");
+            } else {
+                this._activateBtn.tab('show');
+                this._container.parent().width(this._options.defaultWidth);
+                this._containerToAdjust.css('padding-left', this._options.defaultWidth);
+                this._verticalSeparator.css('left', this._options.defaultWidth - this._options.separatorOffset);
+            }
+        };
+
+        /**
+         * Searches operators using the given query.
+         *
+         * @param query String query
+         * @returns {{results: Array, hasResults: boolean, hasQuery: boolean, namespaces: *}} Search results
+         */
+        OperatorFinder.prototype.searchOperators = function (query) {
+            var tokens = [];
+            if (query) {
+                query.split(' ').forEach(function (token) {
+                    if (token.length >= 2) {
+                        tokens.push(token);
+                    }
+                });
+            }
+            var results = [];
+            this._operators.forEach(function (e, i) {
+                var result = {
+                    fqn: hasToken(e.fqn, tokens),
+                    description: hasToken(e.description, tokens)
+                };
+                if (result.fqn.status || result.description.status) {
+                    results.push({
+                        fqn: e.fqn,
+                        htmlFqn: result.fqn.text,
+                        type: e.type,
+                        description: result.description.text,
+                        index: i
+                    });
+                }
+            });
+            return {
+                results: results,
+                hasResults: results.length > 0,
+                hasQuery: tokens.length > 0,
+                namespaces: this._namespaces
+            };
+        };
+
+        /**
+         * Renders search results in the side pane.
+         *
+         * @param query Search query
+         */
+        OperatorFinder.prototype.renderSearchResults = function (query) {
+            var content = $('#operator-finder').find('.result-content');
+            var results = this.searchOperators(query);
+            content.html(this._templates.searchResults(results));
+
+            // If there is search query and results, initialize the interface.
+            if (results.hasQuery && results.hasResults) {
+                content.find('h4, .icon-bar a').tooltip();
+                if (this.isWelcomePageSelected()) {
+                    content.find('a.add-to-source').addClass('disabled');
+                }
+            }
+            $('.nano').nanoScroller();
+        };
+
+        /**
+         * Adds syntax to the cursor point in the source view.
+         *
+         * @param index Operator index
+         */
+        OperatorFinder.prototype.addToSource = function (index) {
+            if (this._operators[index]) {
+                var syntax = buildSyntax(this._operators[index]);
+                var aceEditor = this._activeTab.getSiddhiFileEditor().getSourceView().getEditor();
+                aceEditor.session.insert(aceEditor.getCursorPosition(), syntax);
+            }
+        };
+
+        /**
+         * Copies the syntax into the clipboard.
+         *
+         * @param index Operator index
+         * @param container Current container to find the context.
+         */
+        OperatorFinder.prototype.copyToClipboard = function (index, container) {
+            if (this._operators[index]) {
+                var syntax = buildSyntax(this._operators[index]);
+                container.find('.copyable-text').val(syntax).select();
+                document.execCommand('copy');
+            }
+        };
+
+        /**
+         * Renders the interface.
+         */
+        OperatorFinder.prototype.render = function () {
+            var self = this;
+
+            // Initialize sidebar panel.
+            this._container.append(this._templates.container());
+            var resultContent = $('#operator-finder').find('.result-content');
+            var detailsModal = $('#modalOperatorDetails').clone();
+            var modalContent = detailsModal.find('.modal-content');
+
+            // Load operator metadata from the REST API.
+            loadOperators(
+                function (namespaces, operators) {
+                    self._namespaces = namespaces;
+                    self._operators = operators;
+                    self.renderSearchResults();
+                },
+                function (msg) {
+                    DesignViewUtils.prototype.errorAlert(msg);
+                });
+
+            // Event handler for the sidebar (activate) button.
+            this._activateBtn.on('click', function (e) {
+                e.preventDefault();
+                e.stopPropagation();
+                if (!$(this).hasClass('disabled')) {
+                    self._application.commandManager.dispatch(self._options.command.id);
+                }
+            });
+
+            // Event handler to modal shown event.
+            detailsModal.on('shown.bs.modal', function () {
+                $('.nano').nanoScroller();
+            });
+
+            // Event handler for modal's copy to clipboard event.
+            modalContent.on('click', '#btn-copy-to-clipboard', function () {
+                var index = detailsModal.find('#operator-name').data('index');
+                self.copyToClipboard(index, modalContent);
+                alertCopyToClipboardMessage(modalContent.find('.copy-status-msg'));
+            });
+
+            // Event handler for modal's add to source event.
+            modalContent.on('click', '#btn-add-to-source', function () {
+                var index = detailsModal.find('#operator-name').data('index');
+                self.addToSource(index);
+            });
+
+            // Event handler for search query textbox's key-up event.
+            $('#operator-search-input-field').on('keyup', function () {
+                self.renderSearchResults($(this).val());
+            });
+
+            // Event handler for namespaces list click event.
+            resultContent.on('click', 'a.namespace-entry', function (e) {
+                e.preventDefault();
+                var query = $(this).text() + ':';
+                $('#operator-search-input-field').val(query);
+                self.renderSearchResults(query);
+            });
+
+            resultContent.on('click', 'a.more-info', function (e) {
+                e.preventDefault();
+                var index = $(this).closest('.result').data('index');
+                var data = _.clone(self._operators[index]);
+                data.parameters.forEach(function (p) {
+                    p.dataTypes = p.type.join('<br />');
+                });
+                data.returnAttributes.forEach(function (r) {
+                    r.dataTypes = r.type.join('<br />');
+                });
+                data.index = index;
+                data.enableAddToSource = !self.isWelcomePageSelected() && isSourceView();
+                modalContent.html(self._templates.moreDetails(data));
+                detailsModal.modal('show');
+            });
+
+            // Event handler to expand description.
+            resultContent.on('click', 'a.expand-description', function (e) {
+                e.preventDefault();
+                var container = $(this).closest('.result');
+                if (container.hasClass('less')) {
+                    $(this).text('Less...');
+                    container.removeClass('less');
+                } else {
+                    $(this).text('More...');
+                    container.addClass('less');
+                }
+            });
+
+            // Event handler for add to source button.
+            resultContent.on('click', 'a.add-to-source', function (e) {
+                e.preventDefault();
+                if (self.isWelcomePageSelected()) {
+                    return;
+                }
+                var index = $(this).closest('.result').data('index');
+                self.addToSource(index);
+            });
+
+            // Event handler for copy syntax to clipboard.
+            resultContent.on('click', 'a.copy-to-clipboard', function (e) {
+                e.preventDefault();
+                var resultElement = $(this).closest('.result');
+                self.copyToClipboard(resultElement.data('index'), $('#operator-finder'));
+                alertCopyToClipboardMessage(resultElement.find('.copy-status-msg'));
+            });
+
+            // Event handler for active tab change event.
+            self._application.tabController.on('active-tab-changed', function (e) {
+                self._activeTab = e.newActiveTab;
+                toggleAddToSource(self.isWelcomePageSelected() || !isSourceView());
+            }, this);
+
+            var shortcutPath = 'command.shortcuts.' + (this._application.isRunningOnMacOS() ? 'mac' : 'other') + '.label';
+            this._activateBtn
+                .attr('title', 'Operator Finder (' + _.get(self._options, shortcutPath) + ')')
+                .tooltip();
+        };
+        return {
+            OperatorFinder: OperatorFinder,
+            toggleAddToSource: toggleAddToSource
+        };
+    });

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/source-editor/completion-engine.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/source-editor/completion-engine.js
@@ -2959,6 +2959,7 @@ define(["ace/ace", "jquery", "./constants", "./utils", "ace/snippets", "ace/rang
                 url: constants.SERVER_URL + "metadata",
                 success: function (response, textStatus, jqXHR) {
                     if (response.status == "SUCCESS") {
+                        CompletionEngine.rawMetadata = response;
                         (function () {
                             var snippets = {};
                             for (var processorType in response.inBuilt) {
@@ -3020,6 +3021,10 @@ define(["ace/ace", "jquery", "./constants", "./utils", "ace/snippets", "ace/rang
                     }
                 }
             });
+        };
+
+        CompletionEngine.getRawMetadata = function () {
+            return CompletionEngine.rawMetadata;
         };
 
         /**

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/tab/service-tab.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/tab/service-tab.js
@@ -15,8 +15,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-define(['require', 'log', 'jquery', 'lodash', './tab','workspace','toolEditor','workspace/file'],
-    function (require, log, jquery, _, Tab, Workspace,ToolEditor,File) {
+define(['require', 'log', 'jquery', 'lodash', './tab','workspace','toolEditor','workspace/file', 'operator_finder'],
+    function (require, log, jquery, _, Tab, Workspace, ToolEditor, File, OperatorFinder) {
         var  ServiceTab;
 
         ServiceTab = Tab.extend({
@@ -76,8 +76,9 @@ define(['require', 'log', 'jquery', 'lodash', './tab','workspace','toolEditor','
                     this.app.commandManager.dispatch(id);
                 }, this);
 
-                toolEditor.on("view-switch", function () {
+                toolEditor.on("view-switch", function (e) {
                     this.app.workspaceManager.updateMenuItems();
+                    OperatorFinder.Utils.toggleAddToSource(e.view === 'design');
                 }, this);
 
                 this._file.on("dirty-state-change", function () {

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/tool-editor/views/tool-editor.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/tool-editor/views/tool-editor.js
@@ -190,7 +190,7 @@ define(['require', 'jquery', 'backbone', 'lodash', 'log', 'design_view', "./sour
                                         loadingScreen.hide();
                                     }
                                     // NOTE - This trigger should be always handled at the end of setTimeout()
-                                    self.trigger("view-switch");
+                                    self.trigger("view-switch", { view: 'design' });
                                 }, 100);
                                 toggleViewButton.html("<i class=\"fw fw-code\"></i>" +
                                     "<span class=\"toggle-button-text\">Source View</span>");
@@ -248,7 +248,7 @@ define(['require', 'jquery', 'backbone', 'lodash', 'log', 'design_view', "./sour
                             if (!isDesignViewContentChanged) {
                                 designContainer.hide();
                                 sourceContainer.show();
-                                self.trigger("view-switch");
+                                self.trigger("view-switch", { view: 'source' });
                                 toggleViewButton.html("<i class=\"fw fw-design-view fw-rotate-90\"></i>" +
                                     "<span class=\"toggle-button-text\">Design View</span>");
                                 return;
@@ -279,7 +279,7 @@ define(['require', 'jquery', 'backbone', 'lodash', 'log', 'design_view', "./sour
                                     self._sourceView.format();
                                     loadingScreen.hide();
                                     // NOTE - This trigger should be always handled at the end of setTimeout()
-                                    self.trigger("view-switch");
+                                    self.trigger("view-switch", { view: 'source' });
                                 }, 100);
                                 toggleViewButton.html("<i class=\"fw fw-design-view fw-rotate-90\"></i>" +
                                     "<span class=\"toggle-button-text\">Design View</span>");


### PR DESCRIPTION
## Purpose
In the Editor, it is hard to search for operators (extensions and inbuilt) since the user has to refer the guides out of the Editors context. Hence there needs to be a facility to search and refer to these operators.

## Goals
This PR introduces an Operator Finder feature within the Editor itself.

## Approach
A new interface to find the operators have been introduced in the Editor's side panel. Users can use this interface to search the inbuilt operators and extensions via the namespace, name and the description. 

Once the operator is searched, the user can directly add the operator into the current source view or copy the syntax into the clipboard to use later. 

**Screenshots:**

<img width="1142" alt="screen shot 2019-01-25 at 12 57 51 pm" src="https://user-images.githubusercontent.com/2142703/51731489-1d01ee00-20a1-11e9-8fff-69f4d759a4ff.png">

<img width="1145" alt="screen shot 2019-01-25 at 12 58 16 pm" src="https://user-images.githubusercontent.com/2142703/51731492-1ffcde80-20a1-11e9-9387-b26e9369bc4e.png">

<img width="1571" alt="screen shot 2019-01-25 at 12 58 38 pm" src="https://user-images.githubusercontent.com/2142703/51731496-212e0b80-20a1-11e9-8b5c-05b7d4d8a680.png">

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
Operating System: MacOS
Browser: Chrome, Firefox
 
## Learning
N/A