### PR TITLE
Fix for Siddhi editor

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/dialog/delete-confirm-dialog.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/dialog/delete-confirm-dialog.js
@@ -78,7 +78,7 @@ define(['require', 'lodash', 'jquery', 'log', 'backbone', 'file_browser',
                         "<div class='modal-content'>" +
                         "<div class='modal-header'>" +
                         "<button type='button' class='close' data-dismiss='modal' aria-label='Close'>" +
-                        "<span aria-hidden='true'>&times;</span>" +
+                        "<i class='fw fw-cancel about-dialog-close'> </i> " +
                         "</button>" +
                         "<h4 class='modal-title file-dialog-title' id='newConfigModalLabel'>Delete from Workspace<" +
                         "/h4>" +

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/dialog/modal-dialog.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/dialog/modal-dialog.js
@@ -99,8 +99,9 @@ define(['require', 'jquery', 'event_channel', 'bootstrap'], function (require, $
         var modalContent = $("<div class='modal-content'></div>");
         var modalHeader = $("<div class='modal-header'></div>");
         var modalCloseBtnTop = $("<button type='button' class='close' data-dismiss='modal' aria-label='Close'>" +
-            "<span aria-hidden='true'>&times;</span></button>");
-        var modalTitle = $("<h4 class='modal-title '></h4>");
+            "<i class='fw fw-cancel  about-dialog-close'> </i></button>");
+        var modalTitle = $("<h4 class='modal-title file-dialog-title'></h4>");
+        var modalSeparator = $("<hr class='style1'>");
         var modalBody = $("<div class='modal-body'></div>");
         var modalFooter = $("<div class='modal-footer'></div>");
         var modalCloseBtnBottom = $("<button type='button' class='btn btn-default btn-file-dialog'" +
@@ -122,6 +123,7 @@ define(['require', 'jquery', 'event_channel', 'bootstrap'], function (require, $
         modalContent.append(modalHeader);
         modalHeader.append(modalCloseBtnTop);
         modalHeader.append(modalTitle);
+        modalHeader.append(modalSeparator);
         modalContent.append(modalBody);
         modalContent.append(errorContainer);
         errorContainer.hide();

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/dialog/open-file-dialog.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/dialog/open-file-dialog.js
@@ -62,7 +62,7 @@ define(['require', 'lodash','jquery', 'log', 'backbone', 'file_browser', 'worksp
                         "<div class='modal-content'>" +
                         "<div class='modal-header'>" +
                         "<button type='button' class='close' data-dismiss='modal' aria-label='Close'>" +
-                        "<span aria-hidden='true'>&times;</span>" +
+                        "<i class='fw fw-cancel  about-dialog-close'> </i>" +
                         "</button>" +
                         "<h4 class='modal-title file-dialog-title'>Open File</h4>" +
                         "<hr class='style1'>"+

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/form-utils.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/form-utils.js
@@ -1115,12 +1115,14 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
             var isErrorOccurred = false;
             $(className).each(function () {
                 var checkBox = $(this).find('input:checkbox');
-                if (checkBox.length == 0 || (checkBox.length > 0 && checkBox.is(":checked"))) {
+                if ((checkBox.length == 0 || (checkBox.length > 0 && checkBox.is(":checked")))) {
                     var inputValue = $(this).find('input:text');
-                    if (inputValue.val().trim() == "") {
-                        self.addErrorClass(inputValue);
-                        $(className).find('.error-message').text('Value is required');
-                        isErrorOccurred = true;
+                    if (inputValue.is("visible")) {
+                        if (inputValue.val().trim() == "") {
+                            self.addErrorClass(inputValue);
+                            $(className).find('.error-message').text('Value is required');
+                            isErrorOccurred = true;
+                        }
                     }
                 }
             });
@@ -3288,7 +3290,6 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
         FormUtils.prototype.addAutoCompleteForOutputOperation = function (outputAttributesWithStreamName, inputAttributes) {
             var self = this;
             var outputOperationMatches = outputAttributesWithStreamName.concat(inputAttributes);
-            console.log(outputOperationMatches)
             self.createAutocomplete($('.define-query-operation input[type="text"]'), outputOperationMatches);
         };
 

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/form-utils.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/form-utils.js
@@ -2523,10 +2523,21 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
          */
         FormUtils.prototype.mapUserGroupBy = function (attributes) {
             var i = 0;
+            var found;
             $('.group-by-attributes li').each(function () {
+                found = false;
                 $(this).find('.group-by-selection option').filter(function () {
-                    return ($(this).val() == (attributes[i]));
+                    var currentOption = $(this).val();
+                    if (currentOption == attributes[i]) {
+                        found = true;
+                        return ($(this).val() == (attributes[i]));
+                    }
                 }).prop('selected', true);
+                if (!found) {
+                    $(this).find('.group-by-selection option').filter(function () {
+                        return ($(this).val().includes(attributes[i]));
+                    }).prop('selected', true);;
+                }
                 i++;
             });
         };

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/partition-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/partition-form.js
@@ -142,14 +142,20 @@ define(['require', 'log', 'jquery', 'lodash', 'partitionWith', 'jsonValidator', 
 
                         var partitionKeys = [];
                         $('#partition-by-content .partition-key').each(function () {
-                            var expression = $(this).find('.partition-by-expression-selection').val();
-                            var streamName = $(this).find('.partition-by-stream-name').val().trim();
-                            var partitionKey = {
-                                expression: expression,
-                                streamName: streamName
-                            };
-                            partitionKeys.push(partitionKey);
-
+                            var expression = $(this).find('.partition-by-expression-selection');
+                            if (!expression.val()) {
+                                $(this).find('.error-message').text("Expression is required");
+                                self.formUtils.addErrorClass(expression);
+                                isErrorOccurred = true;
+                                return false;
+                            } else {
+                                var streamName = $(this).find('.partition-by-stream-name').val().trim();
+                                var partitionKey = {
+                                    expression: expression.val(),
+                                    streamName: streamName
+                                };
+                                partitionKeys.push(partitionKey);
+                            }
                         });
 
                         if (!isErrorOccurred) {


### PR DESCRIPTION
## Purpose
> 1. In the design view the user mapped group by value will not be selected if the group by attribute is written without the alias in the source-view.
> 2. UI for the dialog box is not properly aligned.
> 3. Error for partition form needs to be displayed on the form instead of showing it as a design-view alert.

## Goals
> Improves the editor.

## Approach
> 1. If the group by attribute(without the alias) does not match any of the options in the design-view group by down then it checks if the user specified attribute is included in any one of the option in group by drop down.
> 2. Change the dialog box headings' format.
> 3. Displays the error-message on the form.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes