### PR TITLE
Add descriptions for query output options

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/css/design-view.css
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/css/design-view.css
@@ -1206,10 +1206,17 @@ a.list-group-item, button.list-group-item {
 	margin-top: 3px;
 }
 
-.design-view-form-content .group-by-content .btn-del-option,
-.design-view-form-content .order-by-attributes .define-order-del {
+.design-view-form-content .group-by-content .btn-del-option {
 	margin-left: 10px;
-    margin-top: 2px;
+    margin-top: 1px;
+}
+
+.design-view-form-content .order-group-by-content .define-order-del {
+    margin-left: 10px;
+}
+
+.design-view-form-content .order-by-attribute-content .btn-del-option {
+    margin-top: 0px;
 }
 
 .join-query-form-container .define-source input[type="text"].as-content-value {

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/css/design-view.css
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/css/design-view.css
@@ -1055,10 +1055,7 @@ a.list-group-item, button.list-group-item {
 	margin-top: 10px;
 }
 
-.design-view-form-content .option .option-desc-content,
-.design-view-form-content .parameter .parameter-desc-content,
-.aggregation-form-container .attribute-by-desc-content,
-.trigger-form-container #define-trigger-criteria .criteria-description {
+.design-view-form-content .fw-info > span {
 	 font-family: Arial;
 	 background: #252525;
 	 width: 250px;

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
@@ -1677,27 +1677,42 @@
     <h3> Output </h3>
     <div class="define-order-by-attributes"> </div>
     <div class = "define-limit define-content">
-        <label>
-            <input type="checkbox" class="limit-checkbox query-checkbox"> Limit
-        </label>
+        <div class="clearfix">
+            <label>
+                <input type="checkbox" class="limit-checkbox query-checkbox"> Limit
+            </label>
+            <i class = "fw fw-info">
+                <span style = "display:none"> When events are emitted as a batch, limit allows to limit the number
+                    of events in the batch from the defined offset. </span>
+            </i>
+        </div>
         <div class="limit-content query-content">
             <input type="text"  class="clearfix limit-value query-content-value">
             <label class="error-message"> </label>
         </div>
     </div>
     <div class = "define-offset define-content">
-        <label>
-            <input type="checkbox" class="offset-checkbox query-checkbox"> Offset
-        </label>
+        <div class="clearfix">
+            <label> <input type="checkbox" class="offset-checkbox query-checkbox"> Offset </label>
+            <i class = "fw fw-info">
+                <span style = "display:none"> When events are emitted as a batch, offset allows to offset beginning
+                    of the output event batch. </span>
+            </i>
+        </div>
         <div class="offset-content query-content">
             <input type="text"  class="clearfix offset-value query-content-value">
             <label class="error-message"> </label>
         </div>
     </div>
     <div class = "define-rate-limiting define-content">
-        <label>
-            <input type="checkbox" class="rate-limiting-checkbox query-checkbox"> Rate limiting
-        </label>
+        <div class="clearfix">
+            <label> <input type="checkbox" class="rate-limiting-checkbox query-checkbox"> Rate limiting </label>
+            <i class = "fw fw-info">
+                <span style = "display:none"> It allows queries to output events periodically based on a specified
+                    condition.</span>
+            </i>
+        </div>
+
         <div class="rate-limiting-content query-content">
             <input type="text"  class="clearfix rate-limiting-value query-content-value">
             <label class="error-message"> </label>

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
@@ -1201,8 +1201,8 @@
                             <label class = "option-name optional-option">
                                 <input type = "checkbox" class = "option-checkbox" checked> {{name}}
                             </label>
-                            <i class = "fw fw-info option-desc">
-                                <span style = "display:none" class = "option-desc-content"> {{description}} </span>
+                            <i class = "fw fw-info">
+                                <span style = "display:none"> {{description}} </span>
                             </i>
                         </div>
                         <div class = "clearfix">
@@ -1213,8 +1213,8 @@
                             <label class = "option-name optional-option">
                                 <input type = "checkbox" class = "option-checkbox"> {{name}}
                             </label>
-                            <i class = "fw fw-info option-desc">
-                                <span style = "display:none" class="option-desc-content"> {{description}} </span>
+                            <i class = "fw fw-info">
+                                <span style = "display:none"> {{description}} </span>
                             </i>
                         </div>
                         <div class="clearfix">
@@ -1228,8 +1228,8 @@
                         <label class = "option-name mandatory-option">
                             {{name}}
                         </label>
-                        <i class="fw fw-info option-desc">
-                            <span style="display:none" class="option-desc-content"> {{description}} </span>
+                        <i class="fw fw-info">
+                            <span style="display:none"> {{description}} </span>
                         </i>
                     </div>
                     <div class = "clearfix">
@@ -1355,8 +1355,8 @@
                     <label class = "parameter-name optional-parameter">
                         <input type = "checkbox" class = "parameter-checkbox" checked> {{name}}
                     </label>
-                    <i class = "fw fw-info parameter-desc">
-                        <span style = "display:none" class = "parameter-desc-content"> {{description}} </span>
+                    <i class = "fw fw-info">
+                        <span style = "display:none"> {{description}} </span>
                     </i>
                 </div>
                 <div class = "clearfix optional-param-content">
@@ -1367,8 +1367,8 @@
                     <label class = "parameter-name optional-parameter">
                         <input type = "checkbox" class = "parameter-checkbox"> {{name}}
                     </label>
-                    <i class = "fw fw-info parameter-desc">
-                        <span style = "display:none" class="parameter-desc-content"> {{description}} </span>
+                    <i class = "fw fw-info">
+                        <span style = "display:none"> {{description}} </span>
                     </i>
                 </div>
                 <div class="clearfix optional-param-content" style ="display:none">
@@ -1382,8 +1382,8 @@
                 <label class = "parameter-name mandatory-parameter">
                     {{name}}
                 </label>
-                <i class="fw fw-info parameter-desc">
-                    <span style="display:none" class="parameter-desc-content"> {{description}} </span>
+                <i class="fw fw-info">
+                    <span style="display:none"> {{description}} </span>
                 </i>
             </div>
             <div class = "clearfix">
@@ -1600,10 +1600,8 @@
                     <label>
                         <input type = "checkbox" id="aggregate-by-attribute-checkbox"> By Attribute
                     </label>
-                    <i class = "fw fw-info attribute-by-desc">
-                    <span style = "display:none" class="attribute-by-desc-content">
-                        Attribute of timestamp is required
-                    </span>
+                    <i class = "fw fw-info">
+                        <span style = "display:none"> Attribute of timestamp is required </span>
                     </i>
                 </div>
                 <div class="aggregate-by-attribute-content clearfix">

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
@@ -1674,48 +1674,22 @@
 <script id="query-output-template" type = "text/template">
     <h3> Output </h3>
     <div class="define-order-by-attributes"> </div>
-    <div class = "define-limit define-content">
-        <div class="clearfix">
-            <label>
-                <input type="checkbox" class="limit-checkbox query-checkbox"> Limit
-            </label>
-            <i class = "fw fw-info">
-                <span style = "display:none"> When events are emitted as a batch, limit allows to limit the number
-                    of events in the batch from the defined offset. </span>
-            </i>
+    {{#each outputConfig}}
+        <div class = "define-{{name}} define-content">
+            <div class="clearfix">
+                <label>
+                    <input type="checkbox" class="{{name}}-checkbox query-checkbox"> {{addTitle name}}
+                </label>
+                <i class = "fw fw-info">
+                    <span style = "display:none"> {{description}} </span>
+                </i>
+            </div>
+            <div class="{{name}}-content query-content">
+                <input type="text"  class="clearfix {{name}}-value query-content-value">
+                <label class="error-message"> </label>
+            </div>
         </div>
-        <div class="limit-content query-content">
-            <input type="text"  class="clearfix limit-value query-content-value">
-            <label class="error-message"> </label>
-        </div>
-    </div>
-    <div class = "define-offset define-content">
-        <div class="clearfix">
-            <label> <input type="checkbox" class="offset-checkbox query-checkbox"> Offset </label>
-            <i class = "fw fw-info">
-                <span style = "display:none"> When events are emitted as a batch, offset allows to offset beginning
-                    of the output event batch. </span>
-            </i>
-        </div>
-        <div class="offset-content query-content">
-            <input type="text"  class="clearfix offset-value query-content-value">
-            <label class="error-message"> </label>
-        </div>
-    </div>
-    <div class = "define-rate-limiting define-content">
-        <div class="clearfix">
-            <label> <input type="checkbox" class="rate-limiting-checkbox query-checkbox"> Rate limiting </label>
-            <i class = "fw fw-info">
-                <span style = "display:none"> It allows queries to output events periodically based on a specified
-                    condition.</span>
-            </i>
-        </div>
-
-        <div class="rate-limiting-content query-content">
-            <input type="text"  class="clearfix rate-limiting-value query-content-value">
-            <label class="error-message"> </label>
-        </div>
-    </div>
+    {{/each}}
     <div class="define-output-content">
         <label> Operation </label>
         <input type="text" class="clearfix name query-operation" value="{{operation}}" readonly>
@@ -2689,6 +2663,23 @@
                         }
                     ]
 
+                }
+            ],
+            query_output_options: [
+                {
+                    name: "limit",
+                    description: "When events are emitted as a batch, limit allows to limit the number\n" +
+                        " of events in the batch from the defined offset."
+                },
+                {
+                    name: "offset",
+                    description: "When events are emitted as a batch, offset allows to offset beginning\n" +
+                        " of the output event batch."
+                },
+                {
+                    name: "rate-limiting",
+                    description: "It allows queries to output events periodically based on a specified\n" +
+                        "condition."
                 }
             ],
             query_condition_syntax: ["==", ">=", ">", "<=", "<", "&&", "||", "AND", "OR"],

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/form-utils.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/form-utils.js
@@ -302,8 +302,10 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
          * @function to render the html for query output
          */
         FormUtils.prototype.renderQueryOutput = function (outputElementName) {
+            var self = this;
+            var outputConfig = self.configurationData.application.config.query_output_options;
             var queryOutputTemplate = Handlebars.compile($('#query-output-template').html())
-                ({ into: outputElementName, operation: Constants.INSERT });
+                ({ into: outputElementName, operation: Constants.INSERT, outputConfig: outputConfig });
             $('.define-query-output').html(queryOutputTemplate);
         };
 

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/form-utils.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/form-utils.js
@@ -3020,16 +3020,6 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
          * @function to add event listeners for parameter division
          */
         FormUtils.prototype.addEventListenersForParameterDiv = function () {
-            //event listener to show parameter description
-            $('.defineFunctionParameters').on('mouseover', '.parameter-desc', function () {
-                $(this).find('.parameter-desc-content').show();
-            });
-
-            //event listener to hide parameter description
-            $('.defineFunctionParameters').on('mouseout', '.parameter-desc', function () {
-                $(this).find('.parameter-desc-content').hide();
-            });
-
             //event listener when the parameter checkbox is changed
             $('.defineFunctionParameters').on('change', '.parameter-checkbox', function () {
                 var parameterParent = $(this).parents(".parameter");
@@ -3462,20 +3452,23 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
         };
 
         /**
+         * @function to hide and show the description of the info icon
+         */
+        FormUtils.prototype.addEventListenerToShowAndHideInfo = function () {
+            $('.design-view-form-content').on('mouseover', '.fw-info', function () {
+                $(this).find('span').show();
+            });
+
+            $('.design-view-form-content').on('mouseout', '.fw-info', function () {
+                $(this).find('span').hide();
+            });
+        };
+
+        /**
          * @function to add event listeners of the annotation options
          */
         FormUtils.prototype.addEventListenersForGenericOptionsDiv = function (id) {
             var self = this;
-            //To show option description
-            $('#' + id + '-options-div').on('mouseover', '.option-desc', function () {
-                $(this).find('.option-desc-content').show();
-            });
-
-            //To hide option description
-            $('#' + id + '-options-div').on('mouseout', '.option-desc', function () {
-                $(this).find('.option-desc-content').hide();
-            });
-
             //To hide and show the option content of the optional options
             $('#' + id + '-options-div').on('change', '.option-checkbox', function () {
                 var optionParent = $(this).parents(".option");

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/form-utils.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/form-utils.js
@@ -2511,7 +2511,7 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
         FormUtils.prototype.createObjectsForAnnotationsWithKeys = function (predefinedAnnotations) {
             var self = this;
             var annotationsWithKeys = [];
-            var subAnnotations;
+            var subAnnotations = [];
             _.forEach(predefinedAnnotations, function (predefinedAnnotation) {
                 if (predefinedAnnotation.name.toLowerCase() != Constants.PRIMARY_KEY &&
                     predefinedAnnotation.name.toLowerCase() != Constants.INDEX) {
@@ -2530,6 +2530,8 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
                         optional: predefinedAnnotation.optional, isChecked: false
                     }
                     annotationsWithKeys.push(annotationObject);
+                    //clear the sub annotations
+                    subAnnotations.length = 0;
                 }
             });
             return annotationsWithKeys;

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/aggregation-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/aggregation-form.js
@@ -277,6 +277,7 @@ define(['require', 'log', 'jquery', 'lodash', 'aggregateByTimePeriod', 'querySel
                 $('#define-aggregation').html(aggregationFormTemplate);
 
                 self.formUtils.addEventListenerToRemoveRequiredClass();
+                self.formUtils.addEventListenerToShowAndHideInfo();
 
                 //createAnnotationObjects
                 annotationsWithKeys = self.formUtils.createObjectsForAnnotationsWithKeys(predefinedAggregationAnnotations);
@@ -349,14 +350,6 @@ define(['require', 'log', 'jquery', 'lodash', 'aggregateByTimePeriod', 'querySel
                     } else {
                         $('.aggregate-by-attribute-content').hide();
                     }
-                });
-
-                $('#aggregate-by-attribute').on('mouseover', '.attribute-by-desc', function () {
-                    $(this).find('.attribute-by-desc-content').show();
-                });
-
-                $('#aggregate-by-attribute').on('mouseout', '.attribute-by-desc', function () {
-                    $(this).find('.attribute-by-desc-content').hide();
                 });
 
                 $('#define-aggregate-by').on('change', '.aggregate-by-time-period-selection', function () {

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/join-query-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/join-query-form.js
@@ -359,6 +359,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOutputInsert'
                 self.formUtils.renderOutputEventTypes();
 
                 self.formUtils.addEventListenerToRemoveRequiredClass();
+                self.formUtils.addEventListenerToShowAndHideInfo();
 
                 //annotations
                 predefinedAnnotations = self.formUtils.createObjectsForAnnotationsWithKeys(predefinedAnnotations);

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/pattern-query-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/pattern-query-form.js
@@ -187,6 +187,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOutputInsert'
                 self.formUtils.renderOutputEventTypes();
 
                 self.formUtils.addEventListenerToRemoveRequiredClass();
+                self.formUtils.addEventListenerToShowAndHideInfo();
 
                 $('.pattern-sequence-query-form-container').on('change', '.query-checkbox', function () {
                     var parent = $(this).parents(".define-content")

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/sequence-query-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/sequence-query-form.js
@@ -187,6 +187,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOutputInsert'
                 self.formUtils.renderOutputEventTypes();
 
                 self.formUtils.addEventListenerToRemoveRequiredClass();
+                self.formUtils.addEventListenerToShowAndHideInfo();
 
                 $('.pattern-sequence-query-form-container').on('change', '.query-checkbox', function () {
                     var parent = $(this).parents(".define-content")

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/sink-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/sink-form.js
@@ -159,6 +159,7 @@ define(['log', 'jquery', 'lodash', 'mapAnnotation', 'payloadOrAttribute', 'jsonV
                 self.toggleViewButton.addClass('disableContainer');
 
                 self.formUtils.addEventListenerToRemoveRequiredClass();
+                self.formUtils.addEventListenerToShowAndHideInfo();
 
                 //declaration of variables
                 var currentSinkOptions = [];

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/source-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/source-form.js
@@ -153,6 +153,7 @@ define(['log', 'jquery', 'lodash', 'sourceOrSinkAnnotation', 'mapAnnotation', 'p
                 self.toggleViewButton.addClass('disableContainer');
 
                 self.formUtils.addEventListenerToRemoveRequiredClass();
+                self.formUtils.addEventListenerToShowAndHideInfo();
 
                 //declaration of variables
                 var currentSourceOptions = [];

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/table-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/table-form.js
@@ -64,6 +64,7 @@ define(['log', 'jquery', 'lodash', 'attribute', 'storeAnnotation', 'handlebar', 
             self.toggleViewButton.addClass('disableContainer');
 
             self.formUtils.addEventListenerToRemoveRequiredClass();
+            self.formUtils.addEventListenerToShowAndHideInfo();
 
             var predefinedStores = _.orderBy(_.cloneDeep(this.configurationData.rawExtensions["store"]),
                 ['name'], ['asc']);

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/trigger-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/trigger-form.js
@@ -47,7 +47,7 @@ define(['require', 'log', 'jquery', 'lodash', 'constants'],
                 triggerCriteriaDiv += '<option value = "' + triggerCriteria.name + '">' + triggerCriteria.name + '</option>';
             });
             triggerCriteriaDiv += '</select> <i class = "fw fw-info"> ' +
-                '<span style = "display:none" class = "criteria-description"> </span> </i>';
+                '<span style = "display:none"> </span> </i>';
             $('#define-trigger-criteria').html(triggerCriteriaDiv);
         };
 
@@ -142,16 +142,7 @@ define(['require', 'log', 'jquery', 'lodash', 'constants'],
             renderTriggerCriteria(triggerCriteriaObject);
 
             self.formUtils.addEventListenerToRemoveRequiredClass();
-
-            //Event listener to show the criteria description
-            $('#define-trigger-criteria').on('mouseover', '.fw-info', function () {
-                $(this).find('.criteria-description').show();
-            });
-
-            //Event listener to hide the criteria description
-            $('#define-trigger-criteria').on('mouseout', '.fw-info', function () {
-                $(this).find('.criteria-description').hide();
-            });
+            self.formUtils.addEventListenerToShowAndHideInfo();
 
             if (name) {
                 //if the trigger object is already edited

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/window-filter-projection-query-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/window-filter-projection-query-form.js
@@ -132,6 +132,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOutputInsert'
                 self.formUtils.renderOutputEventTypes();
 
                 self.formUtils.addEventListenerToRemoveRequiredClass();
+                self.formUtils.addEventListenerToShowAndHideInfo();
 
                 $('.query-form-container').on('change', '.query-checkbox', function () {
                     var parent = $(this).parents(".define-content")

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/window-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/window-form.js
@@ -62,6 +62,7 @@ define(['require', 'log', 'jquery', 'lodash', 'attribute', 'constants'],
             self.toggleViewButton.addClass('disableContainer');
 
             self.formUtils.addEventListenerToRemoveRequiredClass();
+            self.formUtils.addEventListenerToShowAndHideInfo();
 
             //declaration and initialization of variables
             var predefinedWindowFunctionNames = _.orderBy(this.configurationData.rawExtensions["windowFunctionNames"],


### PR DESCRIPTION
## Purpose
> Purpose of the query output options in the forms were not conveyed to the user.
> To show and hide the descriptions the same event listener was added in many places.

## Goals
> Adds description in info icon tag for query output options.
> Used a common method to show and hide descriptions in info icon.

## Approach
![image](https://user-images.githubusercontent.com/32606884/54973703-f8e65e80-4fb6-11e9-872c-6ba40b2b5811.png)

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
