### PR TITLE
Fix isLeader function extension for non-clustered case

### DIFF
--- a/components/org.wso2.carbon.sp.coordination.listener/src/main/java/org/wso2/carbon/sp/coordination/listener/IsLeaderStreamFunctionProcessor.java
+++ b/components/org.wso2.carbon.sp.coordination.listener/src/main/java/org/wso2/carbon/sp/coordination/listener/IsLeaderStreamFunctionProcessor.java
@@ -32,10 +32,12 @@ import org.wso2.siddhi.query.api.definition.Attribute;
 import java.util.Map;
 
 /**
- * This Siddhi extension returns true if this node is the leader node in the cluster.
+ * In a clustered environment, this Siddhi extension returns true if this node is the leader node in the cluster.
  * False otherwise.
  * In case the leader in the cluster could not be determined (e.g. due to cluster-DB connection issue)
  * false is returned.
+ *
+ * In a non-clustered environment, this extension always returns true.
  *
  */
 @Extension(
@@ -71,7 +73,11 @@ public class IsLeaderStreamFunctionProcessor extends FunctionExecutor {
 
     @Override
     protected Object execute(Object data) {
-        return CoordinationListenerDataHolder.isLeader();
+        if (CoordinationListenerDataHolder.isClusteringEnabled() && !CoordinationListenerDataHolder.isLeader()) {
+            return false;
+        } else {
+            return true;
+        }
     }
 
     @Override

--- a/components/org.wso2.carbon.sp.coordination.listener/src/main/java/org/wso2/carbon/sp/coordination/listener/internal/CoordinationListenerDataHolder.java
+++ b/components/org.wso2.carbon.sp.coordination.listener/src/main/java/org/wso2/carbon/sp/coordination/listener/internal/CoordinationListenerDataHolder.java
@@ -27,8 +27,9 @@ public class CoordinationListenerDataHolder {
     private static CoordinationListenerDataHolder instance = new CoordinationListenerDataHolder();
 
     private static ClusterCoordinator clusterCoordinator;
-    private static boolean isLeader;
-    
+    private static boolean isLeader = false;
+    private static boolean isClusteringEnabled;
+
     private CoordinationListenerDataHolder() {
     
     }
@@ -56,5 +57,13 @@ public class CoordinationListenerDataHolder {
 
     public static void setIsLeader(boolean isLeader) {
         CoordinationListenerDataHolder.isLeader = isLeader;
+    }
+
+    public static boolean isClusteringEnabled() {
+        return isClusteringEnabled;
+    }
+
+    public static void setIsClusteringEnabled(boolean isClusteringEnabled) {
+        CoordinationListenerDataHolder.isClusteringEnabled = isClusteringEnabled;
     }
 }

--- a/components/org.wso2.carbon.sp.coordination.listener/src/main/java/org/wso2/carbon/sp/coordination/listener/internal/service/CoordinationListenerServiceComponent.java
+++ b/components/org.wso2.carbon.sp.coordination.listener/src/main/java/org/wso2/carbon/sp/coordination/listener/internal/service/CoordinationListenerServiceComponent.java
@@ -28,8 +28,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.cluster.coordinator.service.ClusterCoordinator;
 import org.wso2.carbon.config.ConfigurationException;
+import org.wso2.carbon.config.provider.ConfigProvider;
 import org.wso2.carbon.sp.coordination.listener.CoordinationEventListener;
 import org.wso2.carbon.sp.coordination.listener.internal.CoordinationListenerDataHolder;
+
+import java.util.Map;
 
 /**
  * Service component for Coordination Listener.
@@ -74,5 +77,21 @@ public class CoordinationListenerServiceComponent {
 
     protected void unregisterClusterCoordinator(ClusterCoordinator clusterCoordinator) {
         CoordinationListenerDataHolder.setClusterCoordinator(null);
+    }
+
+    @Reference(
+            name = "carbon.config.provider",
+            service = ConfigProvider.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unregisterConfigProvider"
+    )
+    protected void registerConfigProvider(ConfigProvider configProvider) throws ConfigurationException {
+        Map clusterConfiguration = (Map) configProvider.getConfigurationObject("cluster.config");
+        CoordinationListenerDataHolder.setIsClusteringEnabled((Boolean) clusterConfiguration.get("enabled"));
+    }
+
+    protected void unregisterConfigProvider(ConfigProvider configProvider) {
+        CoordinationListenerDataHolder.setIsClusteringEnabled(false);
     }
 }


### PR DESCRIPTION
## Purpose
Fix `coordnation:isLeader()` function extension for non-clustered case.

## Approach
In a non-clustered environment, the extension will always return true.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes