### PR TITLE
Fix - initialize nano scroller on application load

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/main.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/main.js
@@ -37,6 +37,7 @@ define(['require', 'log', 'jquery', 'lodash', 'backbone', 'menu_bar', 'tool_bar'
                     var self = this;
                     var pathSeparator;
                     this.initComponents();
+                    $(".nano").nanoScroller();
                     $( "#service-tabs-wrapper" ).on( "resize", function( event, ui ) {
                         if(self.tabController.activeTab._title != "welcome-page"){
                             if (self.tabController.activeTab.getSiddhiFileEditor().isInSourceView()) {


### PR DESCRIPTION
## Purpose
> Nano scroller does not get initialized on load of the application

## Goals
> Initialize nano scroller

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
