### PR TITLE
Remove unused dependency

### DIFF
--- a/components/org.wso2.carbon.siddhi.store.api.rest/pom.xml
+++ b/components/org.wso2.carbon.siddhi.store.api.rest/pom.xml
@@ -129,10 +129,6 @@
             <artifactId>org.wso2.carbon.analytics.msf4j.interceptor.common</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.transport.http</groupId>
-            <artifactId>org.wso2.transport.http.netty</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.msf4j</groupId>
             <artifactId>msf4j-core</artifactId>
         </dependency>
@@ -195,7 +191,6 @@
             org.wso2.carbon.kernel;version="${carbon.kernel.package.import.version.range}",
             org.wso2.msf4j.*;version="${msf4j.import.version.range}",
             org.wso2.siddhi.*;version="${siddhi.version.range}",
-            org.wso2.transport.http.netty.config.*;version="${carbon.transport.package.import.version.range}",
             org.wso2.carbon.stream.processor.common.*;version="${carbon.analytics.version.range}",
             org.wso2.carbon.analytics.msf4j.interceptor.common.*;version="${carbon.analytics.version.range}",
             *;resolution:=optional


### PR DESCRIPTION
## Purpose

Remove unused dependency and import. 

## Goals
Since the package org.wso2.transport.http.netty.config.* is removed in latest version, using this feature with latest version of org.wso2.transport.http.netty brings conflicts. This is PR is to fix the conflicts.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
