### PR TITLE
Configure the XML parser to disable external entity resolution in carbon data provider

### DIFF
--- a/components/org.wso2.carbon.data.provider/pom.xml
+++ b/components/org.wso2.carbon.data.provider/pom.xml
@@ -99,6 +99,10 @@
             <artifactId>org.wso2.carbon.analytics.msf4j.interceptor.common</artifactId>
         </dependency>
         <dependency>
+            <groupId>xerces</groupId>
+            <artifactId>xercesImpl</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <scope>test</scope>
@@ -146,7 +150,8 @@
         <private.package>
             org.wso2.carbon.database.query.manager.*,
             org.wso2.carbon.database.query.manager.config.*,
-            org.wso2.carbon.database.query.manager.exception.*
+            org.wso2.carbon.database.query.manager.exception.*,
+            org.apache.xerces.util.*
         </private.package>
         <export.package>
             org.wso2.carbon.data.provider.*,

--- a/pom.xml
+++ b/pom.xml
@@ -1582,6 +1582,11 @@
                 <version>${netty.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>xerces</groupId>
+                <artifactId>xercesImpl</artifactId>
+                <version>${xerces.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -1829,5 +1834,7 @@
         <io.nats.version>2.1.2</io.nats.version>
         <siddhi.io.nats.version>1.0.5</siddhi.io.nats.version>
         <org.testcontainers.version>1.8.0</org.testcontainers.version>
+
+        <xerces.version>2.12.0</xerces.version>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1800,7 +1800,7 @@
         <siddhi.io.tcp.version>2.1.2</siddhi.io.tcp.version>
         <siddhi.io.email.version>1.1.0</siddhi.io.email.version>
         <siddhi.io.kafka.version>4.2.1</siddhi.io.kafka.version>
-        <siddhi.io.http.version>1.1.6</siddhi.io.http.version>
+        <siddhi.io.http.version>1.2.0</siddhi.io.http.version>
 
         <siddhi.map.json.version>4.1.2</siddhi.map.json.version>
         <siddhi.map.binary.version>1.1.1</siddhi.map.binary.version>


### PR DESCRIPTION
## Purpose

1. Configure the XML parser to disable external entity resolution in WebSocketProviderEndPoint of carbon data provider.
2. Update siddhi-io-http version.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
