### PR TITLE
Handle null of some of the sinkhandlers(inmemory)

### DIFF
--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/ha/HAEventListener.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/ha/HAEventListener.java
@@ -182,7 +182,9 @@ public class HAEventListener extends MemberEventListener {
                         StreamProcessorDataHolder.getHAManager().changeToPassive();
                         for (Map.Entry<String, SinkHandler> entry : registeredSinkHandlers.entrySet()) {
                             HACoordinationSinkHandler handler = (HACoordinationSinkHandler) entry.getValue();
-                            handler.setAsPassive();
+                            if (handler != null) {
+                                handler.setAsPassive();
+                            }
                         }
                         for (SourceHandler sourceHandler : registeredSourceHandlers.values()) {
                             ((HACoordinationSourceHandler) sourceHandler).setAsPassive();
@@ -214,7 +216,9 @@ public class HAEventListener extends MemberEventListener {
             StreamProcessorDataHolder.getHAManager().changeToPassive();
             for (Map.Entry<String, SinkHandler> entry : registeredSinkHandlers.entrySet()) {
                 HACoordinationSinkHandler handler = (HACoordinationSinkHandler) entry.getValue();
-                handler.setAsPassive();
+                if (handler != null) {
+                    handler.setAsPassive();
+                }
             }
             for (SourceHandler sourceHandler : registeredSourceHandlers.values()) {
                 ((HACoordinationSourceHandler) sourceHandler).setAsPassive();

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/ha/HAManager.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/ha/HAManager.java
@@ -216,7 +216,10 @@ public class HAManager {
             // so that new events will process accordingly
             for (SinkHandler sinkHandler : sinkHandlerManager.getRegisteredSinkHandlers().values()) {
                 try {
-                    ((HACoordinationSinkHandler) sinkHandler).setAsActive();
+                    HACoordinationSinkHandler handler = (HACoordinationSinkHandler) sinkHandler;
+                    if (handler != null) {
+                        handler.setAsActive();
+                    }
                 } catch (Throwable t) {
                     log.error("HA Deployment: Error when connecting to sink " + sinkHandler.getElementId() +
                             " while changing from passive state to active, skipping the sink. ", t);

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/StreamProcessorService.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/StreamProcessorService.java
@@ -158,7 +158,10 @@ public class StreamProcessorService {
                     log.info("Setting SinksHandlers of " + siddhiAppName + " to Active");
                     for (List<Sink> sinks : sinkCollection) {
                         for (Sink sink : sinks) {
-                            ((HACoordinationSinkHandler) sink.getHandler()).setAsActive();
+                            HACoordinationSinkHandler handler = (HACoordinationSinkHandler) sink.getHandler();
+                            if (handler != null) {
+                                handler.setAsActive();
+                            }
                         }
                     }
 
@@ -195,7 +198,10 @@ public class StreamProcessorService {
                     log.info("Setting SinksHandlers of " + siddhiAppName + " to Passive");
                     for (List<Sink> sinks : sinkCollection) {
                         for (Sink sink : sinks) {
-                            ((HACoordinationSinkHandler) sink.getHandler()).setAsPassive();
+                            HACoordinationSinkHandler handler = (HACoordinationSinkHandler) sink.getHandler();
+                            if (handler != null) {
+                                handler.setAsPassive();
+                            }
                         }
                     }
 


### PR DESCRIPTION
## Purpose
Some sink handlers might return a null and we need need to handle it for HA cases

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes