### PR TITLE
Add SSO support to business-rules Component

### DIFF
--- a/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/impl/LoginApiServiceImpl.java
+++ b/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/impl/LoginApiServiceImpl.java
@@ -289,9 +289,6 @@ public class LoginApiServiceImpl extends LoginApiService {
                     String idTokenFirstHalf = idToken.substring(0, idToken.length()/2);
                     String idTokenSecondHalf = idToken.substring(idToken.length()/2);
                     userDTO.setiID(idTokenFirstHalf);
-                    NewCookie idTokenhttpOnlyCookie = AuthUtil
-                            .cookieBuilder(SPConstants.WSO2_SP_ID_TOKEN_2, idTokenFirstHalf, appContext, true, true,
-                                    -1);
                     NewCookie logoutContextIdToken = AuthUtil
                             .cookieBuilder(AuthRESTAPIConstants.WSO2_SP_ID_TOKEN, idTokenSecondHalf,
                                     AuthRESTAPIConstants.LOGOUT_CONTEXT + AuthRESTAPIConstants.LOGOUT_SSO_CONTEXT +  appContext,
@@ -312,25 +309,24 @@ public class LoginApiServiceImpl extends LoginApiService {
                         String refTokenPart1 = refreshToken.substring(0, refreshToken.length() / 2);
                         String refTokenPart2 = refreshToken.substring(refreshToken.length() / 2);
                         userDTO.setlID(refTokenPart1);
-                        NewCookie userAuthenticate = AuthUtil.cookieBuilder(AuthRESTAPIConstants.WSO2_SP_USER_DTO,
-                                new Gson().toJson(userDTO), appContext, true, false, -1);
                         loginContextRefreshTokenCookie = AuthUtil
                                 .cookieBuilder(AuthRESTAPIConstants.WSO2_SP_REFRESH_TOKEN, refTokenPart2,
                                         AuthRESTAPIConstants.LOGIN_CONTEXT + appContext, true, true,
                                         AuthRESTAPIConstants.REFRESH_TOKEN_VALIDITY_PERIOD);
+                        NewCookie userAuthenticate = AuthUtil.cookieBuilder(AuthRESTAPIConstants.WSO2_SP_USER_DTO,
+                                new Gson().toJson(userDTO), appContext, true, false, -1);
                         return Response.status(Response.Status.FOUND)
                                 .header(HttpHeaders.LOCATION, targetURIForRedirection)
                                 .entity(userDTO)
                                 .cookie(accessTokenhttpOnlyCookie, logoutContextAccessToken,
                                         loginContextRefreshTokenCookie, userAuthenticate,
-                                        idTokenhttpOnlyCookie, logoutContextIdToken)
+                                        logoutContextIdToken)
                                 .build();
                     }
                     return Response.status(Response.Status.FOUND)
                             .header(HttpHeaders.LOCATION, targetURIForRedirection)
                             .entity(userDTO)
-                            .cookie(accessTokenhttpOnlyCookie, logoutContextAccessToken,
-                                    idTokenhttpOnlyCookie, logoutContextIdToken)
+                            .cookie(accessTokenhttpOnlyCookie, logoutContextAccessToken, logoutContextIdToken)
                             .build();
                 } else {
                     if (LOG.isDebugEnabled()) {

--- a/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/util/AuthRESTAPIConstants.java
+++ b/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/util/AuthRESTAPIConstants.java
@@ -26,6 +26,7 @@ public class AuthRESTAPIConstants {
     public static final String WSO2_SP_REFRESH_TOKEN = "ASID";
     public static final String WSO2_SP_ID_TOKEN = "FID";
     public static final String WSO2_SP_USER_DTO = "USER_DTO";
+    public static final String ID_TOKEN_HEADER = "Fid";
 
     public static final String HTTP_ONLY_COOKIE = "HttpOnly";
     public static final String SECURE_COOKIE = "Secure";

--- a/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/util/AuthUtil.java
+++ b/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/util/AuthUtil.java
@@ -59,7 +59,7 @@ public class AuthUtil {
 
     public static String extractIdTokenFromHeaders(HttpHeaders headers, String cookieHeader) {
         String token;
-        String authHeader = headers.getHeaderString(SPConstants.ID_TOKEN_HEADER);
+        String authHeader = headers.getHeaderString(AuthRESTAPIConstants.ID_TOKEN_HEADER);
         if (authHeader == null) {
             return null;
         }

--- a/components/org.wso2.carbon.business.rules.web/src/api/AuthenticationAPI.js
+++ b/components/org.wso2.carbon.business.rules.web/src/api/AuthenticationAPI.js
@@ -34,7 +34,8 @@ const basePath = window.location.origin;
 /**
  * Password grant type
  */
-const passwordGrantType = 'password';
+const GRANT_TYPE_PASSWORD = 'password';
+const GRANT_TYPE_REFRESH = 'refresh_token';
 
 /**
  * App context starting from forward slash
@@ -66,13 +67,13 @@ export default class AuthenticationAPI {
         return AuthenticationAPI
             .getHttpClient()
             .post(`/login/${appContext}`, Qs.stringify({
-                grantType: 'refresh_token',
+                grantType: GRANT_TYPE_REFRESH,
                 rememberMe: true,
             }), {
                 headers: {
                     'Content-Type': MediaType.APPLICATION_WWW_FORM_URLENCODED,
                     Authorization: 'Bearer ' + AuthManager.getCookie('RTK'),
-                    Accept: MediaType.APPLICATION_JSON,
+                    'Accept': MediaType.APPLICATION_JSON
                 },
             });
     }
@@ -84,13 +85,13 @@ export default class AuthenticationAPI {
      * @param {boolean} rememberMe      Remember me flag
      * @returns {AxiosPromise}          Response after the login
      */
-    static login(username, password, rememberMe = false) {
+    static login(username, password, rememberMe = false, grantType = GRANT_TYPE_PASSWORD) {
         return AuthenticationAPI
             .getHttpClient()
             .post(`/login/${appContext}`, Qs.stringify({
                 username,
                 password,
-                grantType: passwordGrantType,
+                grantType,
                 rememberMe,
                 appId: 'br_' + BusinessRulesUtilityFunctions.generateGUID(),
             }), {
@@ -114,4 +115,22 @@ export default class AuthenticationAPI {
                 },
             });
     }
+
+    static ssoLogout(accessToken, idToken) {
+        console.log(accessToken);
+        console.log(idToken);
+        return AuthenticationAPI.getHttpClient()
+            .get(`/logout/slo/${appContext}`, {
+                headers: {
+                    Authorization: `Bearer ${accessToken}`,
+                    Fid: idToken,
+                },
+            });
+    }
+
+    static getAuthType() {
+        return AuthenticationAPI.getHttpClient()
+            .get('/login/auth-type');
+    }
+
 }

--- a/components/org.wso2.carbon.business.rules.web/src/api/BusinessRulesAPI.js
+++ b/components/org.wso2.carbon.business.rules.web/src/api/BusinessRulesAPI.js
@@ -38,11 +38,21 @@ export default class BusinessRulesAPI {
      * @returns {AxiosInstance}     Axios HTTP Client
      */
     getHTTPClient() {
-        return axios.create({
+        const httpClient = axios.create({
             baseURL: this.url + appContext,
             timeout: 30000,
             headers: { Authorization: 'Bearer ' + AuthManager.getUser().SDID },
         });
+        httpClient.interceptors.response.use(function (response) {
+            return response;
+        }, function (error) {
+            if (401 === error.response.status) {
+                AuthManager.discardSession();
+                window.handleSessionInvalid();
+            }
+            return Promise.reject(error);
+        });
+        return httpClient;
     }
 
     /**

--- a/components/org.wso2.carbon.business.rules.web/src/components/auth/Login.jsx
+++ b/components/org.wso2.carbon.business.rules.web/src/components/auth/Login.jsx
@@ -33,12 +33,13 @@ import FormPanel from '../common/FormPanel';
 import Header from '../common/Header';
 // Auth Utils
 import AuthManager from '../../utils/AuthManager';
+import {Constants} from '../../utils/Constants';
 
 
 /**
  * App context
  */
-const appContext = window.contextPath;
+const REFERRER_KEY = 'referrer';
 
 const styles = {
   cookiePolicy: {
@@ -66,58 +67,125 @@ export default class Login extends Component {
       password: '',
       authenticated: false,
       rememberMe: false,
-      referrer: '/',
+        authType: Constants.AUTH_TYPE_UNKNOWN,
     };
-    this.authenticate = this.authenticate.bind(this);
+      this.setReferrer(this.getReferrerFromQueryString());
+      this.authenticate = this.authenticate.bind(this);
   }
 
-  componentWillMount() {
-    if (AuthManager.isRememberMeSet() && !AuthManager.isLoggedIn()) {
-      AuthManager.authenticateWithRefreshToken().then(() => this.setState({ authenticated: true }));
+    componentWillMount() {
+        AuthManager.getAuthType()
+            .then((response) => {
+                if (response.data.authType === Constants.AUTH_TYPE_SSO) {
+                    // initialize sso authentication flow
+                    this.initSSOAuthenticationFlow();
+                } else {
+                    // initialize default authentication flow
+                    this.initDefaultAuthenticationFlow();
+                }
+                // Once the auth type has been changed asynchronously, login page needs to be re-rendered to show the
+                // login form.
+                this.setState({authType: response.data.authType});
+            }).catch((e) => {
+            console.error('Unable to get the authentication type.', e);
+        });
     }
-  }
 
-  /**
-   * Extracts the referrer and checks whether the user has been logged-in
-   */
-  componentDidMount() {
-    // Extract referrer from the query string.
-    const queryString = this.props.location.search.replace(/^\?/, '');
-    const params = Qs.parse(queryString);
-    if (params.referrer) {
-      this.state.referrer = params.referrer;
+    /**
+     * Initializes the default authentication flow.
+     */
+    initDefaultAuthenticationFlow() {
+        if (AuthManager.isRememberMeSet() && !AuthManager.isLoggedIn()) {
+            AuthManager.authenticateWithRefreshToken()
+                .then(() =>
+                    this.setState({
+                        authenticated: true
+                    })
+                );
+        }
     }
 
-    // If the user already logged in set the state to redirect user to the referrer page.
-    if (AuthManager.isLoggedIn()) {
-      this.state.authenticated = true;
-    }
-  }
+    /**
+     * Initializes the SSO authentication flow.
+     */
+    initSSOAuthenticationFlow() {
+        // check if the userDTO is available. if so try to authenticate the user. instead forward the user to the idp.
+        // USER_DTO={"authUser":"admin","pID":"0918c1ad-fc0a-35fa","lID":"3ca21853-bd3c-3dfa","validityPeriod":3381};
 
-  /**
+        if (AuthManager.isSSOAuthenticated()) {
+            const {authUser, pID, lID, validityPeriod, iID} = AuthManager.getSSOUserCookie();
+            localStorage.setItem('rememberMe', true);
+            localStorage.setItem('username', authUser);
+            AuthManager.setUser({
+                username: authUser,
+                SDID: pID,
+                validity: validityPeriod,
+                expires: AuthManager.calculateExpiryTime(validityPeriod),
+            });
+            AuthManager.setCookie(Constants.RTK, lID, 604800, window.contextPath);
+            AuthManager.setCookie(Constants.ID_TOKEN, iID, 604800, window.contextPath);
+            AuthManager.deleteCookie(Constants.USER_DTO_COOKIE);
+            this.setState({
+                authenticated: true,
+            });
+        } else {
+            // redirect the user to the service providers auth url
+            AuthManager.ssoAuthenticate()
+                .then((url) => {
+                    window.location.href = url;
+                })
+                .catch((e) => {
+                    console.error('Error getting SSO auth URL.', e);
+                });
+        }
+    }
+
+    /**
+     * Get the referrer URL for the redirection after successful login.
+     *
+     * @returns {string} referrer URL
+     */
+    getReferrer() {
+        const referrer = localStorage.getItem(REFERRER_KEY);
+        localStorage.removeItem(REFERRER_KEY);
+        return referrer || '/';
+    }
+
+    /**
+     * Set referrer URL to the local storage.
+     *
+     * @param {String} referrer Referrer URL
+     */
+    setReferrer(referrer) {
+        if (localStorage.getItem(REFERRER_KEY) == null) {
+            localStorage.setItem(REFERRER_KEY, referrer);
+        }
+    }
+
+    /**
+     * Extract referrer URL from the query string.
+     *
+     * @returns {string} referrer URL
+     */
+    getReferrerFromQueryString() {
+        const queryString = this.props.location.search.replace(/^\?/, '');
+        return Qs.parse(queryString).referrer;
+    }
+
+    /**
    * Authenticates the user
    * @param {Object} e    Event
    */
   authenticate(e) {
+    const {intl} = this.context;
+    const {username, password, rememberMe} = this.state;
     e.preventDefault();
-    AuthManager.authenticate(
-      this.state.username,
-      this.state.password,
-      this.state.rememberMe,
-    )
-      .then(() => this.setState({ authenticated: true }))
+    AuthManager.authenticate(username, password, rememberMe)
+      .then(() => this.setState({authenticated: true}))
       .catch((error) => {
-        const errorMessage = error.response && error.response.status === 401 ? (
-          <FormattedMessage
-            id="login.error.invalid"
-            defaultMessage="The username/password is invalid"
-          />
-        ) : (
-          <FormattedMessage
-            id="login.error.unknown"
-            defaultMessage="Unknown error occurred!"
-          />
-        );
+        const errorMessage = error.response && error.response.status === 401
+                    ? intl.formatMessage({id: 'login.error.message', defaultMessage: 'Invalid username/password!'})
+                    : intl.formatMessage({id: 'login.unknown.error', defaultMessage: 'Unknown error occurred!'});
         this.setState({
           username: '',
           password: '',
@@ -127,12 +195,7 @@ export default class Login extends Component {
       });
   }
 
-  render() {
-    // If the user is already authenticated redirect to referrer link.
-    if (this.state.authenticated) {
-      return <Redirect to={this.state.referrer} />;
-    }
-    // const praivacy_policy = (<Link external="https://webmaker.org/en-US/terms">term</Link>);
+    renderDefaultLogin() {
     const cookiePolicy = (
       <a
         style={styles.cookiePolicyAnchor}
@@ -277,6 +340,30 @@ export default class Login extends Component {
       </div>
     );
   }
+
+    render() {
+        const {authenticated, authType} = this.state;
+        // If the user is already authenticated redirect to referrer link.
+        if (authenticated) {
+            return (
+                <Redirect to={this.getReferrer()}/>
+            );
+        }
+
+        // If the authType is not defined, show a blank page (or loading gif).
+        if (authType === Constants.AUTH_TYPE_UNKNOWN) {
+            return <div/>;
+        }
+
+        // If the authType is sso, show a blank page since the redirection is pending.
+        if (authType === Constants.AUTH_TYPE_SSO) {
+            return <div/>;
+        }
+
+        // Render the default login form.
+        return this.renderDefaultLogin();
+    }
+
 }
 
 Login.propTypes = {

--- a/components/org.wso2.carbon.business.rules.web/src/components/auth/Logout.jsx
+++ b/components/org.wso2.carbon.business.rules.web/src/components/auth/Logout.jsx
@@ -21,6 +21,7 @@ import React, { Component } from 'react';
 import { Redirect } from 'react-router-dom';
 // Auth Utils
 import AuthManager from '../../utils/AuthManager';
+import { Constants } from "../../utils/Constants";
 
 /**
  * App context.
@@ -34,19 +35,27 @@ export default class Logout extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      redirectToLogin: false,
+      redirectUrl :''
     };
   }
 
   componentDidMount() {
-    AuthManager.logout()
-      .then(() => this.setState({ redirectToLogin: true }));
+    AuthManager.getAuthType()
+        .then((response) => {
+          if (response.data.authType === Constants.AUTH_TYPE_SSO) {
+            AuthManager.ssoLogout().then((redirectUrl) => {
+              location.href = redirectUrl;
+            });
+          } else {
+            AuthManager.logout()
+                .then(() => {
+                  this.setState({ redirectUrl: '/login' });
+                });
+          }
+        });
   }
 
   render() {
-    if (this.state.redirectToLogin) {
-      return <Redirect to={{ pathname: '/login' }} />;
-    }
-    return null;
+    return <Redirect to={{ pathname: this.state.redirectUrl }} />;
   }
 }

--- a/components/org.wso2.carbon.business.rules.web/src/components/auth/SecuredRouter.jsx
+++ b/components/org.wso2.carbon.business.rules.web/src/components/auth/SecuredRouter.jsx
@@ -40,6 +40,17 @@ const appContext = window.contextPath;
  * Represents the App's router, which is accessible after a successful login
  */
 export default class SecuredRouter extends Component {
+
+    constructor() {
+        super();
+        this.handleSessionInvalid = this.handleSessionInvalid.bind(this);
+        window.handleSessionInvalid = this.handleSessionInvalid;
+    }
+
+    handleSessionInvalid() {
+        this.forceUpdate();
+    }
+
     componentWillMount() {
         setInterval(() => {
             if (AuthManager.getUser()) {

--- a/components/org.wso2.carbon.business.rules.web/src/utils/AuthManager.js
+++ b/components/org.wso2.carbon.business.rules.web/src/utils/AuthManager.js
@@ -18,13 +18,9 @@
  */
 
 import AuthenticationAPI from '../api/AuthenticationAPI';
+import {Constants} from './Constants';
+import Qs from 'qs';
 
-/**
- * Name of the session cookie
- */
-const SESSION_USER_COOKIE = 'BR_USER';
-const REFRESH_TOKEN_VALIDITY_PERIOD = 604800;
-const RTK = 'RTK';
 
 /**
  * App context
@@ -39,7 +35,7 @@ export default class AuthManager {
      * Deletes user from the session cookie
      */
     static clearUser() {
-        AuthManager.deleteSessionCookie(SESSION_USER_COOKIE);
+        AuthManager.deleteSessionCookie(Constants.SESSION_USER_COOKIE);
     }
 
     /**
@@ -91,7 +87,7 @@ export default class AuthManager {
      * @returns {Object}        User object
      */
     static getUser() {
-        const buffer = AuthManager.getCookie(SESSION_USER_COOKIE);
+        const buffer = AuthManager.getCookie(Constants.SESSION_USER_COOKIE);
         return buffer ? JSON.parse(buffer) : null;
     }
 
@@ -100,17 +96,27 @@ export default class AuthManager {
      * @param {Object} user     User object
      */
     static setUser(user) {
-        AuthManager.setCookie(SESSION_USER_COOKIE, JSON.stringify(user), null, window.contextPath);
+        AuthManager.setCookie(Constants.SESSION_USER_COOKIE, JSON.stringify(user), null, window.contextPath);
     }
 
     /**
      * Discards active user session
      */
     static discardSession() {
-        AuthManager.deleteCookie(SESSION_USER_COOKIE);
-        AuthManager.deleteCookie(RTK);
+        AuthManager.deleteCookie(Constants.SESSION_USER_COOKIE);
+        AuthManager.deleteCookie(Constants.RTK);
         window.localStorage.clear();
     }
+
+    /**
+     * Check if SSO authenticated.
+     *
+     * @returns {boolean}
+     */
+    static isSSOAuthenticated() {
+        return !!this.getSSOUserCookie();
+    }
+
 
     /**
      * Checks whether the user is logged in or not
@@ -166,12 +172,69 @@ export default class AuthManager {
                     });
                     // If rememberMe, set refresh token into a persistent cookie, otherwise a session cookie
                     const refreshTokenValidityPeriod =
-                        AuthManager.isRememberMeSet() ? REFRESH_TOKEN_VALIDITY_PERIOD : null;
-                    AuthManager.setCookie(RTK, lID, refreshTokenValidityPeriod, window.contextPath);
+                        AuthManager.isRememberMeSet() ? Constants.REFRESH_TOKEN_VALIDITY_PERIOD : null;
+                    AuthManager.setCookie(Constants.RTK, lID, refreshTokenValidityPeriod, window.contextPath);
                     resolve();
                 })
                 .catch(error => reject(error));
         });
+    }
+
+    /**
+     * Authenticate user via SSO.
+     *
+     * @returns {Promise<any>}
+     */
+    static ssoAuthenticate() {
+        return new Promise((resolve, reject) => {
+            AuthenticationAPI.login('', '', true, 'authorization_code')
+                .catch((e) => {
+                    if (e.response.status === 302) {
+                        let redirectUrl = e.response.data.redirectUrl + '?' + Qs.stringify({
+                            response_type: 'code',
+                            client_id: e.response.data.clientId,
+                            redirect_uri: e.response.data.callbackUrl,
+                            scope: 'openid',
+
+                        });
+                        resolve(redirectUrl);
+                    } else {
+                        reject(e);
+                    }
+                });
+        });
+    }
+
+    /**
+     * Loogut user via SSO.
+     *
+     * @returns {Promise<any>}
+     */
+    static ssoLogout() {
+        return new Promise((resolve, reject) => {
+            AuthenticationAPI.ssoLogout(AuthManager.getUser().SDID, AuthManager.getCookie(Constants.ID_TOKEN))
+                .then((response) => resolve(response.data.externalLogoutUrl))
+                .catch((error) => reject(error));
+        })
+    }
+
+    /**
+     * Get authentication type.
+     *
+     * @returns {*}
+     */
+    static getAuthType() {
+        return AuthenticationAPI.getAuthType();
+    }
+
+    /**
+     * Get SSO user cookie.
+     *
+     * @returns {null}
+     */
+    static getSSOUserCookie() {
+        const buffer = AuthManager.getCookie(Constants.USER_DTO_COOKIE);
+        return buffer ? JSON.parse(buffer) : null;
     }
 
     /**
@@ -195,8 +258,8 @@ export default class AuthManager {
                     });
                     // If rememberMe, set refresh token into a persistent cookie else session cookie.
                     const refreshTokenValidityPeriod =
-                        AuthManager.isRememberMeSet() ? REFRESH_TOKEN_VALIDITY_PERIOD : null;
-                    AuthManager.setCookie(RTK, lID, refreshTokenValidityPeriod, window.contextPath);
+                        AuthManager.isRememberMeSet() ? Constants.REFRESH_TOKEN_VALIDITY_PERIOD : null;
+                    AuthManager.setCookie(Constants.RTK, lID, refreshTokenValidityPeriod, window.contextPath);
                     resolve();
                 })
                 .catch(error => reject(error));

--- a/components/org.wso2.carbon.business.rules.web/src/utils/Constants.js
+++ b/components/org.wso2.carbon.business.rules.web/src/utils/Constants.js
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+import React, { Component } from 'react';
+
+export const Constants = {
+    // Dashboard authentication types
+    AUTH_TYPE_UNKNOWN: 'unknown',
+    AUTH_TYPE_DEFAULT: 'default',
+    AUTH_TYPE_SSO: 'sso',
+
+    // Cookies
+    RTK: 'RTK',
+    ID_TOKEN: 'RPK',
+    USER_DTO_COOKIE: 'USER_DTO',
+    SESSION_USER_COOKIE: 'BR_USER',
+    REFRESH_TOKEN_VALIDITY_PERIOD: 604800,
+};

--- a/components/org.wso2.carbon.stream.processor.common/src/main/java/org/wso2/carbon/stream/processor/common/utils/SPConstants.java
+++ b/components/org.wso2.carbon.stream.processor.common/src/main/java/org/wso2/carbon/stream/processor/common/utils/SPConstants.java
@@ -22,8 +22,6 @@ package org.wso2.carbon.stream.processor.common.utils;
  */
 public class SPConstants {
     public static final String WSO2_SP_TOKEN_2 = "HID";
-    public static final String WSO2_SP_ID_TOKEN_2 = "TID";
-    public static final String ID_TOKEN_HEADER = "Fid";
     public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final String COOKIE_HEADER = "Cookie";
 


### PR DESCRIPTION
## Purpose
1. Add SSO support to business-rules Component
2. Force session clearance and redirect to the login page when the user session expires. Previously, this rerouted to an Access Denied page and prompted for Login, If this functionality is maintained, in SSO case, after user logs in the state of the react page cannot be updated from access denied, thus the page still shows as Access denied until a refresh

## Documentation
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes