### PR TITLE
Allow only to http request sink and response source to be connected

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/designgenerator/generators/SourceSinkConfigsGenerator.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/designgenerator/generators/SourceSinkConfigsGenerator.java
@@ -106,7 +106,7 @@ public class SourceSinkConfigsGenerator extends CodeSegmentsPreserver {
             } else {
                 options.add(element.toString());
             }
-            if (element.getKey().equalsIgnoreCase(SINK_ID) || element.getKey().equalsIgnoreCase(SOURCE_ID)) {
+            if (element.getKey().equalsIgnoreCase(SINK_ID)) {
                 correlationId = element.getValue();
             }
         }

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/design-grid.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/design-grid.js
@@ -485,8 +485,7 @@ define(['require', 'log', 'jquery', 'backbone', 'lodash', 'designViewUtils', 'dr
                         }
                         DesignViewUtils.prototype
                             .errorAlert("Invalid Connection: http-request sink input source should be a " +
-                                "http-response source or http-response sink input source should be a " +
-                                "http-request source");
+                                "http-response source");
                         return connectionValidity;
                     }
 

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/drop-elements.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/drop-elements.js
@@ -1365,7 +1365,7 @@ define(['require', 'log', 'lodash', 'jquery', 'partition', 'stream', 'query', 'f
         };
 
         DropElements.prototype.generateSpecificSourceConnectionElements = function (type, jsPlumbInstance, i, element) {
-            if (type == Constants.TYPE_HTTP_RESPONSE || type == Constants.TYPE_HTTP_REQUEST) {
+            if (type == Constants.TYPE_HTTP_RESPONSE) {
                 var connectionIn = $('<div class="connectorInSource">').attr('id', i + "-in").addClass('connection');
                 element.append(connectionIn);
                 jsPlumbInstance.makeTarget(connectionIn, {
@@ -1382,7 +1382,7 @@ define(['require', 'log', 'lodash', 'jquery', 'partition', 'stream', 'query', 'f
         };
 
         DropElements.prototype.generateSpecificSinkConnectionElements = function (type, jsPlumbInstance, i, element) {
-            if (type == Constants.TYPE_HTTP_REQUEST || type == Constants.TYPE_HTTP_RESPONSE) {
+            if (type == Constants.TYPE_HTTP_REQUEST) {
                 var connectionOut = $('<div class="connectorOutSink">').attr('id', i + "-out").addClass('connection');
                 element.append(connectionOut);
                 jsPlumbInstance.makeSource(connectionOut, {


### PR DESCRIPTION
## Purpose
Allow only to http request sink and response source to be connected

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes