### PR TITLE
Remove error element class on submit of the element forms.

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/lib/enjoyhint/enjoyhint.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/lib/enjoyhint/enjoyhint.js
@@ -751,7 +751,6 @@ var EnjoyHint = function (_options) {
                                 y1 = labelRect.top;
                                 bezX = x1;
                                 bezY = y1;
-                                console.log("ok");
                             }
 
                             if (window.innerWidth < 900) {

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/JSON-validator.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/JSON-validator.js
@@ -256,6 +256,7 @@ define(['require', 'log', 'jquery', 'lodash', 'designViewUtils', 'constants'],
             }
             if (isValid) {
                 removeErrorHighlighter(aggregation.id);
+                removeIncompleteElement(aggregation.id);
                 removeTooltipErrorMessage(aggregation.id);
             } else {
                 if(aggregation.name) {
@@ -293,6 +294,7 @@ define(['require', 'log', 'jquery', 'lodash', 'designViewUtils', 'constants'],
                 DesignViewUtils.prototype.errorAlert(errorMessage);
             }
             if (isValid) {
+                removeIncompleteElement(query.id);
                 removeErrorHighlighter(query.id);
                 removeTooltipErrorMessage(query.id);
             } else {
@@ -336,6 +338,7 @@ define(['require', 'log', 'jquery', 'lodash', 'designViewUtils', 'constants'],
             }
             if (isValid) {
                 removeErrorHighlighter(query.id);
+                removeIncompleteElement(query.id);
                 removeTooltipErrorMessage(query.id);
             } else {
                 if (self.isQueryFreshlyDropped(query.queryOutput)) {
@@ -375,6 +378,7 @@ define(['require', 'log', 'jquery', 'lodash', 'designViewUtils', 'constants'],
                 DesignViewUtils.prototype.errorAlert(errorMessage);
             }
             if (isValid) {
+                removeIncompleteElement(query.id);
                 removeErrorHighlighter(query.id);
                 removeTooltipErrorMessage(query.id);
             } else {
@@ -553,6 +557,13 @@ define(['require', 'log', 'jquery', 'lodash', 'designViewUtils', 'constants'],
             element.addClass('incomplete-element');
             // set error message as the tooltip message
             element.prop('title', errorMessage);
+        }
+
+        function removeIncompleteElement(incompleteElementId) {
+            var element = $('#' + incompleteElementId);
+            if (element.hasClass('incomplete-element')) {
+                element.removeClass('incomplete-element');
+            }
         }
 
         function removeErrorHighlighter(errorElementId) {

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/aggregation-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/aggregation-form.js
@@ -576,8 +576,7 @@ define(['require', 'log', 'jquery', 'lodash', 'aggregateByTimePeriod', 'querySel
                         var aggregateByTimePeriod = new AggregateByTimePeriod(aggregateByTimePeriodOptions);
                         aggregationObject.setAggregateByTimePeriod(aggregateByTimePeriod);
 
-                        $('#' + id).removeClass('incomplete-element');
-                        $('#' + id).removeClass('error-element');
+                        JSONValidator.prototype.validateAggregation(aggregationObject);
                         //Send aggregation element to the backend and generate tooltip
                         var aggregationToolTip = self.formUtils.getTooltip(aggregationObject, Constants.AGGREGATION);
                         $('#' + id).prop('title', aggregationToolTip);

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/join-query-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/join-query-form.js
@@ -709,7 +709,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOutputInsert'
                         queryOutput.setTarget(outputTarget);
                         queryOutput.setType(Constants.INSERT);
 
-                        $('#' + id).removeClass('incomplete-element');
+                        JSONValidator.prototype.validateJoinQuery(joinQueryObject);
                         self.configurationData.setIsDesignViewContentChanged(true);
 
                         //Send join-query element to the backend and generate tooltip

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/pattern-query-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/pattern-query-form.js
@@ -453,7 +453,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOutputInsert'
                         queryOutput.setTarget(outputTarget);
                         queryOutput.setType(Constants.INSERT);
 
-                        $('#' + id).removeClass('incomplete-element');
+                        JSONValidator.prototype.validatePatternOrSequenceQuery(patternQueryObject, Constants.PATTERN_QUERY);
                         self.configurationData.setIsDesignViewContentChanged(true);
 
                         //Send pattern-query element to the backend and generate tooltip

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/sequence-query-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/sequence-query-form.js
@@ -454,14 +454,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOutputInsert'
                         queryOutput.setTarget(outputTarget);
                         queryOutput.setType(Constants.INSERT);
 
-                        var isValid = JSONValidator.prototype.validatePatternOrSequenceQuery(sequenceQueryObject,
-                            Constants.SEQUENCE_QUERY, false);
-                        if (!isValid) {
-                            isErrorOccurred = true;
-                            return;
-                        }
-
-                        $('#' + id).removeClass('incomplete-element');
+                        JSONValidator.prototype.validatePatternOrSequenceQuery(sequenceQueryObject, Constants.SEQUENCE_QUERY);
                         self.configurationData.setIsDesignViewContentChanged(true);
 
                         //Send sequence-query element to the backend and generate tooltip

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/window-filter-projection-query-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/window-filter-projection-query-form.js
@@ -426,7 +426,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOutputInsert'
                         }
                         queryInput.setType(queryType.toUpperCase());
 
-                        $('#' + id).removeClass('incomplete-element');
+                        JSONValidator.prototype.validateWindowFilterProjectionQuery(queryObject);
                         self.configurationData.setIsDesignViewContentChanged(true);
 
                         //Send query element to the backend and generate tooltip


### PR DESCRIPTION
## Purpose
> On click of submit in the form, the error class isn't removes therefore the red border remains as it is on the element.

## Goals
> On click of the submit in the form, remove the error/incomplete class.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
