### PR TITLE
Fix for design view

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/designgenerator/builders/EventFlowBuilder.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/designgenerator/builders/EventFlowBuilder.java
@@ -271,9 +271,11 @@ public class EventFlowBuilder {
         PartitionConfigGenerator partitionConfigGenerator =
                 new PartitionConfigGenerator(siddhiAppString, siddhiApp, partitionedInnerStreamDefinitions);
         int partitionCounter = 0;
+        int queryCounter = 0;
         for (ExecutionElement executionElement : siddhiApp.getExecutionElementList()) {
             if (executionElement instanceof Query) {
-                QueryConfig queryConfig = queryConfigGenerator.generateQueryConfig((Query) executionElement);
+                queryCounter++;
+                QueryConfig queryConfig = queryConfigGenerator.generateQueryConfig((Query) executionElement, queryCounter);
                 siddhiAppConfig.addQuery(QueryConfigGenerator.getQueryListType(queryConfig), queryConfig);
             } else if (executionElement instanceof Partition) {
                 String partitionId = (String) partitionedInnerStreamDefinitions.keySet().toArray()[partitionCounter];

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/designgenerator/generators/PartitionConfigGenerator.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/designgenerator/generators/PartitionConfigGenerator.java
@@ -94,8 +94,10 @@ public class PartitionConfigGenerator extends CodeSegmentsPreserver {
             throws DesignGenerationException {
         Map<QueryListType, List<QueryConfig>> queryLists = populateEmptyQueryLists();
         QueryConfigGenerator queryConfigGenerator = new QueryConfigGenerator(siddhiAppString, siddhiApp);
+        int queryCounter = 0;
         for (Query query : queryList) {
-            QueryConfig queryConfig = queryConfigGenerator.generateQueryConfig(query);
+            queryCounter++;
+            QueryConfig queryConfig = queryConfigGenerator.generateQueryConfig(query, queryCounter);
             QueryListType queryListType = QueryConfigGenerator.getQueryListType(queryConfig);
             queryLists.get(queryListType).add(queryConfig);
         }

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/designgenerator/generators/query/QueryConfigGenerator.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/designgenerator/generators/query/QueryConfigGenerator.java
@@ -67,7 +67,7 @@ public class QueryConfigGenerator extends CodeSegmentsPreserver {
      * @param query                 Siddhi Query object
      * @return                      QueryConfig object
      */
-    public QueryConfig generateQueryConfig(Query query)
+    public QueryConfig generateQueryConfig(Query query, int queryCounter)
             throws DesignGenerationException {
         QueryConfig queryConfig = new QueryConfig();
 
@@ -85,7 +85,7 @@ public class QueryConfigGenerator extends CodeSegmentsPreserver {
         queryConfig.setOutputRateLimit(generateOutputRateLimit(query.getOutputRate()));
         queryConfig.setAnnotationListObjects(removeInfoAnnotation(query.getAnnotations()));
         queryConfig.setAnnotationList(generateAnnotationList(query.getAnnotations()));
-        queryConfig.setQueryName(generateQueryName(query.getAnnotations()));
+        queryConfig.setQueryName(generateQueryName(query.getAnnotations(), queryCounter));
         preserveAndBindCodeSegment(query, queryConfig);
         return queryConfig;
     }
@@ -249,14 +249,20 @@ public class QueryConfigGenerator extends CodeSegmentsPreserver {
      * @param annotations           Query annotation list
      * @return query name           name of the query
      */
-    private String generateQueryName(List<Annotation> annotations) {
+    private String generateQueryName(List<Annotation> annotations , int queryNumber) {
+        String queryName = "";
+        boolean isQueryName = false;
         for (Annotation annotation : annotations) {
             if (annotation.getName().equalsIgnoreCase("info")) {
                 preserveCodeSegment(annotation);
-                return annotation.getElement("name");
+                 queryName = annotation.getElement("name");
+                 isQueryName = true;
             }
         }
-        return DEFAULT_QUERY_NAME;
+        if (!isQueryName) {
+            queryName = DEFAULT_QUERY_NAME + queryNumber;
+        }
+        return queryName;
     }
 
     /**

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/drop-elements.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/drop-elements.js
@@ -1404,7 +1404,7 @@ define(['require', 'log', 'lodash', 'jquery', 'partition', 'stream', 'query', 'f
             var self = this;
             var oldFaultStreamName = Constants.FAULT_STREAM_PREFIX + previouslySavedStreamName;
             var oldFaultStreamElementId = "";
-            self.configurationData.getSiddhiAppConfig().getStreamList().forEach(function(s) {
+            self.configurationData.getSiddhiAppConfig().getStreamList().forEach(function (s) {
                 if (oldFaultStreamName === s.getName()) {
                     oldFaultStreamElementId = s.getId();
                 }
@@ -1412,29 +1412,10 @@ define(['require', 'log', 'lodash', 'jquery', 'partition', 'stream', 'query', 'f
 
             if (oldFaultStreamElementId != "") {
                 self.configurationData.getSiddhiAppConfig().removeStream(oldFaultStreamElementId);
-                $( "#" + oldFaultStreamElementId ).remove();
+                $("#" + oldFaultStreamElementId).remove();
             }
             if (stream.hasFaultStream()) {
-                //remove existing connectionDots
-                $('#' + stream.getId() + '-in').remove();
-                $('#' + stream.getId() + '-out').remove();
-
-                var connection1 = $('<div class="connectorInStreamForErrorStream">').attr('id', stream.getId() + "-in").
-                    addClass('connection');
-                var connection2 = $('<div class="connectorOutForErrorStream">').attr('id', stream.getId() + "-out").
-                    addClass('connection');
-                $('#' + stream.getId()).append(connection1);
-                $('#' + stream.getId()).append(connection2);
-
-                jsPlumbInstance.makeTarget(connection1, {
-                    deleteEndpointsOnDetach: true,
-                    anchor: 'Left'
-                });
-
-                jsPlumbInstance.makeSource(connection2, {
-                    deleteEndpointsOnDetach: true,
-                    anchor: 'Right'
-                });
+                self.deleteAndConnectConnection(stream.getId());
 
                 var faultStreamName = Constants.FAULT_STREAM_PREFIX + stream.getName();
                 var connectionErrOut = $('<div class="error-connection connectorErrOutStream">')
@@ -1443,9 +1424,11 @@ define(['require', 'log', 'lodash', 'jquery', 'partition', 'stream', 'query', 'f
                 jsPlumbInstance.makeSource(connectionErrOut, {
                     deleteEndpointsOnDetach: true,
                     anchor: 'Right',
-                    connectorStyle: { strokeWidth: 2, stroke: '#FF0000',
+                    connectorStyle: {
+                        strokeWidth: 2, stroke: '#FF0000',
                         outlineStroke: 'transparent',
-                        outlineWidth: '3' }
+                        outlineWidth: '3'
+                    }
                 });
 
                 $('#' + stream.getId()).addClass('errorStreamDrop');
@@ -1454,14 +1437,14 @@ define(['require', 'log', 'lodash', 'jquery', 'partition', 'stream', 'query', 'f
                 var id = self.designGrid.generateNextNewAgentId();
 
                 //add error object
-                var attributeObject = new Attribute({ name: "_error", type: "OBJECT" });
+                var attributeObject = new Attribute({name: "_error", type: "OBJECT"});
                 var attributeList = stream.getAttributeList();
                 // Add the fault stream to the stream list
                 var faultStream = new Stream({
                     id: id,
                     name: faultStreamName
                 });
-                for(var i = 0; i < attributeList.length; i++) {
+                for (var i = 0; i < attributeList.length; i++) {
                     var obj = attributeList[i];
                     faultStream.addAttribute(obj);
                 }
@@ -1474,24 +1457,44 @@ define(['require', 'log', 'lodash', 'jquery', 'partition', 'stream', 'query', 'f
                 _.forEach(connections, function (connection) {
                     self.jsPlumbInstance.deleteConnection(connection);
                 });
+
                 $('#' + stream.getId() + '-err-out').remove();
                 $('#' + stream.getId()).removeClass('errorStreamDrop');
-                $('#' + stream.getId() + '-in').remove();
-                $('#' + stream.getId() + '-out').remove();
 
-                var connection1 = $('<div class="connectorInStream">').attr('id', stream.getId() + "-in").
-                    addClass('connection');
-                var connection2 = $('<div class="connectorOutStream">').attr('id', stream.getId() + "-out").
-                    addClass('connection');
-                $('#' + stream.getId()).append(connection1);
-                $('#' + stream.getId()).append(connection2);
+                self.deleteAndConnectConnection(stream.getId());
+            }
+        };
 
-                jsPlumbInstance.makeTarget(connection1, {
+        DropElements.prototype.deleteAndConnectConnection = function (elementId) {
+            var self = this;
+
+            var inConnection = self.jsPlumbInstance.getConnections({target: elementId + '-in'})[0];
+            var outConnection = self.jsPlumbInstance.getConnections({source: elementId + '-out'})[0];
+
+            if (inConnection) {
+                self.jsPlumbInstance.deleteConnection(inConnection, {
+                    fireEvent: false, //prevents firing a connection detached event
+                    forceDetach: false //override any beforeDetach listeners
+                });
+                self.jsPlumbInstance.connect({
+                    source: inConnection.sourceId,
+                    target: inConnection.targetId
+                });
+                self.jsPlumbInstance.makeTarget(inConnection.targetId, {
                     deleteEndpointsOnDetach: true,
                     anchor: 'Left'
                 });
-
-                jsPlumbInstance.makeSource(connection2, {
+            }
+            if (outConnection) {
+                self.jsPlumbInstance.deleteConnection(outConnection, {
+                    fireEvent: false, //prevents firing a connection detached event
+                    forceDetach: false //override any beforeDetach listeners
+                });
+                self.jsPlumbInstance.connect({
+                    source: outConnection.sourceId,
+                    target: outConnection.targetId
+                });
+                self.jsPlumbInstance.makeSource(outConnection.sourceId, {
                     deleteEndpointsOnDetach: true,
                     anchor: 'Right'
                 });
@@ -1663,17 +1666,17 @@ define(['require', 'log', 'lodash', 'jquery', 'partition', 'stream', 'query', 'f
                 * update the other elements data connected to current element. ex: when a stream is deleted from a
                 * query, from clause in the query will be updated as undefined.
                 * */
-                setTimeout(function () {
-                    var outConnections = self.jsPlumbInstance.getConnections({source: elementId + '-out'});
-                    var inConnections = self.jsPlumbInstance.getConnections({target: elementId + '-in'});
-
-                    _.forEach(outConnections, function (connection) {
-                        self.jsPlumbInstance.deleteConnection(connection);
-                    });
-                    _.forEach(inConnections, function (connection) {
-                        self.jsPlumbInstance.deleteConnection(connection);
-                    });
-                }, 100);
+                // setTimeout(function () {
+                //     var outConnections = self.jsPlumbInstance.getConnections({source: elementId + '-out'});
+                //     var inConnections = self.jsPlumbInstance.getConnections({target: elementId + '-in'});
+                //
+                //     _.forEach(outConnections, function (connection) {
+                //         self.jsPlumbInstance.deleteConnection(connection);
+                //     });
+                //     _.forEach(inConnections, function (connection) {
+                //         self.jsPlumbInstance.deleteConnection(connection);
+                //     });
+                // }, 100);
 
                 self.jsPlumbInstance.remove(newElement, true);
                 if (self.jsPlumbInstance.getGroupFor(newElement)) {

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/drop-elements.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/drop-elements.js
@@ -1415,7 +1415,7 @@ define(['require', 'log', 'lodash', 'jquery', 'partition', 'stream', 'query', 'f
                 $("#" + oldFaultStreamElementId).remove();
             }
             if (stream.hasFaultStream()) {
-                self.deleteAndConnectConnection(stream.getId());
+                self.removeAndRecreateConnection(stream.getId());
 
                 var faultStreamName = Constants.FAULT_STREAM_PREFIX + stream.getName();
                 var connectionErrOut = $('<div class="error-connection connectorErrOutStream">')
@@ -1461,11 +1461,11 @@ define(['require', 'log', 'lodash', 'jquery', 'partition', 'stream', 'query', 'f
                 $('#' + stream.getId() + '-err-out').remove();
                 $('#' + stream.getId()).removeClass('errorStreamDrop');
 
-                self.deleteAndConnectConnection(stream.getId());
+                self.removeAndRecreateConnection(stream.getId());
             }
         };
 
-        DropElements.prototype.deleteAndConnectConnection = function (elementId) {
+        DropElements.prototype.removeAndRecreateConnection = function (elementId) {
             var self = this;
 
             var inConnection = self.jsPlumbInstance.getConnections({target: elementId + '-in'})[0];

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/drop-elements.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/drop-elements.js
@@ -1660,23 +1660,6 @@ define(['require', 'log', 'lodash', 'jquery', 'partition', 'stream', 'query', 'f
                 // set the isDesignViewContentChanged to true
                 self.configurationData.setIsDesignViewContentChanged(true);
                 var elementId = newElement[0].id;
-                /*
-                * before deleting the element data from the data store structure, it is mandatory to delete the element
-                * from jsPlumb because it will fire the 'beforeDetach' and 'connectionDetached' events and it will
-                * update the other elements data connected to current element. ex: when a stream is deleted from a
-                * query, from clause in the query will be updated as undefined.
-                * */
-                // setTimeout(function () {
-                //     var outConnections = self.jsPlumbInstance.getConnections({source: elementId + '-out'});
-                //     var inConnections = self.jsPlumbInstance.getConnections({target: elementId + '-in'});
-                //
-                //     _.forEach(outConnections, function (connection) {
-                //         self.jsPlumbInstance.deleteConnection(connection);
-                //     });
-                //     _.forEach(inConnections, function (connection) {
-                //         self.jsPlumbInstance.deleteConnection(connection);
-                //     });
-                // }, 100);
 
                 self.jsPlumbInstance.remove(newElement, true);
                 if (self.jsPlumbInstance.getGroupFor(newElement)) {

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/form-builder.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/form-builder.js
@@ -112,7 +112,7 @@ define(['require', 'log', 'jquery', 'lodash', 'formUtils', 'streamForm', 'tableF
             var formConsole = this.consoleListManager.newFormConsole(consoleOptions);
             $(formConsole).on("close-button-in-form-clicked", function () {
                 // close the form window
-                self.consoleListManager.removeFormConsole(formConsole);
+                self.consoleListManager.removeAllConsoles();
             });
             return formConsole;
         };

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/form-builder.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/form-builder.js
@@ -112,6 +112,7 @@ define(['require', 'log', 'jquery', 'lodash', 'formUtils', 'streamForm', 'tableF
             var formConsole = this.consoleListManager.newFormConsole(consoleOptions);
             $(formConsole).on("close-button-in-form-clicked", function () {
                 // close the form window
+                self.consoleListManager.removeFormConsole(formConsole);
                 self.consoleListManager.removeAllConsoles();
             });
             return formConsole;

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/aggregation-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/aggregation-form.js
@@ -245,7 +245,7 @@ define(['require', 'log', 'jquery', 'lodash', 'aggregateByTimePeriod', 'querySel
             } else {
                 var propertyDiv = $('<div id = "define-aggregation" class="clearfix form-min-width"> </div>');
 
-                formContainer.append(propertyDiv);
+                formContainer.html(propertyDiv);
                 self.formUtils.buildFormButtons(formConsole.cid);
                 self.designViewContainer.addClass('disableContainer');
                 self.toggleViewButton.addClass('disableContainer');

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/aggregation-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/aggregation-form.js
@@ -242,6 +242,7 @@ define(['require', 'log', 'jquery', 'lodash', 'aggregateByTimePeriod', 'querySel
                 $('#' + id).addClass('incomplete-element');
                 DesignViewUtils.prototype.warnAlert('Connect an input stream element');
                 self.consoleListManager.removeFormConsole(formConsole);
+                self.consoleListManager.removeAllConsoles();
             } else {
                 var propertyDiv = $('<div id = "define-aggregation" class="clearfix form-min-width"> </div>');
 

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/app-annotation-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/app-annotation-form.js
@@ -52,7 +52,7 @@ define(['require', 'log', 'jquery', 'lodash'],
                 '</label> </div> </div>' +
                 '<div class = "siddhi-app-form-container"> <div class = "define-annotation" </div> </div> </div> ');
 
-            formContainer.append(propertyDiv);
+            formContainer.html(propertyDiv);
             self.formUtils.buildFormButtons(formConsole.cid);
             $(".overlayed-container").fadeTo(200, 1);
             // design view container and toggle view button are enabled

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/function-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/function-form.js
@@ -86,7 +86,7 @@ define(['require', 'log', 'jquery', 'lodash', 'constants'],
                 '<textarea id= "script-body-content" class="clearfix" rows="5" cols="50"> </textarea> ' +
                 '<label class = "error-message"></label> </div> </div> </div>');
 
-            formContainer.append(propertyDiv);
+            formContainer.html(propertyDiv);
             self.formUtils.buildFormButtons(formConsole.cid);
             self.formUtils.popUpSelectedElement(id);
             self.designViewContainer.addClass('disableContainer');

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/join-query-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/join-query-form.js
@@ -286,7 +286,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryWindowOrFunct
                 self.consoleListManager.removeFormConsole(formConsole);
             } else {
                 var propertyDiv = $('<div id="define-join-query" class="clearfix form-min-width"></div>');
-                formContainer.append(propertyDiv);
+                formContainer.html(propertyDiv);
                 self.formUtils.buildFormButtons(formConsole.cid);
 
                 self.designViewContainer.addClass('disableContainer');

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/join-query-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/join-query-form.js
@@ -284,6 +284,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryWindowOrFunct
             }
             if (inValid) {
                 self.consoleListManager.removeFormConsole(formConsole);
+                self.consoleListManager.removeAllConsoles();
             } else {
                 var propertyDiv = $('<div id="define-join-query" class="clearfix form-min-width"></div>');
                 formContainer.html(propertyDiv);

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/partition-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/partition-form.js
@@ -90,6 +90,7 @@ define(['require', 'log', 'jquery', 'lodash', 'partitionWith', 'jsonValidator', 
 
                     // close the form window
                     self.consoleListManager.removeFormConsole(formConsole);
+                    self.consoleListManager.removeAllConsoles();
                 } else {
                     var propertyDiv = $('<div class="clearfix form-min-width"> <div class = "partition-form-container"> ' +
                         '<div id = "define-partition-keys"> </div> </div>' +

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/partition-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/partition-form.js
@@ -95,7 +95,7 @@ define(['require', 'log', 'jquery', 'lodash', 'partitionWith', 'jsonValidator', 
                         '<div id = "define-partition-keys"> </div> </div>' +
                         '<div class = "partition-form-container"> <div class = "define-annotation"> </div> </div> </div>');
 
-                    formContainer.append(propertyDiv);
+                    formContainer.html(propertyDiv);
                     self.formUtils.buildFormButtons(formConsole.cid);
                     self.formUtils.popUpSelectedElement(id);
                     // design view container and toggle view button are enabled

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/pattern-query-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/pattern-query-form.js
@@ -151,12 +151,15 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOrderByValue'
                 || patternQueryObject.getQueryInput().getConnectedElementNameList().length === 0) {
                 DesignViewUtils.prototype.warnAlert('Connect input streams');
                 self.consoleListManager.removeFormConsole(formConsole);
+                self.consoleListManager.removeAllConsoles();
             } else if (!self.formUtils.isOneElementFilled(patternQueryObject.getQueryInput().getConnectedElementNameList())) {
                 DesignViewUtils.prototype.warnAlert('Fill the incomplete input stream');
                 self.consoleListManager.removeFormConsole(formConsole);
+                self.consoleListManager.removeAllConsoles();
             } else if (!patternQueryObject.getQueryOutput() || !patternQueryObject.getQueryOutput().getTarget()) {
                 DesignViewUtils.prototype.warnAlert('Connect an output element');
                 self.consoleListManager.removeFormConsole(formConsole);
+                self.consoleListManager.removeAllConsoles();
             } else {
                 var propertyDiv = $('<div id="define-pattern-query" class="clearfix form-min-width"></div>');
                 formContainer.html(propertyDiv);

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/pattern-query-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/pattern-query-form.js
@@ -159,7 +159,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOrderByValue'
                 self.consoleListManager.removeFormConsole(formConsole);
             } else {
                 var propertyDiv = $('<div id="define-pattern-query" class="clearfix form-min-width"></div>');
-                formContainer.append(propertyDiv);
+                formContainer.html(propertyDiv);
                 self.formUtils.buildFormButtons(formConsole.cid);
 
                 self.designViewContainer.addClass('disableContainer');

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/sequence-query-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/sequence-query-form.js
@@ -158,7 +158,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOrderByValue'
                 self.consoleListManager.removeFormConsole(formConsole);
             } else {
                 var propertyDiv = $('<div id="define-sequence-query" class="clearfix form-min-width"></div>');
-                formContainer.append(propertyDiv);
+                formContainer.html(propertyDiv);
                 self.formUtils.buildFormButtons(formConsole.cid);
 
                 self.designViewContainer.addClass('disableContainer');

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/sequence-query-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/sequence-query-form.js
@@ -150,12 +150,15 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOrderByValue'
                 || sequenceQueryObject.getQueryInput().getConnectedElementNameList().length === 0) {
                 DesignViewUtils.prototype.warnAlert('Connect input streams');
                 self.consoleListManager.removeFormConsole(formConsole);
+                self.consoleListManager.removeAllConsoles();
             } else if (!self.formUtils.isOneElementFilled(sequenceQueryObject.getQueryInput().getConnectedElementNameList())) {
                 DesignViewUtils.prototype.warnAlert('Fill the incomplete input stream');
                 self.consoleListManager.removeFormConsole(formConsole);
+                self.consoleListManager.removeAllConsoles();
             } else if (!sequenceQueryObject.getQueryOutput() || !sequenceQueryObject.getQueryOutput().getTarget()) {
                 DesignViewUtils.prototype.warnAlert('Connect an output element');
                 self.consoleListManager.removeFormConsole(formConsole);
+                self.consoleListManager.removeAllConsoles();
             } else {
                 var propertyDiv = $('<div id="define-sequence-query" class="clearfix form-min-width"></div>');
                 formContainer.html(propertyDiv);

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/sink-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/sink-form.js
@@ -153,7 +153,7 @@ define(['log', 'jquery', 'lodash', 'mapAnnotation', 'payloadOrAttribute', 'jsonV
                     '</div> <div class= "source-sink-form-container attribute-map-div"><div id="define-attribute">' +
                     '</div> <div id="attribute-map-content"></div> </div> </div>');
 
-                formContainer.append(propertyDiv);
+                formContainer.html(propertyDiv);
                 self.formUtils.buildFormButtons(formConsole.cid);
                 self.formUtils.popUpSelectedElement(id);
                 self.designViewContainer.addClass('disableContainer');

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/sink-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/sink-form.js
@@ -136,6 +136,7 @@ define(['log', 'jquery', 'lodash', 'mapAnnotation', 'payloadOrAttribute', 'jsonV
             if (!isSinkConnected) {
                 // close the form window
                 self.consoleListManager.removeFormConsole(formConsole);
+                self.consoleListManager.removeAllConsoles();
             } else {
                 var connectedElement = sinkObject.connectedElementName;
                 var predefinedSinks = _.orderBy(this.configurationData.rawExtensions["sink"], ['name'], ['asc']);

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/source-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/source-form.js
@@ -146,7 +146,7 @@ define(['log', 'jquery', 'lodash', 'sourceOrSinkAnnotation', 'mapAnnotation', 'p
                     '</div> </div> <div class= "source-sink-form-container attribute-map-div">' +
                     '<div id="define-attribute"> </div> <div id="attribute-map-content"></div> </div> </div>');
 
-                formContainer.append(propertyDiv);
+                formContainer.html(propertyDiv);
                 self.formUtils.buildFormButtons(formConsole.cid);
                 self.formUtils.popUpSelectedElement(id);
                 self.designViewContainer.addClass('disableContainer');

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/source-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/source-form.js
@@ -130,6 +130,7 @@ define(['log', 'jquery', 'lodash', 'sourceOrSinkAnnotation', 'mapAnnotation', 'p
             if (!isSourceConnected) {
                 // close the form window
                 self.consoleListManager.removeFormConsole(formConsole);
+                self.consoleListManager.removeAllConsoles();
             } else {
                 var connectedElement = sourceObject.connectedElementName;
                 var predefinedSources = _.orderBy(this.configurationData.rawExtensions["source"], ['name'], ['asc']);

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/stream-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/stream-form.js
@@ -56,7 +56,7 @@ define(['require', 'log', 'jquery', 'lodash', 'attribute', 'jsonValidator', 'con
                 '<div id="define-attribute"></div> </div> <div class= "stream-form-container"> ' +
                 '<div class ="define-annotation"> </div> </div>');
 
-            formContainer.append(propertyDiv);
+            formContainer.html(propertyDiv);
             self.formUtils.buildFormButtons(formConsole.cid);
             self.formUtils.popUpSelectedElement(id);
             self.designViewContainer.addClass('disableContainer');

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/table-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/table-form.js
@@ -59,7 +59,7 @@ define(['log', 'jquery', 'lodash', 'attribute', 'storeAnnotation', 'handlebar', 
                 '<div class = "define-predefined-annotations"> </div> <div class="define-user-defined-annotations"> ' +
                 '</div> </div> </div>');
 
-            formContainer.append(propertyDiv);
+            formContainer.html(propertyDiv);
             self.formUtils.buildFormButtons(formConsole.cid);
             self.formUtils.popUpSelectedElement(id);
             self.designViewContainer.addClass('disableContainer');

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/trigger-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/trigger-form.js
@@ -132,7 +132,7 @@ define(['require', 'log', 'jquery', 'lodash', 'constants'],
                 'id = "triggerNameErrorMessage"> </label> </div> <div id= "define-trigger-criteria"> </div>' +
                 '<div id = "trigger-criteria-content"></div> </div> </div>');
 
-            formContainer.append(propertyDiv);
+            formContainer.html(propertyDiv);
             self.formUtils.buildFormButtons(formConsole.cid);
             self.formUtils.popUpSelectedElement(id);
             self.designViewContainer.addClass('disableContainer');

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/window-filter-projection-query-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/window-filter-projection-query-form.js
@@ -86,7 +86,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryWindowOrFunct
                 self.consoleListManager.removeFormConsole(formConsole);
             } else {
                 var propertyDiv = $('<div id="define-windowFilterProjection-query" class="clearfix form-min-width"></div>');
-                formContainer.append(propertyDiv);
+                formContainer.html(propertyDiv);
                 self.formUtils.buildFormButtons(formConsole.cid);
 
                 self.designViewContainer.addClass('disableContainer');

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/window-filter-projection-query-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/window-filter-projection-query-form.js
@@ -81,9 +81,11 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryWindowOrFunct
             if (!queryObject.getQueryInput() || !queryObject.getQueryInput().getConnectedSource()) {
                 DesignViewUtils.prototype.warnAlert('Connect an input element');
                 self.consoleListManager.removeFormConsole(formConsole);
+                self.consoleListManager.hideAllConsoles();
             } else if (!queryObject.getQueryOutput() || !queryObject.getQueryOutput().getTarget()) {
                 DesignViewUtils.prototype.warnAlert('Connect an output stream');
                 self.consoleListManager.removeFormConsole(formConsole);
+                self.consoleListManager.hideAllConsoles();
             } else {
                 var propertyDiv = $('<div id="define-windowFilterProjection-query" class="clearfix form-min-width"></div>');
                 formContainer.html(propertyDiv);

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/window-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/window-form.js
@@ -56,7 +56,7 @@ define(['require', 'log', 'jquery', 'lodash', 'attribute', 'constants'],
                 '<div class ="defineFunctionParameters"> </div> </div> <div class = "window-form-container"> ' +
                 '<div class="define-output-events"> </div><div class="define-annotation"></div> </div> </div>');
 
-            formContainer.append(propertyDiv);
+            formContainer.html(propertyDiv);
             self.formUtils.buildFormButtons(formConsole.cid);
             self.formUtils.popUpSelectedElement(id);
             self.designViewContainer.addClass('disableContainer');

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/output-console/console-list.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/output-console/console-list.js
@@ -263,6 +263,13 @@ define(['log', 'jquery', 'lodash', 'backbone', 'console'], function (log, $, _, 
                 this.setActiveConsole(nextConsole);
             },
             /**
+             * removes all the console instances
+             */
+            removeAllConsoles: function () {
+                this.hideAllConsoles();
+                this.removePoppedUpElement();
+            },
+            /**
              * removes the classes added to pop-up the element
              */
             removePoppedUpElement: function () {


### PR DESCRIPTION
## Purpose
> 1. While the form is open, when the close icon is clicked all the consoles doesn't get closed.
> 2. When moving from source view to design view the default query name gets set if the user has not specified any name for it.
> 3. On open of an form, it's components gets appended to the same form container (which holds the components of a different form).
> 4. When there are more than one stream in a design-view once they are submitted and if a stream is deleted the connections are misplaced. 

## Goals
> Fix bugs for forms.

## Approach 
> 1. On click of the close icon call the method to remove all the tabs from the console panel.
> 2. Use a query counter to have unique query names.
> 3. On open of the form instead of appending, change the html of the form container with the new form division.
> 4. Instead of using jquery [to remove and connect the connections] to toggle the fault stream, jsplumb instance was used to delete and connect it.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
