### PR TITLE
Fix to prevent firing connection on attach event listener when recreating a connection to update fault streams

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/designgenerator/generators/query/QueryConfigGenerator.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/designview/designgenerator/generators/query/QueryConfigGenerator.java
@@ -247,6 +247,7 @@ public class QueryConfigGenerator extends CodeSegmentsPreserver {
     /**
      * Extracts the query name from the annotation list, or returns the default query name
      * @param annotations           Query annotation list
+     * @param queryNumber           to generate unique query names
      * @return query name           name of the query
      */
     private String generateQueryName(List<Annotation> annotations , int queryNumber) {

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/drop-elements.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/drop-elements.js
@@ -1478,7 +1478,8 @@ define(['require', 'log', 'lodash', 'jquery', 'partition', 'stream', 'query', 'f
                 });
                 self.jsPlumbInstance.connect({
                     source: inConnection.sourceId,
-                    target: inConnection.targetId
+                    target: inConnection.targetId,
+                    fireEvent: false
                 });
                 self.jsPlumbInstance.makeTarget(inConnection.targetId, {
                     deleteEndpointsOnDetach: true,
@@ -1492,7 +1493,8 @@ define(['require', 'log', 'lodash', 'jquery', 'partition', 'stream', 'query', 'f
                 });
                 self.jsPlumbInstance.connect({
                     source: outConnection.sourceId,
-                    target: outConnection.targetId
+                    target: outConnection.targetId,
+                    fireEvent: false
                 });
                 self.jsPlumbInstance.makeSource(outConnection.sourceId, {
                     deleteEndpointsOnDetach: true,


### PR DESCRIPTION
## Purpose
> When recreating a connection while updating the fault streams, the event listeners for connection on attach gets triggered.

## Goals
> Prevent firing event listeners while recreating a connection [only when updating a fault stream].

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
