### PR TITLE
Change shortcut key for deploy to server

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/menu-bar/deploy-menu.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/menu-bar/deploy-menu.js
@@ -28,12 +28,12 @@ define(([], function () {
                     id: "deploy-to-server",
                     shortcuts: {
                         mac: {
-                            key: "shift+d",
-                            label: "\u21E7D"
+                            key: "command+shift+d",
+                            label: "\u2318\u21E7D"
                         },
                         other: {
-                            key: "shift+d",
-                            label: "Shift+D"
+                            key: "ctrl+shift+d",
+                            label: "Ctrl+Shift+D"
                         }
                     }
                 },


### PR DESCRIPTION
## Purpose
> Change shortcut key for deploy to server.

## Goals
> This will change the shortcut key for deploy to server from 'Shift+D' to 'Ctrl+Shift+D'

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
