### PR TITLE
Add support to enable disable APIM alerts by configuration

### DIFF
--- a/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/datasource/configreader/ConfigReader.java
+++ b/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/datasource/configreader/ConfigReader.java
@@ -103,7 +103,7 @@ public class ConfigReader {
         List<String> solutionsList = new ArrayList();
         if (analyticsSolutionsConfig != null) {
             if (Boolean.parseBoolean(analyticsSolutionsConfig.get(SiddhiAppProcessorConstants.
-                    APIM_ANALYTICS_ENABLED).toString())) {
+                    APIM_ALETRS_ENABLED).toString())) {
                 solutionsList.add(SiddhiAppProcessorConstants.WSO2_SERVER_TYPE_APIM_ANALYTICS);
             } else if (Boolean.parseBoolean(analyticsSolutionsConfig.get(SiddhiAppProcessorConstants
                     .EI_ANALYTICS_ENABLED).toString())) {

--- a/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/util/SiddhiAppProcessorConstants.java
+++ b/components/org.wso2.carbon.stream.processor.core/src/main/java/org/wso2/carbon/stream/processor/core/internal/util/SiddhiAppProcessorConstants.java
@@ -42,9 +42,11 @@ public class SiddhiAppProcessorConstants {
     public static final String WSO2_SERVER_TYPE_EI_ANALYTICS = "wso2-ei-analytics";
 
     public static final String APIM_ANALYTICS_ENABLED = "APIM-analytics.enabled";
+    public static final String APIM_ALETRS_ENABLED = "APIM-alerts.enabled";
     public static final String IS_ANALYTICS_ENABLED = "IS-analytics.enabled";
     public static final String EI_ANALYTICS_ENABLED = "EI-analytics.enabled";
 
+    public static final String APIM_ALERT_SIDDHI_APP_PREFIX = "APIM_ALERT";
     public static final String APIM_SIDDHI_APP_PREFIX = "APIM_";
     public static final String IS_SIDDHI_APP_PREFIX = "IS_";
     public static final String EI_SIDDHI_APP_PREFIX = "EI_";


### PR DESCRIPTION
## Purpose
Users can enable/disable APIM analytics alerts by adding the following element to deployment.yaml file 
analytics.solutions:
  **APIM-alerts.enabled: true**
```
# Carbon Configuration Parameters
wso2.carbon:
  # server type
  type: wso2-sp

analytics.solutions:
  IS-analytics.enabled: false
  APIM-analytics.enabled: true
  APIM-alerts.enabled: false
  EI-analytics.enabled: true
```

## Goals
Usability improvement by enabling disabling the APIM alerts

## Approach
Configurable flag

## Documentation
Needs to be updated with the additional flag

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes