### PR TITLE
Fix for deign-view

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/codegenerator/generators/query/subelements/QuerySelectCodeGenerator.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/codegenerator/generators/query/subelements/QuerySelectCodeGenerator.java
@@ -71,7 +71,8 @@ public class QuerySelectCodeGenerator {
      */
     private static String generateUserDefinedSelection(UserDefinedSelectionConfig userDefinedSelection)
             throws CodeGenerationException {
-        if (userDefinedSelection == null || userDefinedSelection.getValue() == null) {
+        if (userDefinedSelection == null || userDefinedSelection.getValue() == null ||
+                userDefinedSelection.getValue().isEmpty()) {
             throw new CodeGenerationException("A given user defined selection value is empty");
         }
 

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/designgenerator/generators/AttributesSelectionConfigGenerator.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/designgenerator/generators/AttributesSelectionConfigGenerator.java
@@ -60,7 +60,9 @@ public class AttributesSelectionConfigGenerator extends CodeSegmentsPreserver {
                 try {
                     selectedAttributes.add(generateSelectedAttribute(outputAttribute));
                 } catch (DesignGenerationException e) {
-                    log.error("Definition of the attribute selection is not found " + e.getMessage(), e);
+                    AllSelectionConfig allSelectionConfig = new AllSelectionConfig();
+                    preserveAndBindCodeSegment(selector, allSelectionConfig);
+                    return new AllSelectionConfig();
                 }
             }
         }


### PR DESCRIPTION

## Purpose
> An exception will be thrown if the attribute selection is given as * in query to input into an undefined stream.
> Resolves issue: https://github.com/wso2/carbon-analytics/issues/1584

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
