### PR TITLE
Shows input content on hover

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/form-utils.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/form-utils.js
@@ -3285,7 +3285,6 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
                     if (inputElement.type.toLowerCase() === Constants.TRIGGER) {
                         attributes.push(Constants.TRIGGERED_TIME);
                     } else {
-                        attributes.concat()
                         _.forEach(inputElement.element.getAttributeList(), function (attribute) {
                             attributes.push(attribute.getName());
                         });
@@ -3308,14 +3307,16 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
          * @function to show the input field content on hover
          */
         FormUtils.prototype.addEventListenerToShowInputContentOnHover = function () {
+            var self = this;
             var divToShowInputContent = '<div class="hovered-content" style="display: none"> </div>';
             $('.design-view-form-content').on('mouseover', 'input[type="text"]', function () {
-                if (!$(this).next().hasClass('hovered-content')) {
-                    $(this).after(divToShowInputContent);
+                var inputField = $(this);
+                if (!inputField.next().hasClass('hovered-content')) {
+                    inputField.after(divToShowInputContent);
                 }
-                if ($(this).val().trim() != "") {
-                    $(this).next('.hovered-content').html($(this).val());
-                    $(this).next('.hovered-content').show();
+                if (inputField.val().trim() != "" && self.isElementContentOverflown(inputField)) {
+                    inputField.next('.hovered-content').html(inputField.val().trim());
+                    inputField.next('.hovered-content').show();
                 }
             });
             $('.design-view-form-content').on('mouseout', 'input[type="text"]', function () {
@@ -3324,6 +3325,13 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
             $('.design-view-form-content').on('focus', 'input[type="text"]', function () {
                 $(this).next('.hovered-content').hide();
             });
+        };
+
+        /**
+         * @function to determine if input content is longer than the width of the input
+         */
+        FormUtils.prototype.isElementContentOverflown = function (element) {
+            return element[0].scrollWidth > element[0].clientWidth;
         };
 
         /**


### PR DESCRIPTION

## Purpose
> The input content which are longer than the input field needs to be shown on hover.

## Goals
> The input content will be shown on hover only if the input content is longer than the input field's width.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
