### PR TITLE
Fix for query user defined attribute selection

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/JSON-validator.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/JSON-validator.js
@@ -364,7 +364,7 @@ define(['require', 'log', 'jquery', 'lodash', 'designViewUtils'],
                 return false;
             } else if (!query.queryInput.right) {
                 errorMessage = 'Right source of Join query is not defined';
-                highlightIncompleteElement(query.i, errorMessage);
+                highlightIncompleteElement(query.id, errorMessage);
                 if (!doNotShowErrorMessages) {
                     DesignViewUtils.prototype.errorAlert(errorMessage);
                 }

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/form-utils.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/form-utils.js
@@ -1016,11 +1016,11 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
         FormUtils.prototype.expandCollapsedDiv = function (divToBeExpanded) {
             var collapseHeader = $(divToBeExpanded).find('.collapsed:first');
             var collapseBody = $(divToBeExpanded).find('.collapse:first');
-            collapseHeader.attr("aria-expanded","true");
+            collapseHeader.attr("aria-expanded", "true");
             collapseHeader.removeClass("collapsed");
-            collapseBody.attr("aria-expanded","true");
+            collapseBody.attr("aria-expanded", "true");
             collapseBody.addClass("collapse in");
-            collapseBody.css("height","auto");
+            collapseBody.css("height", "auto");
             $('.collapse .error-input-field')[0].scrollIntoView();
         };
 

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/form-utils.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/form-utils.js
@@ -718,8 +718,12 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
             var i = 0;
             var connectedElement = self.configurationData.getSiddhiAppConfig().getDefinitionElementByName(outputElementName);
             _.forEach(connectedElement.element.getAttributeList(), function (attribute) {
+                var expression = "";
+                if(projectionValues[i]) {
+                    expression = projectionValues[i].expression;
+                }
                 attributes.push({
-                    expression: projectionValues[i].expression,
+                    expression: expression,
                     as: attribute.getName()
                 });
                 i++;


### PR DESCRIPTION
## Purpose
> When the number of attributes are changed in a connected query's output element. While loading the query form the expression of the newly added attribute throws an error as it is undefined.

## Goals
> I check if the expression is defined else I add an empty string to the newly added attribute.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
