### PR TITLE
Allow sync transport properties to be synced in HA scenarios

### DIFF
--- a/components/org.wso2.carbon.stream.processor.core/pom.xml
+++ b/components/org.wso2.carbon.stream.processor.core/pom.xml
@@ -178,6 +178,10 @@
             <groupId>org.wso2.carbon.analytics-common</groupId>
             <artifactId>org.wso2.carbon.databridge.commons</artifactId>
         </dependency>
+        <dependency>
+            <groupId>findbugs</groupId>
+            <artifactId>findbugs</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/event/queue/EventListMapManager.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/event/queue/EventListMapManager.java
@@ -95,8 +95,8 @@ public class EventListMapManager {
                 int transportSyncPropertiesBytes = eventContent.getInt();
                 if (transportSyncPropertiesBytes != 0) {
                     int transportSyncPropertiesSize = eventContent.getInt();
-                    transportSyncProperties = new String[transportSyncPropertiesSize];
                     if (transportSyncPropertiesSize != 0) {
+                        transportSyncProperties = new String[transportSyncPropertiesSize];
                         int byteReadLength = 0;
                         int propertiesLength = 0;
                         while (transportSyncPropertiesBytes != byteReadLength) {
@@ -172,9 +172,14 @@ public class EventListMapManager {
                         if(queuedEvent.getSourceHandlerElementId().equals(source.getMapper().
                                 getHandler().getElementId())){
                             source.getMapper().getHandler().sendEvent(queuedEvent.getEvent(),
-                                    null);
-                            ((HACoordinationSourceHandler)source.getMapper().getHandler()).
-                                    updateTransportSyncProperties(queuedEvent.getTransportSyncProperties());
+                                    queuedEvent.getTransportSyncProperties());
+                            if (null != queuedEvent.getTransportSyncProperties() &&
+                                    queuedEvent.getTransportSyncProperties().length != 0) {
+                                if (source.getMapper().getHandler() instanceof HACoordinationSourceHandler) {
+                                    ((HACoordinationSourceHandler)source.getMapper().getHandler()).
+                                            updateTransportSyncProperties(queuedEvent.getTransportSyncProperties());
+                                }
+                            }
                             eventListMap.remove(key);
                             isFound = true;
                             break;

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/event/queue/EventListMapManager.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/event/queue/EventListMapManager.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.stream.processor.core.event.queue;
 
 import org.apache.log4j.Logger;
+import org.wso2.carbon.stream.processor.core.ha.HACoordinationSourceHandler;
 import org.wso2.carbon.stream.processor.core.ha.exception.InvalidByteMessageException;
 import org.wso2.carbon.stream.processor.core.ha.tcp.SiddhiEventConverter;
 import org.wso2.carbon.stream.processor.core.ha.util.HAConstants;
@@ -76,6 +77,7 @@ public class EventListMapManager {
             for (int i = 0; i < noOfEvents; i++) {
                 String sourceHandlerElementId;
                 String siddhiAppName;
+                String[] transportSyncProperties = null;
                 long sequenceID = eventContent.getLong();
                 int sourceHandlerLength = eventContent.getInt();
                 if (sourceHandlerLength == 0) {
@@ -89,6 +91,22 @@ public class EventListMapManager {
                     throw new InvalidByteMessageException("Invalid appNameLength size = 0");
                 } else {
                     siddhiAppName = BinaryMessageConverterUtil.getString(eventContent, appNameLength);
+                }
+                int transportSyncPropertiesBytes = eventContent.getInt();
+                if (transportSyncPropertiesBytes != 0) {
+                    int transportSyncPropertiesSize = eventContent.getInt();
+                    transportSyncProperties = new String[transportSyncPropertiesSize];
+                    if (transportSyncPropertiesSize != 0) {
+                        int byteReadLength = 0;
+                        int propertiesLength = 0;
+                        while (transportSyncPropertiesBytes != byteReadLength) {
+                            int readLength = eventContent.getInt();
+                            byteReadLength += readLength;
+                            transportSyncProperties[propertiesLength] = BinaryMessageConverterUtil.
+                                    getString(eventContent, readLength);
+                            propertiesLength ++;
+                        }
+                    }
                 }
                 long lastSequenceIdForApp = -1;
 
@@ -110,7 +128,8 @@ public class EventListMapManager {
                         }
                         String[] attributeTypes = attributes.substring(1, attributes.length() - 1).split(", ");
                         events[i] = SiddhiEventConverter.getEvent(eventContent, attributeTypes);
-                        queuedEvent = new QueuedEvent(siddhiAppName, sourceHandlerElementId, sequenceID, events[i]);
+                        queuedEvent = new QueuedEvent(siddhiAppName, sourceHandlerElementId, sequenceID, events[i],
+                                transportSyncProperties);
                         this.addToEventListMap(sequenceID, queuedEvent);
                     }
 
@@ -152,7 +171,10 @@ public class EventListMapManager {
                     for (Source source : sources) {
                         if(queuedEvent.getSourceHandlerElementId().equals(source.getMapper().
                                 getHandler().getElementId())){
-                            source.getMapper().getHandler().sendEvent(queuedEvent.getEvent());
+                            source.getMapper().getHandler().sendEvent(queuedEvent.getEvent(),
+                                    null);
+                            ((HACoordinationSourceHandler)source.getMapper().getHandler()).
+                                    updateTransportSyncProperties(queuedEvent.getTransportSyncProperties());
                             eventListMap.remove(key);
                             isFound = true;
                             break;

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/event/queue/QueuedEvent.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/event/queue/QueuedEvent.java
@@ -19,8 +19,7 @@
 package org.wso2.carbon.stream.processor.core.event.queue;
 
 import org.wso2.siddhi.core.event.Event;
-
-import java.util.Arrays;
+import edu.umd.cs.findbugs.annotations.SuppressWarnings;
 
 public class QueuedEvent {
     private String sourceHandlerElementId;
@@ -30,15 +29,14 @@ public class QueuedEvent {
     private String siddhiAppName;
     private String[] transportSyncProperties;
 
+    @SuppressWarnings("EI_EXPOSE_REP2")
     public QueuedEvent(String siddhiAppName, String sourceHandlerElementId, long sequenceID, Event event,
                        String[] transportSyncProperties) {
         this.sourceHandlerElementId = sourceHandlerElementId;
         this.siddhiAppName = siddhiAppName;
         this.sequenceID = sequenceID;
         this.event = event;
-        this.transportSyncProperties = transportSyncProperties != null ?
-                Arrays.copyOf(transportSyncProperties,transportSyncProperties.length) : null;
-
+        this.transportSyncProperties = transportSyncProperties;
     }
 
     public long getSequenceID() {
@@ -81,8 +79,8 @@ public class QueuedEvent {
         this.siddhiAppName = siddhiAppName;
     }
 
+    @SuppressWarnings("EI_EXPOSE_REP")
     public String[] getTransportSyncProperties() {
-        return this.transportSyncProperties != null ?
-                Arrays.copyOf(this.transportSyncProperties, this.transportSyncProperties.length) : null;
+        return transportSyncProperties;
     }
 }

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/event/queue/QueuedEvent.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/event/queue/QueuedEvent.java
@@ -20,18 +20,25 @@ package org.wso2.carbon.stream.processor.core.event.queue;
 
 import org.wso2.siddhi.core.event.Event;
 
+import java.util.Arrays;
+
 public class QueuedEvent {
     private String sourceHandlerElementId;
     private long sequenceID;
     private Event event;
     private long timestamp;
     private String siddhiAppName;
+    private String[] transportSyncProperties;
 
-    public QueuedEvent(String siddhiAppName, String sourceHandlerElementId, long sequenceID, Event event) {
+    public QueuedEvent(String siddhiAppName, String sourceHandlerElementId, long sequenceID, Event event,
+                       String[] transportSyncProperties) {
         this.sourceHandlerElementId = sourceHandlerElementId;
         this.siddhiAppName = siddhiAppName;
         this.sequenceID = sequenceID;
         this.event = event;
+        this.transportSyncProperties = transportSyncProperties != null ?
+                Arrays.copyOf(transportSyncProperties,transportSyncProperties.length) : null;
+
     }
 
     public long getSequenceID() {
@@ -63,17 +70,19 @@ public class QueuedEvent {
     }
 
     public void setTimestamp(long timestamp) {
-
         this.timestamp = timestamp;
     }
 
     public String getSiddhiAppName() {
-
         return siddhiAppName;
     }
 
     public void setSiddhiAppName(String siddhiAppName) {
-
         this.siddhiAppName = siddhiAppName;
+    }
+
+    public String[] getTransportSyncProperties() {
+        return this.transportSyncProperties != null ?
+                Arrays.copyOf(this.transportSyncProperties, this.transportSyncProperties.length) : null;
     }
 }

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/ha/HACoordinationSourceHandler.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/ha/HACoordinationSourceHandler.java
@@ -65,7 +65,6 @@ public class HACoordinationSourceHandler extends SourceHandler {
         this.sourceHandlerElementId = sourceElementId;
         this.siddhiAppName = siddhiAppName;
         this.sourceSyncCallback = sourceSyncCallback;
-
     }
 
     /**
@@ -78,11 +77,13 @@ public class HACoordinationSourceHandler extends SourceHandler {
     @Override
     public void sendEvent(Event event, String[] transportSyncProperties, InputHandler inputHandler)
             throws InterruptedException {
+        log.info("SENDING EVENT");
         if (isActiveNode) {
             lastProcessedEventTimestamp = event.getTimestamp();
             if (passiveNodeAdded) {
                 sendEventsToPassiveNode(event, transportSyncProperties);
             }
+            log.info("SENT EVENT");
             inputHandler.send(event);
         }
     }
@@ -127,6 +128,7 @@ public class HACoordinationSourceHandler extends SourceHandler {
 
     @Override
     public Map<String, Object> currentState() {
+        log.info("TESTTTTTTTTTTTTTTTTTTTTTTT");
         Map<String, Object> currentState = new HashMap<>();
         currentState.put(CoordinationConstants.ACTIVE_PROCESSED_LAST_TIMESTAMP, lastProcessedEventTimestamp);
         if (log.isDebugEnabled()) {
@@ -180,9 +182,14 @@ public class HACoordinationSourceHandler extends SourceHandler {
             QueuedEvent[] queuedEvents = new QueuedEvent[events.length];
             int i = 0;
             for (Event event : events) {
-                QueuedEvent queuedEvent = new QueuedEvent(siddhiAppName, sourceHandlerElementId, sequenceIDGenerator
-                        .incrementAndGet(), event,
-                        transportSyncProperties != null ? new String[]{transportSyncProperties[i]} : null);
+                QueuedEvent queuedEvent;
+                if (i == 0) {
+                    queuedEvent = new QueuedEvent(siddhiAppName, sourceHandlerElementId, sequenceIDGenerator
+                            .incrementAndGet(), event, transportSyncProperties);
+                } else {
+                    queuedEvent = new QueuedEvent(siddhiAppName, sourceHandlerElementId, sequenceIDGenerator
+                            .incrementAndGet(), event, null);
+                }
                 queuedEvents[i] = queuedEvent;
                 i++;
             }
@@ -219,7 +226,7 @@ public class HACoordinationSourceHandler extends SourceHandler {
     }
 
     public void updateTransportSyncProperties(String[] transportSyncProperties) {
-        if (null != transportSyncProperties && transportSyncProperties.length != 0) {
+        if (null != sourceSyncCallback) {
             sourceSyncCallback.update(transportSyncProperties);
         }
     }

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/ha/HACoordinationSourceHandler.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/ha/HACoordinationSourceHandler.java
@@ -126,7 +126,6 @@ public class HACoordinationSourceHandler extends SourceHandler {
 
     @Override
     public Map<String, Object> currentState() {
-        log.info("TESTTTTTTTTTTTTTTTTTTTTTTT");
         Map<String, Object> currentState = new HashMap<>();
         currentState.put(CoordinationConstants.ACTIVE_PROCESSED_LAST_TIMESTAMP, lastProcessedEventTimestamp);
         if (log.isDebugEnabled()) {

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/ha/HACoordinationSourceHandler.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/ha/HACoordinationSourceHandler.java
@@ -77,13 +77,11 @@ public class HACoordinationSourceHandler extends SourceHandler {
     @Override
     public void sendEvent(Event event, String[] transportSyncProperties, InputHandler inputHandler)
             throws InterruptedException {
-        log.info("SENDING EVENT");
         if (isActiveNode) {
             lastProcessedEventTimestamp = event.getTimestamp();
             if (passiveNodeAdded) {
                 sendEventsToPassiveNode(event, transportSyncProperties);
             }
-            log.info("SENT EVENT");
             inputHandler.send(event);
         }
     }

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/ha/HACoordinationSourceHandler.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/ha/HACoordinationSourceHandler.java
@@ -81,7 +81,7 @@ public class HACoordinationSourceHandler extends SourceHandler {
         if (isActiveNode) {
             lastProcessedEventTimestamp = event.getTimestamp();
             if (passiveNodeAdded) {
-                sendEventsToPassiveNode(event,transportSyncProperties);
+                sendEventsToPassiveNode(event, transportSyncProperties);
             }
             inputHandler.send(event);
         }

--- a/components/org.wso2.carbon.stream.processor.core/src/test/java/org/wso2/carbon/stream/processor/core/HACoordinationSourceHandlerTest.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/test/java/org/wso2/carbon/stream/processor/core/HACoordinationSourceHandlerTest.java
@@ -51,14 +51,15 @@ public class HACoordinationSourceHandlerTest extends PowerMockTestCase {
     public void testActiveNodeProcessing() throws InterruptedException {
 
         HACoordinationSourceHandler haCoordinationSourceHandler = spy(new HACoordinationSourceHandler());
-        doNothing().when(haCoordinationSourceHandler).sendEvent(Mockito.any(Event.class));
+        doNothing().when(haCoordinationSourceHandler).sendEvent(Mockito.any(Event.class), Mockito.any());
 
         InputHandler inputHandler = mock(InputHandler.class);
         doNothing().when(inputHandler).send(any(Event.class));
         haCoordinationSourceHandler.setInputHandler(inputHandler);
         haCoordinationSourceHandler.setAsActive();
+        haCoordinationSourceHandler.setPassiveNodeAdded(false);
 
-        haCoordinationSourceHandler.init("A", SOURCE_1, new StreamDefinition());
+        haCoordinationSourceHandler.init("A", null, SOURCE_1, new StreamDefinition());
 
         Event event = new Event();
         Event eventTwo = new Event();
@@ -69,16 +70,14 @@ public class HACoordinationSourceHandlerTest extends PowerMockTestCase {
         eventThree.setTimestamp(3L);
         eventFour.setTimestamp(4L);
 
-        //Active Should Send Events for Processing and Update the Last Published Events TS
-        haCoordinationSourceHandler.sendEvent(event, inputHandler);
-        haCoordinationSourceHandler.sendEvent(eventTwo, inputHandler);
-
+        haCoordinationSourceHandler.sendEvent(event, null, inputHandler);
+        haCoordinationSourceHandler.sendEvent(eventTwo, null, inputHandler);
 
         Map<String, Object> stateObject = haCoordinationSourceHandler.currentState();
         Assert.assertEquals((long) stateObject.get(CoordinationConstants.ACTIVE_PROCESSED_LAST_TIMESTAMP), 2L);
 
-        haCoordinationSourceHandler.sendEvent(eventThree, inputHandler);
-        haCoordinationSourceHandler.sendEvent(eventFour, inputHandler);
+        haCoordinationSourceHandler.sendEvent(eventThree, null, inputHandler);
+        haCoordinationSourceHandler.sendEvent(eventFour, null, inputHandler);
 
         stateObject = haCoordinationSourceHandler.currentState();
         Assert.assertEquals((long) stateObject.get(CoordinationConstants.ACTIVE_PROCESSED_LAST_TIMESTAMP), 4L);
@@ -89,14 +88,15 @@ public class HACoordinationSourceHandlerTest extends PowerMockTestCase {
     public void testActiveNodeArrayOfEventsProcessing() throws InterruptedException {
 
         HACoordinationSourceHandler haCoordinationSourceHandler = spy(new HACoordinationSourceHandler());
-        doNothing().when(haCoordinationSourceHandler).sendEvent(Mockito.any(Event.class));
+        doNothing().when(haCoordinationSourceHandler).sendEvent(Mockito.any(Event.class), Mockito.any());
 
         InputHandler inputHandler = mock(InputHandler.class);
         doNothing().when(inputHandler).send(any(Event.class));
         haCoordinationSourceHandler.setInputHandler(inputHandler);
         haCoordinationSourceHandler.setAsActive();
+        haCoordinationSourceHandler.setPassiveNodeAdded(false);
 
-        haCoordinationSourceHandler.init("A", SOURCE_1, new StreamDefinition());
+        haCoordinationSourceHandler.init("A", null, SOURCE_1, new StreamDefinition());
 
         Event event = new Event();
         Event eventTwo = new Event();
@@ -108,7 +108,7 @@ public class HACoordinationSourceHandlerTest extends PowerMockTestCase {
         eventFour.setTimestamp(4L);
         Event[] events = {event, eventTwo, eventThree, eventFour};
 
-        haCoordinationSourceHandler.sendEvent(events, inputHandler);
+        haCoordinationSourceHandler.sendEvent(events, null, inputHandler);
 
         Map<String, Object> stateObject = haCoordinationSourceHandler.currentState();
         Assert.assertEquals((long) stateObject.get(CoordinationConstants.ACTIVE_PROCESSED_LAST_TIMESTAMP), 4L);

--- a/pom.xml
+++ b/pom.xml
@@ -1553,8 +1553,8 @@
 
     <properties>
         <carbon.analytics.version>2.0.479-SNAPSHOT</carbon.analytics.version>
-        <siddhi.version>4.3.12</siddhi.version>
-        <siddhi.bundle.version>4.3.12</siddhi.bundle.version>
+        <siddhi.version>4.4.0</siddhi.version>
+        <siddhi.bundle.version>4.4.0</siddhi.bundle.version>
         <siddhi.version.range>[4.0.0, 5.0.0)</siddhi.version.range>
         <carbon.analytics-common.version>6.0.73</carbon.analytics-common.version>
         <carbon.analytics-common.version.range>[6.0.66, 6.1.0)</carbon.analytics-common.version.range>


### PR DESCRIPTION
## Purpose
Allow transport sync properties to be synced to passive node when starting up

## Goals
To make the source state to be in synced when active node goes down


## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes