### PR TITLE
Fix empty partial app redeployment issue

### DIFF
--- a/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/deployment/DeploymentManagerImpl.java
+++ b/components/org.wso2.carbon.sp.jobmanager.core/src/main/java/org/wso2/carbon/sp/jobmanager/core/deployment/DeploymentManagerImpl.java
@@ -212,6 +212,10 @@ public class DeploymentManagerImpl implements DeploymentManager, ResourcePoolCha
         try {
             for (String parentSiddhiAppName : waitingParentAppNames) {
                 partialAppHoldersOfSiddhiApp = waitingList.getOrDefault(parentSiddhiAppName, Collections.emptyList());
+                if (partialAppHoldersOfSiddhiApp.size() == 0) {
+                    //continue to next parent app if all partial apps are deployed
+                    continue;
+                }
                 deployedCompletely = true;
                 currentDeployedPartialApps = new ArrayList<>();
 


### PR DESCRIPTION
## Purpose
$Subject. Else this will cause manager nodes state to be faulty stating no partial apps are present.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
