### PR TITLE
Fix toggle button cannot be seen when there are lot of tabs opened

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/css/design-view.css
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/css/design-view.css
@@ -26,9 +26,9 @@
 }
 
 .toggle-controls-container {
-    position: absolute;
-    bottom: 2%;
-    right: 2%;
+    position: fixed;
+    bottom: 35px;
+    right: 10px;
     z-index: 23;
 }
 


### PR DESCRIPTION
## Purpose
Allow source to design button to be fixed irrespective of the tabs opened

## Goals
improve UX

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
