### PR TITLE
Fix styling for import sample and generate sample event headings in the dialog box

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/dialog/open-sample-file-dialog.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/dialog/open-sample-file-dialog.js
@@ -62,7 +62,7 @@ define(['require', 'lodash','jquery', 'log', 'backbone', 'file_browser', 'worksp
                         "<div class='modal-content' id='sampleDialog'>" +
                         "<div class='modal-header'>" +
                         "<button type='button' class='close' data-dismiss='modal' aria-label='Close'>" +
-                        "<span aria-hidden='true'>&times;</span>" +
+                        "<i class=\"fw fw-cancel  about-dialog-close\"></i>" +
                         "</button>" +
                         "<h4 class='modal-title file-dialog-title'>Import Sample</h4>" +
                         "<hr class='style1'>" +

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
@@ -2105,7 +2105,7 @@
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                     <i class="fw fw-cancel  about-dialog-close"></i></button>
-                <h4 class="modal-title file-dialog-title" id="sampleEvent">Generate sample event</h4>
+                <h4 class="modal-title file-dialog-title" id="sampleEvent">Generate Sample Event</h4>
                 <hr class="style1">
             </div>
             <div class="modal-body add-margin-top-2x add-margin-bottom-2x">

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
@@ -2105,7 +2105,8 @@
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                     <i class="fw fw-cancel  about-dialog-close"></i></button>
-                <h3 class="modal-title" id="sampleEvent">Generate sample event</h3>
+                <h4 class="modal-title file-dialog-title" id="sampleEvent">Generate sample event</h4>
+                <hr class="style1">
             </div>
             <div class="modal-body add-margin-top-2x add-margin-bottom-2x">
                 <form id="sampleEventForm">


### PR DESCRIPTION
## Purpose
> $subject

## Approach
> Import Sample dialog box
![image](https://user-images.githubusercontent.com/32606884/55055204-51d1f780-5088-11e9-9658-3f439c698d68.png)
> Generate sample event dialog box
![image](https://user-images.githubusercontent.com/32606884/55055485-17b52580-5089-11e9-86b8-7b23f60b7f1e.png)

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
