### PR TITLE
Prevent running the commands if the SP tool editor icons are disabled

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/tool-bar/tool-bar.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/commons/js/tool-bar/tool-bar.js
@@ -33,22 +33,30 @@ define(['log', 'jquery', 'lodash', 'workspace', 'backbone'],
                     this._runButn.on('click', function (e) {
                         e.preventDefault();
                         e.stopPropagation();
-                        self.application.commandManager.dispatch(_.get(self._options, 'commandRun.id'));
+                        if(!$(this).hasClass('disabled')) {
+                            self.application.commandManager.dispatch(_.get(self._options, 'commandRun.id'));
+                        }
                     });
                     this._debugBtn.on('click', function (e) {
                         e.preventDefault();
                         e.stopPropagation();
-                        self.application.commandManager.dispatch(_.get(self._options, 'commandDebug.id'));
+                        if(!$(this).hasClass('disabled')) {
+                            self.application.commandManager.dispatch(_.get(self._options, 'commandDebug.id'));
+                        }
                     });
                     this._stopBtn.on('click', function (e) {
                         e.preventDefault();
                         e.stopPropagation();
-                        self.application.commandManager.dispatch(_.get(self._options, 'commandStop.id'));
+                        if(!$(this).hasClass('disabled')) {
+                            self.application.commandManager.dispatch(_.get(self._options, 'commandStop.id'));
+                        }
                     });
                     this._revertBtn.on('click', function (e) {
                         e.preventDefault();
                         e.stopPropagation();
-                        self.application.commandManager.dispatch(_.get(self._options, 'commandRevert.id'));
+                        if(!$(this).hasClass('disabled')) {
+                            self.application.commandManager.dispatch(_.get(self._options, 'commandRevert.id'));
+                        }
                     });
 
                     // register command


### PR DESCRIPTION
## Purpose
> On click of the disabled icons[run/debug/stop/revert] in the SP tool editor, the icon action gets executed therefore an error is thrown in the console.

## Goals
> Prevent the actions from executing if the icon has the class 'disabled'.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes