### PR TITLE
Add parameter names along with the function names

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/Constants.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/Constants.java
@@ -23,6 +23,7 @@ import org.wso2.siddhi.core.query.processor.stream.StreamProcessor;
 import org.wso2.siddhi.core.query.processor.stream.function.StreamFunctionProcessor;
 import org.wso2.siddhi.core.query.processor.stream.window.WindowProcessor;
 import org.wso2.siddhi.core.query.selector.attribute.aggregator.AttributeAggregator;
+import org.wso2.siddhi.core.query.selector.attribute.aggregator.incremental.IncrementalAttributeAggregator;
 import org.wso2.carbon.utils.Utils;
 import org.wso2.siddhi.core.stream.input.source.Source;
 import org.wso2.siddhi.core.stream.input.source.SourceMapper;
@@ -53,6 +54,7 @@ public class Constants {
     public static final String SERVER_LIST = "serverList";
     static final String FUNCTION_EXECUTOR = "FunctionExecutor";
     static final String ATTRIBUTE_AGGREGATOR = "AttributeAggregator";
+    static final String INCREMENTAL_AGGREGATOR = "IncrementalAggregator";
     static final String WINDOW_PROCESSOR = "WindowProcessor";
     static final String STREAM_FUNCTION_PROCESSOR = "StreamFunctionProcessor";
     static final String STREAM_PROCESSOR = "StreamProcessor";
@@ -82,6 +84,7 @@ public class Constants {
         // Populating the processor super class map
         SUPER_CLASS_MAP = new HashMap<>();
         SUPER_CLASS_MAP.put(FUNCTION_EXECUTOR, FunctionExecutor.class);
+        SUPER_CLASS_MAP.put(INCREMENTAL_AGGREGATOR, IncrementalAttributeAggregator.class);
         SUPER_CLASS_MAP.put(ATTRIBUTE_AGGREGATOR, AttributeAggregator.class);
         SUPER_CLASS_MAP.put(WINDOW_PROCESSOR, WindowProcessor.class);
         SUPER_CLASS_MAP.put(STREAM_FUNCTION_PROCESSOR, StreamFunctionProcessor.class);

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/SourceEditorUtils.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/SourceEditorUtils.java
@@ -342,6 +342,10 @@ public class SourceEditorUtils {
                     .isAssignableFrom(extensionClass)) {
                 processorType = Constants.ATTRIBUTE_AGGREGATOR;
                 processorMetaDataList = metaData.getFunctions();
+            } else if (Constants.SUPER_CLASS_MAP.get(Constants.INCREMENTAL_AGGREGATOR)
+                        .isAssignableFrom(extensionClass)) {
+                    processorType = Constants.INCREMENTAL_AGGREGATOR;
+                    processorMetaDataList = metaData.getFunctions();
             } else if (Constants.SUPER_CLASS_MAP.get(Constants.STREAM_FUNCTION_PROCESSOR)
                     .isAssignableFrom(extensionClass)) {
                 processorType = Constants.STREAM_FUNCTION_PROCESSOR;

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/css/design-view.css
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/css/design-view.css
@@ -693,8 +693,7 @@ a.list-group-item, button.list-group-item {
 
 .source-sink-form-container .source-sink-map-options .error-message,
 .design-view-form-content #store-options .error-message,
-.design-view-form-content #primary-index-annotations .error-message,
-.window-form-container .defineFunctionParameters .error-message {
+.design-view-form-content #primary-index-annotations .error-message {
     margin-left: 20px;
 }
 
@@ -758,11 +757,15 @@ a.list-group-item, button.list-group-item {
     text-align: left;
 }
 
-.design-view-form-content input[type="text"].option-value,
-.window-form-container input[type="text"].parameter-value {
+.design-view-form-content input[type="text"].option-value {
     width: 85%;
     margin-bottom: 2px;
     margin-left: 20px;
+}
+
+.defineFunctionParameters input[type="text"].parameter-value {
+    width: 85%;
+    margin-bottom: 2px;
 }
 
 .trigger-form-container #trigger-criteria-content .description {
@@ -1159,13 +1162,13 @@ a.list-group-item, button.list-group-item {
     margin-left: 20px;
 }
 
-.design-view-form-content .option .mandatory-symbol,
-.design-view-form-content .parameter .mandatory-symbol {
+.design-view-form-content .option .mandatory-symbol {
     margin-right: 12px;
 }
 
-.design-view-form-content .mandatory-symbol {
-    margin-right: 8px;
+.design-view-form-content .mandatory-symbol,
+.design-view-form-content .parameter .mandatory-symbol {
+    margin-right: 7px;
 }
 
 .design-view-form-content select,
@@ -1611,4 +1614,43 @@ label.option-name {
 .design-view-form-content .design-view-combobox {
     max-height: 150px;
     z-index: 1000 !important;
+}
+
+.design-view-form-content .display-predefined-parameters {
+    margin-top: 10px;
+    background: rgb(40, 41, 41);
+}
+
+.design-view-form-content .predefined-param {
+    margin: 5px;
+}
+
+.design-view-form-content .predefined-param .predefined-param-name {
+    font-weight: normal;
+}
+
+.design-view-form-content .predefined-param .optional-label {
+    font-weight: 300;
+    font-style: italic;
+}
+
+.design-view-form-content .predefined-param .predefined-param-desc {
+    margin-left: 5px;
+    word-break: break-word;
+}
+
+.design-view-form-content .display-predefined-parameters .parameter-label {
+    font-weight: bold;
+}
+
+.design-view-form-content .defineFunctionParameters .btn-add-param-attribute {
+    margin-top: -1px;
+    height: 21px;
+    padding: 0 10px;
+    margin-left: 3px;
+    border: 1px solid #716e6e;
+}
+
+.design-view-form-content .defineFunctionParameters .attribute-param-value {
+    margin-top: 5px;
 }

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
@@ -1389,7 +1389,7 @@
                     <label class = "parameter-name mandatory-parameter"> {{name}} </label>
                 </div>
                 {{/if}}
-                {{#if isAttribute}}
+                {{#if isMultiValue}}
                 <div class = "clearfix param-content attribute-param">
                     {{#each value}}
                     <div class="attribute-param-value">
@@ -1440,7 +1440,7 @@
                     </i>
                 </div>
                 {{/if}}
-                {{#if isAttribute}}
+                {{#if isMultiValue}}
                 <div class = "param-content attribute-param clearfix">
                     {{#each value}}
                     <div class="attribute-param-value">

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/index.html
@@ -1342,7 +1342,77 @@
                     </div>
                 </div>
             {{/each}}
+        </div>
     </div>
+</script>
+
+<script id="window-function-unknown-parameters-template" type = "text/template">
+    {{#if predefinedParameters}}
+    <div class="display-predefined-parameters">
+        <div class="clearfix collapse-div" data-toggle="collapse" href="#predefined-param-content"
+             aria-controls="join-{{type}}-content" aria-expanded="false">
+            <label class="parameter-label"> Supported Parameters </label>
+            <a class="collapse-icon"> </a>
+        </div>
+        <div class = "collapse" id ="predefined-param-content">
+            {{#each predefinedParameters}}
+            <div class="predefined-param">
+                {{#if optional}}
+                <label class = "predefined-param-name clearfix"> {{name}}
+                    <span class="optional-label"> (optional) </span>
+                </label>
+                {{else}}
+                <label class = "clearfix predefined-param-name"> {{name}}
+                    <span class = "optional-label"> (mandatory)</span>
+                </label>
+                {{/if}}
+                <label class="clearfix predefined-param-desc"> {{description}} </label>
+            </div>
+            {{/each}}
+        </div>
+    </div>
+    {{/if}}
+
+    {{#if parameters}}
+    <h4> Parameters </h4>
+    <div id = "{{id}}-unknown-parameters">
+        <div class = "sub-{{id}}-parameter-div">
+            {{#each parameters}}
+            <div class = "parameter" id="{{name}}">
+                {{#if optional}}
+                <div class = "clearfix">
+                    <label class = "parameter-name optional-parameter"> {{name}} </label>
+                </div>
+                {{else}}
+                <div class="clearfix">
+                    <span class = "mandatory-symbol"> * </span>
+                    <label class = "parameter-name mandatory-parameter"> {{name}} </label>
+                </div>
+                {{/if}}
+                {{#if isAttribute}}
+                <div class = "clearfix param-content attribute-param">
+                    {{#each value}}
+                    <div class="attribute-param-value">
+                        <input class = "parameter-value" type = "text" value = "{{this}}">
+                        <a class = "btn-del-option"> <i class = "fw fw-delete"> </i></a>
+                    </div>
+                    {{/each}}
+                </div>
+                {{else}}
+                <div class = "clearfix param-content">
+                    <input class = "parameter-value" type = "text" value = "{{value}}">
+                </div>
+                {{/if}}
+                <label class = "error-message"></label>
+            </div>
+            {{#if (isDivisor (sum @index 1) ../parameters)}}
+        </div>
+        <div class = "sub-{{../id}}-parameter-div">
+            {{/if}}
+            {{/each}}
+        </div>
+    </div>
+    {{/if}}
 </script>
 
 <script id="window-function-parameters-template" type = "text/template">
@@ -1350,56 +1420,47 @@
     <h4> Parameters </h4>
     <div id = "{{id}}-parameters">
         <div class = "sub-{{id}}-parameter-div">
-    {{#each parameters}}
-        <div class = "parameter" id="{{name}}-parameter">
-        {{#if optional}}
-            {{#if value}}
+            {{#each parameters}}
+            <div class = "parameter" id="{{name}}-parameter">
+                {{#if optional}}
                 <div class = "clearfix">
-                    <label class = "parameter-name optional-parameter">
-                        <input type = "checkbox" class = "parameter-checkbox" checked> {{name}}
-                    </label>
+                    <label class = "parameter-name optional-parameter">{{name}} </label>
                     <i class = "fw fw-info">
                         <span style = "display:none"> {{description}} </span>
                     </i>
                 </div>
-                <div class = "clearfix optional-param-content">
+                {{else}}
+                <div class="clearfix">
+                    <span class = "mandatory-symbol"> * </span>
+                    <label class = "parameter-name mandatory-parameter">
+                        {{name}}
+                    </label>
+                    <i class="fw fw-info">
+                        <span style="display:none"> {{description}} </span>
+                    </i>
+                </div>
+                {{/if}}
+                {{#if isAttribute}}
+                <div class = "param-content attribute-param clearfix">
+                    {{#each value}}
+                    <div class="attribute-param-value">
+                        <input class = "parameter-value" type = "text" value = "{{this}}">
+                        <a class = "btn-del-option"> <i class = "fw fw-delete"> </i></a>
+                    </div>
+                    {{/each}}
+                </div>
+                {{else}}
+                <div class = "param-content clearfix">
                     <input class = "parameter-value" type = "text" value = "{{value}}">
                 </div>
-            {{else}}
-                <div class="clearfix">
-                    <label class = "parameter-name optional-parameter">
-                        <input type = "checkbox" class = "parameter-checkbox"> {{name}}
-                    </label>
-                    <i class = "fw fw-info">
-                        <span style = "display:none"> {{description}} </span>
-                    </i>
-                </div>
-                <div class="clearfix optional-param-content" style ="display:none">
-                    <input class = "parameter-value" type = "text" value="{{defaultValue}}">
-                </div>
-            {{/if}}
+                {{/if}}
                 <label class = "error-message"></label>
-        {{else}}
-            <div class="clearfix">
-                <span class = "mandatory-symbol"> * </span>
-                <label class = "parameter-name mandatory-parameter">
-                    {{name}}
-                </label>
-                <i class="fw fw-info">
-                    <span style="display:none"> {{description}} </span>
-                </i>
             </div>
-            <div class = "clearfix">
-                <input class = "parameter-value" type = "text" value = "{{value}}">
-            </div>
-            <label class = "error-message"></label>
-        {{/if}}
+            {{#if (isDivisor (sum @index 1) ../parameters)}}
         </div>
-        {{#if (isDivisor (sum @index 1) ../parameters)}}
-            </div>
-            <div class = "sub-{{../id}}-parameter-div">
-        {{/if}}
-    {{/each}}
+        <div class = "sub-{{../id}}-parameter-div">
+            {{/if}}
+            {{/each}}
         </div>
     </div>
     {{/if}}
@@ -2724,7 +2785,6 @@
             query_operators: ["==", ">=", ">", "<=", "<", "AND", "OR", "NOT", "IN", "IS NULL"],
             output_rate_limit_keywords: ["snapshot", "every", "within", "events", "ALL", "LAST", "FIRST"],
             logic_statement_keywords: ["for", "every", "within"],
-            incremental_aggregator: ["sum", "min", "max", "avg", "count", "distinctCount"],
             join_types: ["join", "left_outer_join", "right_outer_join", "full_outer_join"],
             stream_handler_types: ["filter", "function","window"],
             query_output_operations: ["insert", "delete", "update", "update_or_insert_into"],

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/constants.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/constants.js
@@ -124,7 +124,10 @@ define(function () {
         KEYWORD: "keyword",
         OPERATOR: "operator",
         INPUT: "input",
-        FOR: "for"
+        FOR: "for",
+        ASC:"asc",
+        DESC: "desc",
+        BATCH_WINDOW_PROCESSOR: "batch"
     };
 
     return constants;

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/constants.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/constants.js
@@ -127,7 +127,8 @@ define(function () {
         FOR: "for",
         ASC:"asc",
         DESC: "desc",
-        BATCH_WINDOW_PROCESSOR: "batch"
+        BATCH_WINDOW_PROCESSOR: "batch",
+        MULTI_VALUE: "..."
     };
 
     return constants;

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/form-utils.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/form-utils.js
@@ -945,24 +945,30 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
          */
         FormUtils.prototype.getParameterOverloads = function (functionName, predefinedParameters) {
             var parameterOverloads = [];
+            var multiValue;
             if (functionName.includes("(")) {
                 var regexToGetTextInsideBrackets = /\(([^)]+)\)/;
-                var overloads = regexToGetTextInsideBrackets.exec(functionName);
-                if (overloads) {
-                    overloads = overloads[1].trim();
-                    var overloadParameters = overloads.split(",");
-                    _.forEach(overloadParameters, function (overload) {
-                        overload = overload.trim();
-                        _.forEach(predefinedParameters, function (parameter) {
-                            if (overload === parameter.name) {
-                                parameterOverloads.push(parameter);
-                                return false;
-                            }
-                        });
+                var overloads = regexToGetTextInsideBrackets.exec(functionName)[1].trim();
+                var listOfOverloads = overloads.split(",");
+                _.forEach(listOfOverloads, function (overload, index) {
+                    multiValue = false;
+                    overload = overload.trim();
+                    _.forEach(predefinedParameters, function (parameter) {
+                        if (listOfOverloads[index+1] === Constants.MULTI_VALUE) {
+                            multiValue = true;
+                        }
+                        if (overload === parameter.name) {
+                            parameterOverloads.push({
+                                name: parameter.name,
+                                description: parameter.description,
+                                optional: parameter.optional,
+                                defaultValue: parameter.defaultValue,
+                                isMultiValue: multiValue
+                            });
+                            return false;
+                        }
                     });
-                } else {
-                    parameterOverloads = predefinedParameters;
-                }
+                });
             } else {
                 parameterOverloads = predefinedParameters;
             }
@@ -2487,27 +2493,21 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
                         for (var i = 0; i < predefinedFunction.parameterOverloads.length; i++) {
                             var overload = predefinedFunction.parameterOverloads[i];
                             var lengthOfSavedParameters = savedParameters.length;
-                            if (overload.includes(Constants.ATTRIBUTE)) {
-                                var attributeIndex = overload.indexOf(Constants.ATTRIBUTE);
-                                var attributes = [];
-                                for (var j = attributeIndex; j < savedParameters.length; j++) {
-                                    var parameter = savedParameters[j].substring(1, savedParameters[j].length - 1)
-                                        .toLowerCase();
-                                    if (parameter === Constants.ASC || parameter === Constants.DESC) {
-                                        break;
-                                    } else {
-                                        attributes.push(savedParameters[j])
+                            var noOfOverloadParameters = overload.length;
+                            for (var k = 0; k < overload.length; k++) {
+                                if (overload[k + 1] === Constants.MULTI_VALUE) {
+                                    var multiValues = [];
+                                    for (var j = k; j < savedParameters.length; j++) {
+                                        multiValues.push(savedParameters[j])
                                     }
+                                    lengthOfSavedParameters = lengthOfSavedParameters - (multiValues.length - 1);
+                                    noOfOverloadParameters = noOfOverloadParameters - 1;
                                 }
-                                lengthOfSavedParameters = lengthOfSavedParameters - (attributes.length - 1);
                             }
-                            if (overload.length === lengthOfSavedParameters) {
+                            if (noOfOverloadParameters === lengthOfSavedParameters) {
                                 sameParameterLengths.sameLength = sameParameterLengths.sameLength + 1;
-                                nameWithUniqueOverload += overload + ",";
+                                nameWithUniqueOverload += overload;
                             }
-                        }
-                        if (overload.length !== 0) {
-                            nameWithUniqueOverload = nameWithUniqueOverload.slice(0, -1);
                         }
                         nameWithUniqueOverload += ")";
                         functionName = nameWithUniqueOverload;
@@ -2536,20 +2536,12 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
             var savedParamIndex = 0;
             for (var i = 0; i < predefinedParameters.length; i++) {
                 var name = "Parameter " + (i + 1);
-                //Temporarily this variable is required until this property is added in the siddhi level
-                var isAttribute = false;
                 if (i < lengthOfSavedParameters) {
                     var savedValue = savedParameters[savedParamIndex];
-                    if (predefinedParameters[i].name === Constants.ATTRIBUTE) {
-                        isAttribute = true;
+                    if (predefinedParameters[i].isMultiValue) {
                         var parameterValue = [];
                         for (var j = i; j < savedParameters.length; j++) {
-                            var parameter = savedParameters[j].toLowerCase();
-                            if (parameter === Constants.ASC || parameter === Constants.DESC) {
-                                break;
-                            } else {
-                                parameterValue.push(savedParameters[j]);
-                            }
+                            parameterValue.push(savedParameters[j]);
                         }
                         savedValue = parameterValue;
                         lengthOfSavedParameters = lengthOfSavedParameters - (parameterValue.length - 1);
@@ -2557,18 +2549,18 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
                     }
                     parameters.push({
                         name: name, value: savedValue, optional: predefinedParameters[i].optional,
-                        isAttribute: isAttribute
+                        isMultiValue: predefinedParameters[i].isMultiValue
                     });
                 } else {
                     var value;
-                    if (name === Constants.ATTRIBUTE) {
+                    if (predefinedParameters[i].isMultiValue) {
                         value = [""];
-                        isAttribute = true;
                     } else {
                         value = ""
                     }
                     parameters.push({
-                        name: name, value: value, optional: predefinedParameters[i].optional
+                        name: name, value: value, optional: predefinedParameters[i].optional,
+                        isMultiValue: predefinedParameters[i].isMultiValue
                     });
                 }
                 savedParamIndex++;
@@ -2584,20 +2576,12 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
             var lengthOfSavedParameters = savedParameters.length;
             var savedParamIndex = 0;
             for (var i = 0; i < predefinedParameters.length; i++) {
-                var isAttribute = false;
                 if (i < lengthOfSavedParameters) {
                     var savedValue = savedParameters[savedParamIndex];
-                    if (predefinedParameters[i].name === Constants.ATTRIBUTE) {
-                        //Temporarily this variable is required until this property is added in the siddhi level
-                        isAttribute = true;
+                    if (predefinedParameters[i].isMultiValue) {
                         var parameterValue = [];
                         for (var j = i; j < savedParameters.length; j++) {
-                            var parameter = savedParameters[j].toLowerCase();
-                            if (parameter === Constants.ASC || parameter === Constants.DESC) {
-                                break;
-                            } else {
-                                parameterValue.push(savedParameters[j]);
-                            }
+                            parameterValue.push(savedParameters[j]);
                         }
                         savedValue = parameterValue;
                         lengthOfSavedParameters = lengthOfSavedParameters - (parameterValue.length - 1);
@@ -2606,20 +2590,21 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
                     parameters.push({
                         name: predefinedParameters[i].name, value: savedValue, description:
                         predefinedParameters[i].description, optional: predefinedParameters[i].optional,
-                        defaultValue: predefinedParameters[i].defaultValue, isAttribute: isAttribute
+                        defaultValue: predefinedParameters[i].defaultValue,
+                        isMultiValue: predefinedParameters[i].isMultiValue
                     });
                 } else {
                     var value;
-                    if (predefinedParameters[i].name === Constants.ATTRIBUTE) {
+                    if (predefinedParameters[i].isMultiValue) {
                         value = [""];
-                        isAttribute = true;
                     } else {
                         value = ""
                     }
                     parameters.push({
                         name: predefinedParameters[i].name, value: value, description: predefinedParameters[i]
                             .description, optional: predefinedParameters[i].optional,
-                        defaultValue: predefinedParameters[i].defaultValue, isAttribute: isAttribute
+                        defaultValue: predefinedParameters[i].defaultValue,
+                        isMultiValue: predefinedParameters[i].isMultiValue
                     });
                 }
                 savedParamIndex++;

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/form-utils.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/form-utils.js
@@ -550,9 +550,46 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
          * @param {String} id window or stream-function
          */
         FormUtils.prototype.renderFunctions = function (predefinedFunctions, className, id) {
+            var self = this;
+            var overloadParameters = self.getParameterOverloadNames(predefinedFunctions);
             var windowFunctionNameTemplate = Handlebars.compile($('#type-selection-form-template').html())
-            ({id: id, types: predefinedFunctions});
+            ({id: id, types: overloadParameters});
             $(className).find('.defineFunctionName').html(windowFunctionNameTemplate);
+        };
+
+        /**
+         * @function to construct the stream function or window name with overload parameters
+         * @param predefinedFunctions
+         * @returns {Array}
+         */
+        FormUtils.prototype.getParameterOverloadNames = function (predefinedFunctions) {
+            var overloadParameters = [];
+            _.forEach(predefinedFunctions, function (predefinedFunction) {
+                if (predefinedFunction.parameterOverloads) {
+                    _.forEach(predefinedFunction.parameterOverloads, function (overloads) {
+                        var possibleParamNames = predefinedFunction.name + "(";
+                        _.forEach(overloads, function (overload) {
+                            possibleParamNames = possibleParamNames + overload + ","
+                        });
+                        if (overloads.length !== 0) {
+                            possibleParamNames = possibleParamNames.slice(0, -1);
+                        }
+                        possibleParamNames = possibleParamNames + ")";
+                        overloadParameters.push({name: possibleParamNames});
+                    })
+                } else {
+                    var possibleParamNames = predefinedFunction.name + "(";
+                    _.forEach(predefinedFunction.parameters, function (parameter) {
+                        possibleParamNames = possibleParamNames + parameter.name + ","
+                    });
+                    if (predefinedFunction.parameters && predefinedFunction.parameters.length !== 0) {
+                        possibleParamNames = possibleParamNames.slice(0, -1);
+                    }
+                    possibleParamNames = possibleParamNames + ")";
+                    overloadParameters.push({name: possibleParamNames});
+                }
+            });
+            return overloadParameters;
         };
 
         /**
@@ -571,6 +608,24 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
             var parameterTemplate = Handlebars.compile($('#window-function-parameters-template').html())({
                 id: id,
                 parameters: parameterArray
+            });
+            $(parameterDiv).find('.defineFunctionParameters').html(parameterTemplate);
+            self.updatePerfectScroller();
+        };
+
+        /**
+         * @function to render parameters if a particular function has same no of parameters in 2 or more overloads
+         * @param {Object} parameters saved parameters
+         * @param {Object} supportedParameters
+         * @param {String} id window or stream-function
+         * @param {String} parameterDiv div to embed the parameters
+         */
+        FormUtils.prototype.renderUnknownParameters = function (parameters, supportedParameters, id, parameterDiv) {
+            var self = this;
+            var parameterTemplate = Handlebars.compile($('#window-function-unknown-parameters-template').html())({
+                id: id,
+                parameters: parameters,
+                predefinedParameters: supportedParameters
             });
             $(parameterDiv).find('.defineFunctionParameters').html(parameterTemplate);
             self.updatePerfectScroller();
@@ -858,7 +913,9 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
          * @return {object} parameters
          */
         FormUtils.prototype.getSelectedTypeParameters = function (selectedType, predefinedTypes) {
+            var self = this;
             var parameters = [];
+            selectedType = self.getFunctionNameWithoutParameterOverload(selectedType);
             _.forEach(predefinedTypes, function (type) {
                 if (type.name.toLowerCase() == selectedType.toLowerCase()) {
                     if (type.parameters) {
@@ -868,6 +925,48 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
                 }
             });
             return parameters;
+        };
+
+        /**
+         * @function to return the function name if it is concated with the parameter overloads
+         * @param functionName
+         * @returns {String}
+         */
+        FormUtils.prototype.getFunctionNameWithoutParameterOverload = function (functionName) {
+            if (functionName.includes("(")) {
+                return functionName.split("(")[0].trim();
+            }
+            return functionName;
+        };
+
+        /**
+         * @function to get only the parameters which are included in the overload
+         * @returns {Array}
+         */
+        FormUtils.prototype.getParameterOverloads = function (functionName, predefinedParameters) {
+            var parameterOverloads = [];
+            if (functionName.includes("(")) {
+                var regexToGetTextInsideBrackets = /\(([^)]+)\)/;
+                var overloads = regexToGetTextInsideBrackets.exec(functionName);
+                if (overloads) {
+                    overloads = overloads[1].trim();
+                    var overloadParameters = overloads.split(",");
+                    _.forEach(overloadParameters, function (overload) {
+                        overload = overload.trim();
+                        _.forEach(predefinedParameters, function (parameter) {
+                            if (overload === parameter.name) {
+                                parameterOverloads.push(parameter);
+                                return false;
+                            }
+                        });
+                    });
+                } else {
+                    parameterOverloads = predefinedParameters;
+                }
+            } else {
+                parameterOverloads = predefinedParameters;
+            }
+            return parameterOverloads;
         };
 
         /**
@@ -904,14 +1003,37 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
         /**
          * @function to obtain only the stream function names
          */
-        FormUtils.prototype.getStreamFunctionNames = function () {
+        FormUtils.prototype.getFunctionNames = function (functionType) {
             var self = this;
-            var streamFunctions = self.configurationData.rawExtensions["streamFunctions"];
-            var streamFunctionNames = [];
-            _.forEach(streamFunctions, function (streamFunction) {
-                streamFunctionNames.push(streamFunction.name);
+            var functions = [];
+            var functionNames = [];
+            if (functionType === Constants.STREAM_FUNCTION) {
+                functions = self.getParameterOverloadNames(self.configurationData.rawExtensions["streamFunctions"]);
+            } else if (functionType === Constants.AGGREGATE_FUNCTION) {
+                functions = self.getParameterOverloadNames(self.configurationData.rawExtensions["incrementalAggregators"]);
+            } else if (functionType === Constants.FUNCTION) {
+                functions = self.getParameterOverloadNames(self.configurationData.rawExtensions["functions"]);
+            }
+            _.forEach(functions, function (functionObject) {
+                functionNames.push(self.replaceDotsInParameterNamesWithUnderscore(functionObject.name));
             });
-            return streamFunctionNames;
+            return functionNames;
+        };
+
+        /**
+         * @function to replace the dots in the parameter names with underscores so that it will be easy for the user
+         * to edit the name
+         * @param parameterName
+         * @returns {String}
+         */
+        FormUtils.prototype.replaceDotsInParameterNamesWithUnderscore = function (parameterName) {
+            var name;
+            if (parameterName.includes(".")) {
+                name = parameterName.replace(/\./g, '_');
+            } else {
+                name = parameterName;
+            }
+            return name;
         };
 
         /**
@@ -1220,10 +1342,18 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
                             predefinedParameters = self.getPredefinedParameters(streamHandlerContent,
                                 self.configurationData.rawExtensions["streamFunctions"])
                         }
-                        if (self.validateParameters(streamHandlerContent, predefinedParameters)) {
-                            self.expandCollapsedDiv($(this));
-                            isErrorOccurred = true;
-                            return false;
+                        if (streamHandlerContent.find('.display-predefined-parameters').length === 0) {
+                            if (self.validateParameters(streamHandlerContent, predefinedParameters)) {
+                                self.expandCollapsedDiv($(this));
+                                isErrorOccurred = true;
+                                return false;
+                            }
+                        } else {
+                            if (self.validateUnknownParameters(streamHandlerContent)) {
+                                self.expandCollapsedDiv($(this));
+                                isErrorOccurred = true;
+                                return false;
+                            }
                         }
                     }
                 });
@@ -1235,8 +1365,10 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
          * @function to obtain the predefined parameters of particular window or stream-function type
          */
         FormUtils.prototype.getPredefinedParameters = function (div, predefinedFunctions) {
+            var self = this;
             var predefinedParameters = [];
-            var functionName = $(div).find('.defineFunctionName select').val().toLowerCase()
+            var functionName = self.getFunctionNameWithoutParameterOverload
+            ($(div).find('.defineFunctionName .custom-combobox-input').val().toLowerCase());
             _.forEach(predefinedFunctions, function (predefinedFunction) {
                 if (functionName == predefinedFunction.name.toLowerCase()) {
                     predefinedParameters = predefinedFunction.parameters;
@@ -1248,6 +1380,7 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
 
         /**
          * @function for generic validation of parameter values
+         * @param parameterDiv the div where the parameters are embedded
          * @param {Object} predefinedParameters predefined parameters of the selected window type
          * @return {boolean} isError
          */
@@ -1259,16 +1392,44 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
                 var parameterName = $(this).find('.parameter-name').text().trim();
                 var predefinedParameter = self.getObject(parameterName, predefinedParameters);
                 if (!predefinedParameter.optional) {
-                    if (!self.checkParameterValue(parameterValue, predefinedParameter, this)) {
+                    if (!self.checkParameterValue(parameterValue, predefinedParameter, this, true)) {
                         isError = true;
                         return false;
                     }
                 } else {
-                    if ($(this).find('.parameter-checkbox').is(":checked")) {
-                        if (!self.checkParameterValue(parameterValue, predefinedParameter, this)) {
+                    if ($(this).find('.param-content').hasClass('attribute-param')) {
+                        $(this).find('.parameter-value').each(function (attribute) {
+                            if (!self.checkParameterValue(attribute, predefinedParameter, this, false)) {
+                                isError = true;
+                                return false;
+                            }
+                        });
+                    } else {
+                        if (!self.checkParameterValue(parameterValue, predefinedParameter, this, false)) {
                             isError = true;
                             return false;
                         }
+                    }
+                }
+            });
+            return isError;
+        };
+
+        /**
+         * @function to validate the parameters which are unknown
+         * @param parameterDiv the div where the parameters are embedded
+         * @returns {boolean}
+         */
+        FormUtils.prototype.validateUnknownParameters = function (parameterDiv) {
+            var self = this;
+            var isError = false;
+            $(parameterDiv).find('.parameter').each(function () {
+                if($(this).find('.mandatory-symbol').length !== 0) {
+                    var parameterValue = $(this).find('.parameter-value');
+                    if(parameterValue.val().trim() === "") {
+                        isError = true;
+                        $(this).find('.error-message').text('Parameter Value is required.');
+                        self.addErrorClass(parameterValue);
                     }
                 }
             });
@@ -1413,7 +1574,9 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
                 }
             });
 
-            $("#stream-function-type").combobox();
+            $(".define-function-stream-handler select").combobox();
+            $(".define-window-stream-handler select").combobox();
+            $("#window-type").combobox();
             $("#toggle").on("click", function () {
                 $("#combobox").toggle();
             });
@@ -1424,26 +1587,29 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
          * @param {String} parameterValue value which needs to be validated
          * @param {Object} predefinedParameter predefined parameter object
          * @param {Object} parent div of the html to locate the parameter
+         * @param {boolean} checkForEmpty to enable empty check or not
          * @return {boolean}
          */
-        FormUtils.prototype.checkParameterValue = function (parameterValue, predefinedParameter, parent) {
+        FormUtils.prototype.checkParameterValue = function (parameterValue, predefinedParameter, parent, checkForEmpty) {
             var self = this;
-            if (parameterValue === "") {
+            if (parameterValue === "" && checkForEmpty) {
                 $(parent).find('.error-message').text('Parameter Value is required.');
                 self.addErrorClass($(parent).find('.parameter-value'));
                 return false;
             } else {
-                var dataType = predefinedParameter.type;
-                if (self.validateDataType(dataType, parameterValue)) {
-                    var errorMessage = "Invalid data-type. ";
-                    _.forEach(dataType, function (type) {
-                        errorMessage += type + " or ";
-                    });
-                    errorMessage = errorMessage.substring(0, errorMessage.length - 4);
-                    errorMessage += " is required";
-                    $(parent).find('.error-message').text(errorMessage);
-                    self.addErrorClass($(parent).find('.parameter-value'));
-                    return false;
+                if (parameterValue !== "") {
+                    var dataType = predefinedParameter.type;
+                    if (self.validateDataType(dataType, parameterValue)) {
+                        var errorMessage = "Invalid data-type. ";
+                        _.forEach(dataType, function (type) {
+                            errorMessage += type + " or ";
+                        });
+                        errorMessage = errorMessage.substring(0, errorMessage.length - 4);
+                        errorMessage += " is required";
+                        $(parent).find('.error-message').text(errorMessage);
+                        self.addErrorClass($(parent).find('.parameter-value'));
+                        return false;
+                    }
                 }
             }
             return true;
@@ -1939,19 +2105,15 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
                         _.set(streamHandlerOptions, 'value', filterCondition);
                     } else if (streamHandlerContent.hasClass('define-window-stream-handler') ||
                         streamHandlerContent.hasClass('define-function-stream-handler')) {
-                        var functionName = streamHandlerContent.find('.defineFunctionName select').val();
+                        var functionName = self.getFunctionNameWithoutParameterOverload(streamHandlerContent.find
+                        ('.defineFunctionName .custom-combobox-input').val());
                         var parameters;
-                        var predefinedFunctions;
                         var handlerType;
-                        var predefinedParameters;
                         if (streamHandlerContent.hasClass('define-window-stream-handler')) {
-                            predefinedFunctions = self.configurationData.rawExtensions["windowFunctionNames"]
-                            parameters = self.buildWindowParameters(streamHandlerContent, functionName, predefinedFunctions)
+                            parameters = self.buildParameterValues(streamHandlerContent);
                             handlerType = Constants.WINDOW.toUpperCase()
                         } else {
-                            predefinedFunctions = self.configurationData.rawExtensions["streamFunctions"]
-                            predefinedParameters = self.getPredefinedParameters(streamHandlerContent, predefinedFunctions);
-                            parameters = self.buildParameterValues(streamHandlerContent, predefinedParameters)
+                            parameters = self.buildParameterValues(streamHandlerContent);
                             handlerType = Constants.FUNCTION.toUpperCase()
                         }
                         var windowFunctionOptions = {};
@@ -1969,99 +2131,20 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
         };
 
         /**
-         * @function to build the parameters of window
-         */
-        FormUtils.prototype.buildWindowParameters = function (div, selectedType, predefinedFunctions) {
-            var self = this;
-            var parameters = [];
-            var predefinedParameters = self.getPredefinedParameters(div, predefinedFunctions)
-            if (selectedType.toLowerCase() === Constants.SORT) {
-                parameters = self.buildParameterValuesSort(div)
-            } else if (selectedType.toLowerCase() === Constants.FREQUENT ||
-                selectedType.toLowerCase() === Constants.LOSSY_FREQUENT) {
-                parameters = self.buildParameterValuesFrequentOrLossyFrequent(div,
-                    predefinedParameters)
-            } else {
-                parameters = self.buildParameterValues(div, predefinedParameters);
-            }
-            return parameters;
-        };
-
-        /**
          * @function to build the parameter values
          * @param {Object} div division where the parameters are in html
          * @param {Object} predefinedParameters predefined parameters
          */
-        FormUtils.prototype.buildParameterValues = function (div, predefinedParameters) {
+        FormUtils.prototype.buildParameterValues = function (div) {
             var self = this;
             var parameterValues = [];
-            $(div).find('.parameter').each(function () {
-                if ($(this).find('.parameter-name').hasClass('mandatory-parameter') || ($(this).find('.parameter-name')
-                    .hasClass('optional-parameter') && $(this).find('.parameter-checkbox').is(":checked"))) {
-                    var parameterValue = $(this).find('.parameter-value').val().trim();
-                    var parameterName = $(this).find('.parameter-name').text().trim();
-                    ;
-                    var predefinedParameter = self.getObject(parameterName, predefinedParameters);
-                    if (predefinedParameter.type.includes("STRING")) {
-                        parameterValue = "'" + parameterValue + "'";
-                    }
-                    parameterValues.push(parameterValue);
-                }
-            });
-            return parameterValues;
-        };
-
-        /**
-         * @function to build parameters for sort type
-         * @param {Object} div where the parameters are in html
-         * @returns {Object} parameterValues
-         */
-        FormUtils.prototype.buildParameterValuesSort = function (div) {
-            var self = this;
-            var parameterValues = [];
-            $(div).find('.parameter').each(function () {
-                var parameterValue = $(this).find('.parameter-value').val().trim();
-                var parameterName = $(this).find('.parameter-name').text().trim();
-                ;
-                if (parameterName === "window.length") {
-                    parameterValues.push(parameterValue)
-                } else if (parameterName === "attribute") {
-                    if ($('#attribute-parameter').find('.parameter-checkbox').is(":checked")) {
-                        self.buildAttributes(parameterValue, parameterValues);
-                    }
+            $(div).find('.parameter .param-content').each(function () {
+                if ($(this).hasClass('attribute-param')) {
+                    self.buildAttributesParameters($(this), parameterValues);
                 } else {
-                    if (($('#attribute-parameter').find('.parameter-checkbox').is(":checked")) && ($
-                    ('#order-parameter').find('.parameter-checkbox').is(":checked"))) {
-                        parameterValue = "'" + parameterValue + "'";
-                        parameterValues.push(parameterValue)
-                    }
-                }
-            });
-            return parameterValues;
-        };
-
-        /**
-         * @function to build parameters for frequent and lossyFrequent type
-         * @param {Object} div where the parameters are in html
-         * @param {Object} predefinedParameters predefined parameters
-         * @returns {Object} parameterValues
-         */
-        FormUtils.prototype.buildParameterValuesFrequentOrLossyFrequent = function (div, predefinedParameters) {
-            var self = this;
-            var parameterValues = [];
-            $(div).find('.parameter').each(function () {
-                if ($(this).find('.parameter-name').hasClass('mandatory-parameter') || ($(this).find('.parameter-name')
-                    .hasClass('optional-parameter') && $(this).find('.parameter-checkbox').is(":checked"))) {
                     var parameterValue = $(this).find('.parameter-value').val().trim();
-                    var parameterName = $(this).find('.parameter-name').text().trim();
-                    var predefinedParameter = self.getObject(parameterName, predefinedParameters);
-                    if (parameterName === "attribute") {
-                        self.buildAttributes(parameterValue, parameterValues);
-                    } else {
-                        if (predefinedParameter.type.includes("STRING")) {
-                            parameterValue = "'" + parameterValue + "'";
-                        }
-                        parameterValues.push(parameterValue)
+                    if (parameterValue !== "") {
+                        parameterValues.push(parameterValue);
                     }
                 }
             });
@@ -2073,12 +2156,11 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
          * @param {String} parameterValue the attribute value
          * @param {Object} parameterValues array to add the parameters
          */
-        FormUtils.prototype.buildAttributes = function (parameterValue, parameterValues) {
-            var attributeArray = parameterValue.split(',');
-            _.forEach(attributeArray, function (attribute) {
-                attribute = attribute.trim();
-                if (attribute !== "") {
-                    parameterValues.push(attribute);
+        FormUtils.prototype.buildAttributesParameters = function (attributeContent, parameterValues) {
+            $(attributeContent).find('.parameter-value').each(function () {
+                var parameterValue = $(this).val().trim();
+                if (parameterValue !== "") {
+                    parameterValues.push(parameterValue);
                 }
             });
         };
@@ -2313,8 +2395,6 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
             self.removeNavigationForWindow(sourceDiv)
             self.showHideStreamHandlerWindowButton(sourceDiv)
             self.preventMultipleSelectionOfWindowStreamHandler(sourceDiv)
-            self.addEventListenersForParameterDiv();
-            self.showDropDown();
         };
 
         /**
@@ -2337,46 +2417,214 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
                 var predefinedWindowFunctions = _.orderBy(JSON.parse(JSON.stringify
                 (self.configurationData.rawExtensions["windowFunctionNames"]), ['name'], ['asc']));
                 self.renderFunctions(predefinedWindowFunctions, div, Constants.WINDOW);
-                self.mapStreamHandlerWindow(div, predefinedWindowFunctions, streamHandler);
+                self.showDropDown();
+                self.mapParameterValues(streamHandler, div, false);
             } else if (type === Constants.FUNCTION) {
                 var predefinedStreamFunctions = _.orderBy(JSON.parse(JSON.stringify
                 (self.configurationData.rawExtensions["streamFunctions"]), ['name'], ['asc']));
                 self.renderFunctions(predefinedStreamFunctions, div, Constants.STREAM_FUNCTION);
-                self.mapStreamHandlerStreamFunction(div, predefinedStreamFunctions, streamHandler)
+                self.showDropDown();
+                self.mapParameterValues(streamHandler, div, false);
             }
         };
 
         /**
-         * @function to map the window stream handler
+         * @function to map the parameters of the stream function/window
+         * @param streamHandler object which has the stream handler to be mapped
+         * @param div the div to embed the parameters
+         * @param onChange to check if the method is called on change of the drop-down or on load of the form
          */
-        FormUtils.prototype.mapStreamHandlerWindow = function (div, predefinedFunctions, streamHandler) {
+        FormUtils.prototype.mapParameterValues = function (streamHandler, div, onChange) {
             var self = this;
-            var windowType = streamHandler.value.function.toLowerCase();
-            $(div).find('#window-type option').filter(function () {
-                return ($(this).val().toLowerCase() == (windowType));
-            }).prop('selected', true);
-            var savedParameterValues = streamHandler.value.parameters;
-            var functionParameters = self.getSelectedTypeParameters(windowType, predefinedFunctions);
-            self.callToMapParameters(windowType, functionParameters, savedParameterValues, div)
-            if (windowType === Constants.SORT) {
-                self.showHideOrderForSort();
-                self.addEventListenerForSortWindow(selectedType)
+            var predefinedFunctions;
+            var functionName;
+            var parameters;
+            var savedType = streamHandler.value.function.toLowerCase();
+            var savedParameters = streamHandler.value.parameters;
+            var windowFunctionType = streamHandler.type.toLowerCase();
+            var parameterLength = {sameLength: 0};
+            if (windowFunctionType === Constants.WINDOW) {
+                predefinedFunctions = _.orderBy(_.cloneDeep
+                (self.configurationData.rawExtensions["windowFunctionNames"]), ['name'], ['asc']);
+            } else {
+                predefinedFunctions = _.orderBy(_.cloneDeep
+                (self.configurationData.rawExtensions["streamFunctions"]), ['name'], ['asc']);
             }
+            var functionParameters = self.getSelectedTypeParameters(savedType, predefinedFunctions);
+            if (!onChange) {
+                functionName = self.getFunctionNameWithParameterOverloads(predefinedFunctions, savedType,
+                    savedParameters, parameterLength)
+            } else {
+                functionName = savedType;
+            }
+            var overloadParameters = self.getParameterOverloads(functionName, functionParameters);
+            if (parameterLength.sameLength > 1 && !onChange) {
+                $(div).find('.custom-combobox-input').val(self.getFunctionNameWithoutParameterOverload(functionName));
+                parameters = self.createObjectsForUnknownParameters(functionParameters, savedParameters);
+                self.renderUnknownParameters(parameters, functionParameters, windowFunctionType, div);
+            } else {
+                $(div).find('.custom-combobox-input').val(functionName);
+                parameters = self.createObjectsForKnownParameters(overloadParameters, savedParameters);
+                self.renderParameters(parameters, windowFunctionType, div);
+            }
+            $('.attribute-param .attribute-param-value:first .btn-del-option').remove();
+            $('.attribute-param .attribute-param-value:first')
+                .append('<button class="btn btn-default btn-add-param-attribute"> + </button>');
+
+            self.addEventListenersForParameterDiv();
         };
 
         /**
-         * @function to map the stream function stream handler
+         * @function to construct the function name with corresponding parameter overload when the form is opened
          */
-        FormUtils.prototype.mapStreamHandlerStreamFunction = function (div, predefinedFunctions, streamHandler) {
-            var self = this;
-            var functionType = streamHandler.value.function.toLowerCase();
-            $(div).find('#stream-function-type option').filter(function () {
-                return ($(this).val().toLowerCase() == (functionType));
-            }).prop('selected', true);
-            var savedParameterValues = streamHandler.value.parameters;
-            var functionParameters = self.getSelectedTypeParameters(functionType, predefinedFunctions);
-            var functionParametersWithValues = self.mapUserParameterValues(functionParameters, savedParameterValues);
-            self.renderParameters(functionParametersWithValues, Constants.STREAM_FUNCTION, div);
+        FormUtils.prototype.getFunctionNameWithParameterOverloads = function (predefinedFunctions, savedType,
+                                                                              savedParameters, sameParameterLengths) {
+            var functionName = "";
+            _.forEach(predefinedFunctions, function (predefinedFunction) {
+                if (predefinedFunction.name.toLowerCase() === savedType) {
+                    if (predefinedFunction.parameterOverloads) {
+                        var nameWithUniqueOverload = predefinedFunction.name + "(";
+                        for (var i = 0; i < predefinedFunction.parameterOverloads.length; i++) {
+                            var overload = predefinedFunction.parameterOverloads[i];
+                            var lengthOfSavedParameters = savedParameters.length;
+                            if (overload.includes(Constants.ATTRIBUTE)) {
+                                var attributeIndex = overload.indexOf(Constants.ATTRIBUTE);
+                                var attributes = [];
+                                for (var j = attributeIndex; j < savedParameters.length; j++) {
+                                    var parameter = savedParameters[j].substring(1, savedParameters[j].length - 1)
+                                        .toLowerCase();
+                                    if (parameter === Constants.ASC || parameter === Constants.DESC) {
+                                        break;
+                                    } else {
+                                        attributes.push(savedParameters[j])
+                                    }
+                                }
+                                lengthOfSavedParameters = lengthOfSavedParameters - (attributes.length - 1);
+                            }
+                            if (overload.length === lengthOfSavedParameters) {
+                                sameParameterLengths.sameLength = sameParameterLengths.sameLength + 1;
+                                nameWithUniqueOverload += overload + ",";
+                            }
+                        }
+                        if (overload.length !== 0) {
+                            nameWithUniqueOverload = nameWithUniqueOverload.slice(0, -1);
+                        }
+                        nameWithUniqueOverload += ")";
+                        functionName = nameWithUniqueOverload;
+                    } else {
+                        var nameWithAllParameters = predefinedFunction.name + "(";
+                        _.forEach(predefinedFunction.parameters, function (parameter) {
+                            nameWithAllParameters += parameter.name + ",";
+                        });
+                        if (predefinedFunction.parameters && predefinedFunction.parameters.length !== 0) {
+                            nameWithAllParameters = nameWithAllParameters.slice(0, -1);
+                        }
+                        nameWithAllParameters += ")";
+                        functionName = nameWithAllParameters
+                    }
+                }
+            });
+            return functionName;
+        };
+
+        /**
+         * @function to create parameter objects for unknown parameters
+         */
+        FormUtils.prototype.createObjectsForUnknownParameters = function (predefinedParameters, savedParameters) {
+            var parameters = [];
+            var lengthOfSavedParameters = savedParameters.length;
+            var savedParamIndex = 0;
+            for (var i = 0; i < predefinedParameters.length; i++) {
+                var name = "Parameter " + (i + 1);
+                //Temporarily this variable is required until this property is added in the siddhi level
+                var isAttribute = false;
+                if (i < lengthOfSavedParameters) {
+                    var savedValue = savedParameters[savedParamIndex];
+                    if (predefinedParameters[i].name === Constants.ATTRIBUTE) {
+                        isAttribute = true;
+                        var parameterValue = [];
+                        for (var j = i; j < savedParameters.length; j++) {
+                            var parameter = savedParameters[j].toLowerCase();
+                            if (parameter === Constants.ASC || parameter === Constants.DESC) {
+                                break;
+                            } else {
+                                parameterValue.push(savedParameters[j]);
+                            }
+                        }
+                        savedValue = parameterValue;
+                        lengthOfSavedParameters = lengthOfSavedParameters - (parameterValue.length - 1);
+                        savedParamIndex = savedParamIndex + (parameterValue.length - 1);
+                    }
+                    parameters.push({
+                        name: name, value: savedValue, optional: predefinedParameters[i].optional,
+                        isAttribute: isAttribute
+                    });
+                } else {
+                    var value;
+                    if (name === Constants.ATTRIBUTE) {
+                        value = [""];
+                        isAttribute = true;
+                    } else {
+                        value = ""
+                    }
+                    parameters.push({
+                        name: name, value: value, optional: predefinedParameters[i].optional
+                    });
+                }
+                savedParamIndex++;
+            }
+            return parameters;
+        };
+
+        /**
+         * @function to create parameter objects for known parameters
+         */
+        FormUtils.prototype.createObjectsForKnownParameters = function (predefinedParameters, savedParameters) {
+            var parameters = [];
+            var lengthOfSavedParameters = savedParameters.length;
+            var savedParamIndex = 0;
+            for (var i = 0; i < predefinedParameters.length; i++) {
+                var isAttribute = false;
+                if (i < lengthOfSavedParameters) {
+                    var savedValue = savedParameters[savedParamIndex];
+                    if (predefinedParameters[i].name === Constants.ATTRIBUTE) {
+                        //Temporarily this variable is required until this property is added in the siddhi level
+                        isAttribute = true;
+                        var parameterValue = [];
+                        for (var j = i; j < savedParameters.length; j++) {
+                            var parameter = savedParameters[j].toLowerCase();
+                            if (parameter === Constants.ASC || parameter === Constants.DESC) {
+                                break;
+                            } else {
+                                parameterValue.push(savedParameters[j]);
+                            }
+                        }
+                        savedValue = parameterValue;
+                        lengthOfSavedParameters = lengthOfSavedParameters - (parameterValue.length - 1);
+                        savedParamIndex = savedParamIndex + (parameterValue.length - 1);
+                    }
+                    parameters.push({
+                        name: predefinedParameters[i].name, value: savedValue, description:
+                        predefinedParameters[i].description, optional: predefinedParameters[i].optional,
+                        defaultValue: predefinedParameters[i].defaultValue, isAttribute: isAttribute
+                    });
+                } else {
+                    var value;
+                    if (predefinedParameters[i].name === Constants.ATTRIBUTE) {
+                        value = [""];
+                        isAttribute = true;
+                    } else {
+                        value = ""
+                    }
+                    parameters.push({
+                        name: predefinedParameters[i].name, value: value, description: predefinedParameters[i]
+                            .description, optional: predefinedParameters[i].optional,
+                        defaultValue: predefinedParameters[i].defaultValue, isAttribute: isAttribute
+                    });
+                }
+                savedParamIndex++;
+            }
+            return parameters;
         };
 
         /**
@@ -2392,180 +2640,11 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
                         predefinedAnnotation.values = [];
                         _.forEach(savedAnnotation.elements, function (element) {
                             predefinedAnnotation.values.push({value: element.value});
-                        })
+                        });
                         return false;
                     }
                 })
             });
-        };
-
-        /**
-         * @function to map the saved parameter values to the parameter object
-         * @param {Object} predefinedParameters Predefined parameters of a particular window type
-         * @param {Object} savedParameterValues Saved parameter values
-         * @return {Object} parameters
-         */
-        FormUtils.prototype.mapUserParameterValues = function (predefinedParameters, savedParameterValues) {
-            var parameters = [];
-            for (var i = 0; i < predefinedParameters.length; i++) {
-                var timeStamp = "";
-                if (i < savedParameterValues.length) {
-                    var parameterValue = savedParameterValues[i];
-                    if (predefinedParameters[i].type.includes("STRING")) {
-                        parameterValue = parameterValue.slice(1, parameterValue.length - 1)
-                    }
-                    parameters.push({
-                        name: predefinedParameters[i].name, value: parameterValue, description:
-                        predefinedParameters[i].description, optional: predefinedParameters[i].optional,
-                        defaultValue: predefinedParameters[i].defaultValue, timeStamp: timeStamp
-                    });
-                } else {
-                    parameters.push({
-                        name: predefinedParameters[i].name, value: "", description: predefinedParameters[i]
-                            .description, optional: predefinedParameters[i].optional,
-                        defaultValue: predefinedParameters[i].defaultValue, timeStamp: timeStamp
-                    });
-                }
-            }
-            return parameters;
-        };
-
-        /**
-         * @function to map the user saved parameters of lossyFrequent
-         * @param {Object} predefinedParameters predefined parameters
-         * @param {Object} savedParameterValues user saved parameters
-         * @return {Object} parameters
-         *
-         */
-        FormUtils.prototype.mapParameterValuesLossyFrequent = function (predefinedParameters, savedParameterValues) {
-            var parameters = [];
-            var attributes = "";
-            //add the two mandatory params of the saved values to the predefined param objects
-            for (var i = 0; i <= 1; i++) {
-                parameters.push({
-                    name: predefinedParameters[i].name, value: savedParameterValues[i], description:
-                    predefinedParameters[i].description, optional: predefinedParameters[i].optional,
-                    defaultValue: predefinedParameters[i].defaultValue
-                });
-            }
-            // add the attributes
-            for (var i = 2; i < savedParameterValues.length; i++) {
-                attributes += savedParameterValues[i] + ", "
-            }
-            //cutting off the last white space and the comma
-            attributes = attributes.substring(0, attributes.length - 2);
-            //add the attributes to the third obj of the predefined parameter
-            parameters.push({
-                name: predefinedParameters[2].name, value: attributes, description:
-                predefinedParameters[2].description, optional: predefinedParameters[2].optional,
-                defaultValue: predefinedParameters[2].defaultValue
-            });
-            return parameters;
-        };
-
-        /**
-         * @function to map the user saved parameters of frequent
-         * @param {Object} predefinedParameters predefined parameters
-         * @param {Object} savedParameterValues user saved parameters
-         * @return {Object} parameters
-         */
-        FormUtils.prototype.mapParameterValuesFrequent = function (predefinedParameters, savedParameterValues) {
-            var parameters = [];
-            var attributes = "";
-            //add the first saved param to predefined param's first index (event.count)
-            parameters.push({
-                name: predefinedParameters[0].name, value: savedParameterValues[0], description:
-                predefinedParameters[0].description, optional: predefinedParameters[0].optional,
-                defaultValue: predefinedParameters[0].defaultValue
-            });
-            // add the attributes
-            for (var i = 1; i < savedParameterValues.length; i++) {
-                attributes += savedParameterValues[i] + ", "
-            }
-            //cutting off the last white space and the comma
-            attributes = attributes.substring(0, attributes.length - 2);
-            //add the attributes to second obj of the predefined parameter
-            parameters.push({
-                name: predefinedParameters[1].name, value: attributes, description:
-                predefinedParameters[1].description, optional: predefinedParameters[1].optional,
-                defaultValue: predefinedParameters[1].defaultValue
-            });
-            return parameters;
-        };
-
-        /**
-         * @function to map the user saved parameters of sort
-         * @param {Object} predefinedParameters predefined parameters
-         * @param {Object} savedParameterValues user saved parameters
-         * @return {Object} parameters
-         */
-        FormUtils.prototype.mapParameterValuesSort = function (predefinedParameters, savedParameterValues) {
-            var parameters = [];
-            var attributes = "";
-            var order = "";
-            var length = "";
-            if (savedParameterValues.length != 0) {
-                length = savedParameterValues[0];
-            }
-            //add the first saved param to predefined param's first index (window.length)
-            parameters.push({
-                name: predefinedParameters[0].name, value: length, description:
-                predefinedParameters[0].description, optional: predefinedParameters[0].optional,
-                defaultValue: predefinedParameters[0].defaultValue
-            });
-            // to determine the attributes and order
-            if (savedParameterValues.length > 1) {
-                for (var i = 1; i < savedParameterValues.length; i++) {
-                    if (savedParameterValues[i].indexOf("'") >= 0 || savedParameterValues[i].indexOf('"') >= 0) {
-                        order = savedParameterValues[i];
-                        order = order.slice(1, order.length - 1)
-                    } else {
-                        //attributes
-                        attributes += savedParameterValues[i] + ", ";
-
-                    }
-                }
-                //cutting off the last white space and the comma
-                attributes = attributes.substring(0, attributes.length - 2);
-            }
-            //add the attributes to second obj of the predefined parameter
-            parameters.push({
-                name: predefinedParameters[1].name, value: attributes, description:
-                predefinedParameters[1].description, optional: predefinedParameters[1].optional,
-                defaultValue: predefinedParameters[1].defaultValue
-            });
-            //add the order to the third obj of the predefined parameter
-            parameters.push({
-                name: predefinedParameters[2].name, value: order, description:
-                predefinedParameters[2].description, optional: predefinedParameters[2].optional,
-                defaultValue: predefinedParameters[2].defaultValue
-            });
-            return parameters;
-        };
-
-        /**
-         * Function to select the parameter mapping method
-         * @param {String} selectedType selected window type
-         * @param {Object} functionParameters parameters of the selected window type
-         * @param {Object} savedParameterValues saved parameter values
-         * @param {Object} functionParametersWithValues array to hold the parameter of the mapped value
-         */
-        FormUtils.prototype.callToMapParameters = function (selectedType, functionParameters, savedParameterValues,
-                                                            parameterDiv) {
-            var self = this;
-            var functionParametersWithValues;
-            if (selectedType === Constants.SORT) {
-                functionParametersWithValues = self.mapParameterValuesSort(functionParameters, savedParameterValues);
-            } else if (selectedType === Constants.FREQUENT) {
-                functionParametersWithValues = self.mapParameterValuesFrequent(functionParameters,
-                    savedParameterValues);
-            } else if (selectedType === Constants.LOSSY_FREQUENT) {
-                functionParametersWithValues = self.mapParameterValuesLossyFrequent(functionParameters,
-                    savedParameterValues);
-            } else {
-                functionParametersWithValues = self.mapUserParameterValues(functionParameters, savedParameterValues);
-            }
-            self.renderParameters(functionParametersWithValues, Constants.WINDOW, parameterDiv);
         };
 
         /**
@@ -2588,7 +2667,6 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
                     $(this).find('.group-by-selection option').filter(function () {
                         return ($(this).val().includes(attributes[i]));
                     }).prop('selected', true);
-                    ;
                 }
                 i++;
             });
@@ -3325,6 +3403,21 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
                 }
                 self.updatePerfectScroller();
             });
+
+            //event listener to delete an attribute of the attribute parameters
+            $('.defineFunctionParameters').on('click', '.btn-del-option', function () {
+                $(this).parents('.attribute-param-value').remove();
+                self.updatePerfectScroller();
+            });
+
+            var attributeParam =  '<div class="attribute-param-value">' +
+                '<input class = "parameter-value" type = "text" value = ""> ' +
+                '<a class = "btn-del-option"> <i class = "fw fw-delete"> </i></a> </div>';
+            //event listener to add an attribute of the attribute parameter
+            $('.btn-add-param-attribute').on('click', function () {
+                $(this).parents('.attribute-param').append(attributeParam);
+                self.updatePerfectScroller();
+            });
         };
 
         /**
@@ -3406,18 +3499,34 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
         FormUtils.prototype.addAutoCompleteForSelectExpressions = function (attributes, elementType) {
             var self = this;
             var incrementalAggregator = self.addLabelsForAutocompleteDropDowns
-            (self.configurationData.application.config.incremental_aggregator, Constants.AGGREGATE_FUNCTION);
-            var streamFunctions = self.addLabelsForAutocompleteDropDowns
-            (self.getStreamFunctionNames(), Constants.STREAM_FUNCTION);
+            (self.getFunctionNames(Constants.AGGREGATE_FUNCTION), Constants.AGGREGATE_FUNCTION);
+            var functions = self.addLabelsForAutocompleteDropDowns
+            (self.getFunctionNames(Constants.FUNCTION), Constants.FUNCTION);
             var selectExpressionMatches = self.addLabelsForAutocompleteDropDowns
             (attributes, Constants.ATTRIBUTE);
             selectExpressionMatches = selectExpressionMatches.concat(incrementalAggregator);
-            selectExpressionMatches = selectExpressionMatches.concat(streamFunctions);
+            selectExpressionMatches = selectExpressionMatches.concat(functions);
             if (elementType === Constants.AGGREGATION) {
                 selectExpressionMatches = selectExpressionMatches.concat(self.addLabelsForAutocompleteDropDowns
                 ([Constants.AS], Constants.KEYWORD));
             }
             self.createAutocomplete($('.attribute-expression'), selectExpressionMatches);
+        };
+
+        /**
+         * @function to add auto-complete for attributes of stream and window functions
+         */
+        FormUtils.prototype.addAutoCompleteForStreamWindowFunctionAttributes = function (attributes) {
+            var self = this;
+            var matches = self.addLabelsForAutocompleteDropDowns
+            (attributes, Constants.ATTRIBUTE);
+            var incrementalAggregator = self.addLabelsForAutocompleteDropDowns
+            (self.getFunctionNames(Constants.AGGREGATE_FUNCTION), Constants.AGGREGATE_FUNCTION);
+            var functions = self.addLabelsForAutocompleteDropDowns
+            (self.getFunctionNames(Constants.FUNCTION), Constants.FUNCTION);
+            matches = matches.concat(incrementalAggregator);
+            matches = matches.concat(functions);
+            self.createAutocomplete($('.parameter-value'), matches);
         };
 
         /**
@@ -3428,12 +3537,12 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
             var queryOperators = self.addLabelsForAutocompleteDropDowns
             (self.configurationData.application.config.query_operators, Constants.OPERATOR)
             var incrementalAggregator = self.addLabelsForAutocompleteDropDowns
-            (self.configurationData.application.config.incremental_aggregator, Constants.AGGREGATE_FUNCTION);
-            var streamFunctions = self.addLabelsForAutocompleteDropDowns
-            (self.getStreamFunctionNames(), Constants.STREAM_FUNCTION);
+            (self.getFunctionNames(Constants.AGGREGATE_FUNCTION), Constants.AGGREGATE_FUNCTION);
+            var functions = self.addLabelsForAutocompleteDropDowns
+            (self.getFunctionNames(Constants.FUNCTION), Constants.FUNCTION);
             var filterMatches = self.addLabelsForAutocompleteDropDowns
             (attributes, Constants.ATTRIBUTE).concat(incrementalAggregator);
-            filterMatches = filterMatches.concat(streamFunctions);
+            filterMatches = filterMatches.concat(functions);
             filterMatches = filterMatches.concat(queryOperators);
             self.createAutocomplete($('.filter-condition-content '), filterMatches);
         };
@@ -3488,14 +3597,14 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
             var queryOperators = self.addLabelsForAutocompleteDropDowns
             (self.configurationData.application.config.query_operators, Constants.OPERATOR);
             var incrementalAggregator = self.addLabelsForAutocompleteDropDowns
-            (self.configurationData.application.config.incremental_aggregator, Constants.AGGREGATE_FUNCTION);
-            var streamFunctions = self.addLabelsForAutocompleteDropDowns
-            (self.getStreamFunctionNames(), Constants.STREAM_FUNCTION);
+            (self.getFunctionNames(Constants.AGGREGATE_FUNCTION), Constants.AGGREGATE_FUNCTION);
+            var functions = self.addLabelsForAutocompleteDropDowns
+            (self.getFunctionNames(Constants.FUNCTION), Constants.FUNCTION);
             var onConditionMatches = self.addLabelsForAutocompleteDropDowns(attributes, Constants.ATTRIBUTE);
             onConditionMatches = onConditionMatches.concat(self.addLabelsForAutocompleteDropDowns
             (inputSources, Constants.INPUT));
             onConditionMatches = onConditionMatches.concat(incrementalAggregator);
-            onConditionMatches = onConditionMatches.concat(streamFunctions);
+            onConditionMatches = onConditionMatches.concat(functions);
             onConditionMatches = onConditionMatches.concat(queryOperators);
             self.createAutocomplete($('.on-condition-value'), onConditionMatches);
             self.createAutocomplete($('.define-operation-on-condition .query-content-value'), onConditionMatches)
@@ -3520,16 +3629,15 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
             var queryOperators = self.addLabelsForAutocompleteDropDowns
             (self.configurationData.application.config.query_operators, Constants.OPERATOR);
             var incrementalAggregator = self.addLabelsForAutocompleteDropDowns
-            (self.configurationData.application.config.incremental_aggregator, Constants.AGGREGATE_FUNCTION);
-            var streamFunctions = self.addLabelsForAutocompleteDropDowns
-            (self.getStreamFunctionNames(), Constants.STREAM_FUNCTION);
+            (self.getFunctionNames(Constants.AGGREGATE_FUNCTION), Constants.AGGREGATE_FUNCTION);
+            var functions = self.addLabelsForAutocompleteDropDowns
+            (self.getFunctionNames(Constants.FUNCTION), Constants.FUNCTION);
             var havingMatches = self.addLabelsForAutocompleteDropDowns(attributes, Constants.ATTRIBUTE);
             havingMatches = havingMatches.concat(incrementalAggregator);
-            havingMatches = havingMatches.concat(streamFunctions);
+            havingMatches = havingMatches.concat(functions);
             havingMatches = havingMatches.concat(queryOperators);
             self.createAutocomplete($('.having-value'), havingMatches);
         };
-
 
 
         /**
@@ -3599,20 +3707,6 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
          */
         FormUtils.prototype.isElementContentOverflown = function (element) {
             return element[0].scrollWidth > element[0].clientWidth;
-        };
-
-        /**
-         * @function to add event listeners for sort window type parameters
-         */
-        FormUtils.prototype.addEventListenerForSortWindow = function (selectedType) {
-            var self = this;
-            $('.defineFunctionParameters').on('change', '.parameter-checkbox', function () {
-                //check for sort type's parameter (order & attribute params)
-                if (selectedType === Constants.SORT) {
-                    self.showHideOrderForSort();
-                }
-                self.updatePerfectScroller();
-            });
         };
 
         /**
@@ -3691,7 +3785,7 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
          * @function to add event listeners for stream handler section
          * @param {Object} streamHandlerList list of stream handlers
          */
-        FormUtils.prototype.addEventListenersForStreamHandlersDiv = function (streamHandlerList) {
+        FormUtils.prototype.addEventListenersForStreamHandlersDiv = function (streamHandlerList, attributes) {
             var self = this;
 
             //on change of stream handler checkbox
@@ -3708,63 +3802,55 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
             });
 
             //on change of window type
-            var predefinedWindowFunctions = _.orderBy(JSON.parse(JSON.stringify
-            (self.configurationData.rawExtensions["windowFunctionNames"]), ['name'], ['asc']));
-            $('.define-stream-handler').on('change', '#window-type', function () {
-                var sourceDiv = self.getSourceDiv($(this))
-                if ($(sourceDiv).hasClass('define-left-source')) {
-                    var source = Constants.LEFT
-                } else {
-                    var source = Constants.RIGHT
-                }
-                var windowType;
-                var savedParameterValues;
-                var selectedType = this.value.toLowerCase();
-                var streamHandlerWindow = self.getStreamHandler(streamHandlerList, Constants.WINDOW, selectedType);
-                if (streamHandlerWindow) {
-                    windowType = streamHandlerWindow.value.function.toLowerCase();
-                    savedParameterValues = streamHandlerWindow.value.parameters;
-                }
-                var functionParameters = self.getSelectedTypeParameters(selectedType, predefinedWindowFunctions);
-                var parameterDiv = $(this).closest('.defineFunctionName').parents('.define-stream-handler-type-content');
-                if (savedParameterValues && selectedType == windowType) {
-                    self.callToMapParameters(selectedType, functionParameters, savedParameterValues, parameterDiv)
-                } else {
-                    var functionParametersWithValues = self.createObjectWithValues(functionParameters);
-                    self.renderParameters(functionParametersWithValues, Constants.WINDOW, parameterDiv);
-                }
-                if (selectedType === Constants.SORT) {
-                    self.showHideOrderForSort();
-                    self.addEventListenerForSortWindow(selectedType)
-                }
-            });
+            $(".define-stream-handler").on("autocompleteselect",
+                '.define-window-stream-handler .custom-combobox-input', function (event, ui) {
+                    var savedParameterValues = [];
+                    var selectedType = ui.item.value.toLowerCase();
+                    var streamHandlerWindow = self.getStreamHandler(streamHandlerList, Constants.WINDOW,
+                        self.getFunctionNameWithoutParameterOverload(selectedType));
+                    if (streamHandlerWindow) {
+                        savedParameterValues = streamHandlerWindow.value.parameters;
+                    }
+                    var streamHandler = {
+                        type: Constants.WINDOW,
+                        value: {
+                            function: selectedType,
+                            parameters: savedParameterValues
+                        }
+                    };
+                    var parameterDiv = $(this).closest('.defineFunctionName').parents('.define-stream-handler-type-content');
+                    self.mapParameterValues(streamHandler, parameterDiv, true);
+                    self.addAutoCompleteForStreamWindowFunctionAttributes(attributes);
+                });
 
             //on change of stream-function type
-            var predefinedStreamFunctions = _.orderBy(JSON.parse(JSON.stringify
-            (self.configurationData.rawExtensions["streamFunctions"]), ['name'], ['asc']));
-            $(".define-stream-handler").on("autocompleteselect", '.custom-combobox-input', function (event, ui) {
-                var selectedType = ui.item.value.toLowerCase();
-                var functionType;
-                var savedParameterValues;
-                var streamHandlerFunction = self.getStreamHandler(streamHandlerList, Constants.FUNCTION, selectedType);
-                if (streamHandlerFunction) {
-                    functionType = streamHandlerFunction.value.function.toLowerCase();
-                    savedParameterValues = streamHandlerFunction.value.parameters;
-                }
-                var functionParameters = self.getSelectedTypeParameters(selectedType, predefinedStreamFunctions);
-                var parameterDiv = $(this).closest('.defineFunctionName').parents('.define-stream-handler-type-content');
-                if (savedParameterValues && selectedType == functionType) {
-                    self.callToMapParameters(selectedType, functionParameters, savedParameterValues, parameterDiv)
-                } else {
-                    functionParametersWithValues = self.createObjectWithValues(functionParameters);
-                }
-                self.renderParameters(functionParametersWithValues, Constants.STREAM_FUNCTION, parameterDiv);
-            });
+            $(".define-stream-handler").on("autocompleteselect",
+                '.define-function-stream-handler .custom-combobox-input', function (event, ui) {
+                    var selectedType = ui.item.value.toLowerCase();
+                    var savedParameterValues = [];
+                    var streamHandlerFunction = self.getStreamHandler(streamHandlerList, Constants.FUNCTION,
+                        self.getFunctionNameWithoutParameterOverload(selectedType));
+                    if (streamHandlerFunction) {
+                        savedParameterValues = streamHandlerFunction.value.parameters;
+                    }
+                    var streamHandler = {
+                        type: Constants.STREAM_FUNCTION,
+                        value: {
+                            function: selectedType,
+                            parameters: savedParameterValues
+                        }
+                    };
+                    var parameterDiv = $(this).closest('.defineFunctionName').parents('.define-stream-handler-type-content');
+                    self.mapParameterValues(streamHandler, parameterDiv, true);
+                    self.addAutoCompleteForStreamWindowFunctionAttributes(attributes);
+                });
 
             //to add window
             $('.define-stream-handler').on('click', ".btn-add-window", function () {
                 var sourceDiv = self.getSourceDiv($(this));
                 self.addNewStreamHandler(sourceDiv, Constants.WINDOW);
+                self.showDropDown();
+                self.addAutoCompleteForStreamWindowFunctionAttributes(attributes);
             });
 
             //to add stream-function
@@ -3772,6 +3858,14 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
                 var sourceDiv = self.getSourceDiv($(this));
                 self.addNewStreamHandler(sourceDiv, Constants.FUNCTION);
                 self.showDropDown();
+                self.addAutoCompleteForStreamWindowFunctionAttributes(attributes);
+            });
+
+            //to add filter
+            $('.define-stream-handler').on('click', '.btn-add-filter', function () {
+                var sourceDiv = self.getSourceDiv($(this));
+                self.addNewStreamHandler(sourceDiv, Constants.FILTER);
+                self.addAutoCompleteForFilterConditions(attributes);
             });
 
             //on change of stream-handler type
@@ -3779,20 +3873,28 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
             var previousContent;
             $('.define-stream-handler').on('focus', '.stream-handler-selection', function () {
                 previousValue = this.value;
-                previousContent = $(this).closest('.define-stream-handler-type').next().find('.define-stream-handler-type-content').contents();
+                previousContent = $(this).closest('.define-stream-handler-type').
+                parents('.define-stream-handler-content').find('.define-stream-handler-type-content').contents();
 
             }).on('change', '.stream-handler-selection', function () {
                 var currentValue = this.value; // New Value
-                var currentContentDiv = $(this).closest('.define-stream-handler-type').next().find('.define-stream-handler-type-content');
+                var currentContentDiv = $(this).closest('.define-stream-handler-type').
+                parents('.define-stream-handler-content').find('.define-stream-handler-type-content');
                 if (currentValue == previousValue) {
                     currentContentDiv.html(previousContent)
                 } else {
                     var sourceDiv = self.getSourceDiv($(this));
-                    var streamHandlerContent = $(this).closest('.define-stream-handler-type').next().find('.define-stream-handler-type-content');
+                    var streamHandlerContent = $(this).closest('.define-stream-handler-type').
+                    parents('.define-stream-handler-content').find('.define-stream-handler-type-content');
+                    streamHandlerContent.removeClass();
+                    streamHandlerContent.addClass('define-stream-handler-type-content');
+                    streamHandlerContent.addClass('define-' + currentValue + '-stream-handler');
                     self.renderStreamHandlerContentDiv(currentValue, streamHandlerContent)
-                    self.mapStreamHandlerContent(streamHandlerContent, self.createEmptyStreamHandler(currentValue));
+                    self.mapStreamHandlerContent(streamHandlerContent, self.createEmptyStreamHandler(currentValue))
                 }
                 self.preventMultipleSelectionOfWindowStreamHandler(sourceDiv);
+                self.addAutoCompleteForStreamWindowFunctionAttributes(attributes);
+                self.addAutoCompleteForFilterConditions(attributes);
             });
 
             //To delete stream-handler
@@ -3862,7 +3964,11 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
          */
         FormUtils.prototype.addNewStreamHandler = function (sourceDiv, type) {
             var self = this;
-            var streamHandlerTypes = self.configurationData.application.config.stream_handler_types;
+            if ($(sourceDiv).parents('.pattern-sequence-query-form-container').length !== 0 ) {
+                var streamHandlerTypes = self.configurationData.application.config.stream_handler_types_without_window;
+            } else {
+                var streamHandlerTypes = self.configurationData.application.config.stream_handler_types;
+            }
             var id = self.getIdOfDiv(sourceDiv);
             var streamHandlerList = $(sourceDiv).find('.stream-handler-list');
             var streamHandlerListLength = $(streamHandlerList).find('.define-stream-handler-content').length
@@ -3977,7 +4083,7 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
                 streamHandlerObject = {
                     type: Constants.FUNCTION,
                     value: {
-                        function: "approximate:count", //as default
+                        function: "rdbms:query", //as default
                         parameters: []
                     }
                 }
@@ -4206,17 +4312,6 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
         };
 
         /**
-         * @function to show and hide the order parameter of sort type
-         */
-        FormUtils.prototype.showHideOrderForSort = function () {
-            if ($('#window-parameters #attribute-parameter').find('.parameter-checkbox').is(":checked")) {
-                $('#window-parameters #order-parameter').show();
-            } else {
-                $('#window-parameters #order-parameter').hide();
-            }
-        };
-
-        /**
          * @function to show and hide the window button for stream handlers
          */
         FormUtils.prototype.showHideStreamHandlerWindowButton = function (sourceDiv) {
@@ -4258,16 +4353,8 @@ define(['require', 'lodash', 'appData', 'log', 'constants', 'handlebar', 'annota
          * @function to pop up the element which is being currently edited
          */
         FormUtils.prototype.popUpSelectedElement = function (id) {
-            var self = this;
             $('#' + id).addClass('selected-element');
             $(".overlayed-container").fadeTo(200, 1);
-        };
-
-        /**
-         * @function to change the height for the form-container of the design-view
-         */
-        FormUtils.prototype.changeHeightOfPerfectScroller = function () {
-            $('.console-wrap').addClass('form-height');
         };
 
         /**

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/join-query-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/join-query-form.js
@@ -197,7 +197,6 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryWindowOrFunct
         var autoCompleteFieldsWithChangingAttributes = function (self, outputAttributes) {
             var inputSources = getLeftRightSourceNames();
             var possibleAttributesWithSourceAs = getPossibleAttributesWithSourceAs(self);
-            self.formUtils.addAutoCompleteForFilterConditions(possibleAttributesWithSourceAs.concat(outputAttributes));
             self.formUtils.addAutoCompleteForSelectExpressions(possibleAttributesWithSourceAs);
             self.formUtils.addAutoCompleteForOnCondition(possibleAttributesWithSourceAs.concat(outputAttributes), inputSources);
             self.formUtils.addAutoCompleteForPerWithinConditions(possibleAttributesWithSourceAs.concat(outputAttributes));
@@ -406,6 +405,11 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryWindowOrFunct
                 self.formUtils.renderStreamHandler(Constants.RIGHT, rightSourceData, streamHandlerTypes);
                 self.formUtils.renderDropDown('.input-from-drop-down', possibleSources, Constants.SOURCE);
 
+                var inputAttributes = [];
+                _.forEach(self.formUtils.getInputAttributes(possibleSources), function (attribute) {
+                    inputAttributes.push(attribute.name);
+                });
+
                 if (leftSourceData && !rightSourceData) {
                     mapSourceType(Constants.LEFT, leftSourceData.getConnectedSource(), true);
                     mapSourceType(Constants.RIGHT, leftSourceData.getConnectedSource(), false);
@@ -428,7 +432,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryWindowOrFunct
                 var streamHandlerList = [];
                 getStreamHandlers(leftSourceData, streamHandlerList, Constants.LEFT);
                 getStreamHandlers(rightSourceData, streamHandlerList, Constants.RIGHT);
-                self.formUtils.addEventListenersForStreamHandlersDiv(streamHandlerList);
+                self.formUtils.addEventListenersForStreamHandlersDiv(streamHandlerList, inputAttributes);
 
                 self.formUtils.mapStreamHandler(leftSourceData, Constants.LEFT)
                 self.formUtils.mapStreamHandler(rightSourceData, Constants.RIGHT)
@@ -508,25 +512,16 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryWindowOrFunct
                 }
 
                 //autocompletion
-                var inputAttributes = [];
-                _.forEach(self.formUtils.getInputAttributes(possibleSources), function (attribute) {
-                    inputAttributes.push(attribute.name);
-                });
                 var outputAttributesWithElementName = self.formUtils.constructOutputAttributes(outputAttributes);
                 self.formUtils.addAutoCompleteForRateLimits();
+                self.formUtils.addAutoCompleteForFilterConditions(inputAttributes);
+                self.formUtils.addAutoCompleteForStreamWindowFunctionAttributes(inputAttributes);
                 autoCompleteFieldsWithChangingAttributes(self, outputAttributesWithElementName);
 
                 $('.join-query-form-container').on('blur', '.as-content-value', function () {
                     autoCompleteFieldsWithChangingAttributes(self, outputAttributesWithElementName);
                     var possibleAttributesWithSourceAs = getPossibleAttributesWithSourceAs(self);
                     self.formUtils.generateGroupByDiv(groupBy, possibleAttributesWithSourceAs);
-                });
-
-                //to add filter
-                $('.define-stream-handler').on('click', '.btn-add-filter', function () {
-                    var sourceDiv = self.formUtils.getSourceDiv($(this));
-                    self.formUtils.addNewStreamHandler(sourceDiv, Constants.FILTER);
-                    autoCompleteFieldsWithChangingAttributes(self, outputAttributesWithElementName);
                 });
 
                 //to add query operation set

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/pattern-query-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/pattern-query-form.js
@@ -81,7 +81,6 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOrderByValue'
         var autoCompleteFieldsWithChangingAttributes = function (self, partitionId, outputAttributes) {
             var possibleAttributes = getPossibleAttributes(self, partitionId);
             self.formUtils.addAutoCompleteForSelectExpressions(possibleAttributes);
-            self.formUtils.addAutoCompleteForFilterConditions(possibleAttributes.concat(outputAttributes));
             self.formUtils.addAutoCompleteForLogicStatements();
             self.formUtils.addAutoCompleteForHavingCondition(possibleAttributes.concat(outputAttributes));
             self.formUtils.addAutoCompleteForOnCondition(possibleAttributes.concat(outputAttributes),
@@ -123,17 +122,6 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOrderByValue'
                 isErrorOccurred = true;
             }
             return isErrorOccurred;
-        };
-
-        /**
-         * @function to add new filter stream handler
-         */
-        var addEventListenerToAddNewFilter = function (self, partitionId, outputAttributes) {
-            $('.define-stream-handler').on('click', '.btn-add-filter', function () {
-                var sourceDiv = self.formUtils.getSourceDiv($(this));
-                self.formUtils.addNewStreamHandler(sourceDiv, Constants.FILTER);
-                autoCompleteFieldsWithChangingAttributes(self, partitionId, outputAttributes);
-            });
         };
 
         /**
@@ -246,6 +234,10 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOrderByValue'
                         inputStreamNames.push(streamName)
                     }
                 });
+                var inputAttributes = [];
+                _.forEach(self.formUtils.getInputAttributes(inputStreamNames), function (attribute) {
+                    inputAttributes.push(attribute.name);
+                });
 
                 //conditions
                 if (!conditionList || (conditionList && conditionList.length == 0)) {
@@ -256,7 +248,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOrderByValue'
                 self.formUtils.mapConditions(conditionList);
                 self.formUtils.selectFirstConditionByDefault();
                 var streamHandlerList = getStreamHandlers(conditionList);
-                self.formUtils.addEventListenersForStreamHandlersDiv(streamHandlerList);
+                self.formUtils.addEventListenersForStreamHandlersDiv(streamHandlerList, inputAttributes);
                 self.formUtils.addEventListenersForConditionDiv();
 
                 var outputAttributes = [];
@@ -314,15 +306,11 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOrderByValue'
                     validateSectionsOnLoadOfForm(self);
                 }
 
-                var inputAttributes = [];
-                _.forEach(self.formUtils.getInputAttributes(inputStreamNames), function (attribute) {
-                    inputAttributes.push(attribute.name);
-                });
                 var outputAttributesWithElementName = self.formUtils.constructOutputAttributes(outputAttributes);
+                self.formUtils.addAutoCompleteForFilterConditions(inputAttributes);
+                self.formUtils.addAutoCompleteForStreamWindowFunctionAttributes(inputAttributes);
                 self.formUtils.addAutoCompleteForRateLimits();
                 autoCompleteFieldsWithChangingAttributes(self, partitionId, outputAttributesWithElementName);
-
-                addEventListenerToAddNewFilter(self, partitionId, outputAttributesWithElementName);
 
                 $('.define-conditions').on('click', '.btn-del-condition', function () {
                     var conditionIndex = $(this).closest('.condition-navigation').index();
@@ -339,7 +327,6 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOrderByValue'
                     self.formUtils.addNewCondition(inputStreamNames);
                     generateDivRequiringPossibleAttributes(self, partitionId, groupBy);
                     autoCompleteFieldsWithChangingAttributes(self, partitionId, outputAttributesWithElementName);
-                    addEventListenerToAddNewFilter(self, partitionId, outputAttributesWithElementName);
                 });
 
                 $('.define-conditions').on('blur', '.condition-id', function () {

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/sequence-query-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/sequence-query-form.js
@@ -80,7 +80,6 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOrderByValue'
         var autoCompleteFieldsWithChangingAttributes = function (self, partitionId, outputAttributes) {
             var possibleAttributes = getPossibleAttributes(self, partitionId);
             self.formUtils.addAutoCompleteForSelectExpressions(possibleAttributes);
-            self.formUtils.addAutoCompleteForFilterConditions(possibleAttributes.concat(outputAttributes));
             self.formUtils.addAutoCompleteForLogicStatements();
             self.formUtils.addAutoCompleteForHavingCondition(possibleAttributes.concat(outputAttributes));
             self.formUtils.addAutoCompleteForOnCondition(possibleAttributes.concat(outputAttributes),
@@ -122,17 +121,6 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOrderByValue'
                 isErrorOccurred = true;
             }
             return isErrorOccurred;
-        };
-
-        /**
-         * @function to add new filter stream handler
-         */
-        var addEventListenerToAddNewFilter = function (self, partitionId, outputAttributes) {
-            $('.define-stream-handler').on('click', '.btn-add-filter', function () {
-                var sourceDiv = self.formUtils.getSourceDiv($(this));
-                self.formUtils.addNewStreamHandler(sourceDiv, Constants.FILTER);
-                autoCompleteFieldsWithChangingAttributes(self, partitionId, outputAttributes);
-            });
         };
 
         /**
@@ -245,6 +233,10 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOrderByValue'
                         inputStreamNames.push(streamName)
                     }
                 });
+                var inputAttributes = [];
+                _.forEach(self.formUtils.getInputAttributes(inputStreamNames), function (attribute) {
+                    inputAttributes.push(attribute.name);
+                });
 
                 //conditions
                 if (!conditionList || (conditionList && conditionList.length == 0)) {
@@ -255,7 +247,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOrderByValue'
                 self.formUtils.mapConditions(conditionList);
                 self.formUtils.selectFirstConditionByDefault();
                 var streamHandlerList = getStreamHandlers(conditionList);
-                self.formUtils.addEventListenersForStreamHandlersDiv(streamHandlerList);
+                self.formUtils.addEventListenersForStreamHandlersDiv(streamHandlerList, inputAttributes);
                 self.formUtils.addEventListenersForConditionDiv();
 
                 var outputAttributes = [];
@@ -313,15 +305,11 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOrderByValue'
                     validateSectionsOnLoadOfForm(self);
                 }
 
-                var inputAttributes = [];
-                _.forEach(self.formUtils.getInputAttributes(inputStreamNames), function (attribute) {
-                    inputAttributes.push(attribute.name);
-                });
                 var outputAttributesWithElementName = self.formUtils.constructOutputAttributes(outputAttributes);
                 self.formUtils.addAutoCompleteForRateLimits();
+                self.formUtils.addAutoCompleteForFilterConditions(inputAttributes);
+                self.formUtils.addAutoCompleteForStreamWindowFunctionAttributes(inputAttributes);
                 autoCompleteFieldsWithChangingAttributes(self, partitionId, outputAttributesWithElementName);
-
-                addEventListenerToAddNewFilter(self, partitionId, outputAttributesWithElementName);
 
                 $('.define-conditions').on('click', '.btn-del-condition', function () {
                     var conditionIndex = $(this).closest('.condition-navigation').index();
@@ -338,7 +326,6 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryOrderByValue'
                     self.formUtils.addNewCondition(inputStreamNames);
                     generateDivRequiringPossibleAttributes(self, partitionId, groupBy);
                     autoCompleteFieldsWithChangingAttributes(self, partitionId, outputAttributesWithElementName);
-                    addEventListenerToAddNewFilter(self, partitionId, outputAttributesWithElementName);
                 });
 
                 $('.define-conditions').on('blur', '.condition-id', function () {

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/window-filter-projection-query-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/window-filter-projection-query-form.js
@@ -238,7 +238,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryWindowOrFunct
                 }
                 self.formUtils.renderStreamHandler("query", queryInput, streamHandlerTypes);
                 self.formUtils.mapStreamHandler(queryInput, "query");
-                self.formUtils.addEventListenersForStreamHandlersDiv(streamHandlerList);
+                self.formUtils.addEventListenersForStreamHandlersDiv(streamHandlerList, possibleAttributes);
 
                 /**
                  * to show user the lost saved data when the connection is deleted/ when the connected stream is modified
@@ -251,19 +251,13 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryWindowOrFunct
                 //autocompletion
                 var outputAttributesWithElementName = self.formUtils.constructOutputAttributes(outputAttributes);
                 self.formUtils.addAutoCompleteForSelectExpressions(possibleAttributes);
-                self.formUtils.addAutoCompleteForFilterConditions(possibleAttributes.concat(outputAttributes));
+                self.formUtils.addAutoCompleteForFilterConditions(possibleAttributes);
+                self.formUtils.addAutoCompleteForStreamWindowFunctionAttributes(possibleAttributes);
                 self.formUtils.addAutoCompleteForOutputOperation(outputAttributesWithElementName, possibleAttributes);
                 self.formUtils.addAutoCompleteForHavingCondition(possibleAttributes.concat(outputAttributes));
                 self.formUtils.addAutoCompleteForOnCondition(possibleAttributes.concat(outputAttributes),
                     [inputElementName]);
                 self.formUtils.addAutoCompleteForRateLimits();
-
-                //to add filter
-                $('.define-stream-handler').on('click', '.btn-add-filter', function () {
-                    var sourceDiv = self.formUtils.getSourceDiv($(this));
-                    self.formUtils.addNewStreamHandler(sourceDiv, Constants.FILTER);
-                    self.formUtils.addAutoCompleteForFilterConditions(possibleAttributes.concat(outputAttributes));
-                });
 
                 //to add query operation set
                 var setDiv = '<li class="setAttributeValue">' +

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/window-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/design-view/form-builder/forms/window-form.js
@@ -37,6 +37,18 @@ define(['require', 'log', 'jquery', 'lodash', 'attribute', 'constants'],
             }
         };
 
+        //function to get the attributes
+        var getAttributes = function () {
+            var attributes = [];
+            $('.attr-name').each(function () {
+                var value = $(this).val().trim();
+                if (value !== "") {
+                    attributes.push(value)
+                }
+            });
+            return attributes;
+        };
+
         /**
          * @function generate properties form for a window
          * @param element selected element(window)
@@ -69,39 +81,28 @@ define(['require', 'log', 'jquery', 'lodash', 'attribute', 'constants'],
             //declaration and initialization of variables
             var predefinedWindowFunctionNames = _.orderBy(this.configurationData.rawExtensions["windowFunctionNames"],
                 ['name'], ['asc']);
-            var functionParameters = [];
-            var functionParametersWithValues = [];
+            var windowFormContainer = '.window-form-container';
+            var savedParameters = [];
             var selectedType;
             var annotations = [];
 
-            self.formUtils.renderFunctions(predefinedWindowFunctionNames, '.window-form-container', Constants.WINDOW);
+            self.formUtils.renderFunctions(predefinedWindowFunctionNames, windowFormContainer, Constants.WINDOW);
+            self.formUtils.showDropDown();
             var name = windowObject.getName();
             self.formUtils.renderOutputEventTypes();
             if (!name) {
                 //if window form is freshly opened[unedited window object]
-                var attributes = [{ name: "" }];
+                var attributes = [{name: ""}];
                 self.formUtils.renderAttributeTemplate(attributes)
-                selectedType = $('.defineFunctionName #window-type').val();
-                functionParameters = self.formUtils.getSelectedTypeParameters(selectedType,
-                    predefinedWindowFunctionNames);
-                functionParametersWithValues = self.formUtils.createObjectWithValues(functionParameters);
-                self.formUtils.renderParameters(functionParametersWithValues, selectedType, Constants.WINDOW)
+                selectedType = Constants.BATCH_WINDOW_PROCESSOR;
             } else {
                 //if window object is already edited
                 var windowType = windowObject.getType().toLowerCase();
-                var parameterValues = windowObject.getParameters();
+                savedParameters = windowObject.getParameters();
 
                 $('#windowName').val(name.trim());
                 selectedType = windowType;
-                $('.defineFunctionName').find('#window-type option').filter(function () {
-                    return ($(this).val().toLowerCase() == (windowType));
-                }).prop('selected', true);
-                functionParameters = self.formUtils.getSelectedTypeParameters(windowType, predefinedWindowFunctionNames);
-                self.formUtils.callToMapParameters(selectedType, functionParameters, parameterValues,
-                    '.window-form-container')
-                if (selectedType === Constants.SORT) {
-                    self.formUtils.showHideOrderForSort();
-                }
+
                 var attributeList = windowObject.getAttributeList();
                 self.formUtils.renderAttributeTemplate(attributeList)
                 self.formUtils.selectTypesOfSavedAttributes(attributeList);
@@ -114,28 +115,39 @@ define(['require', 'log', 'jquery', 'lodash', 'attribute', 'constants'],
                 var annotationListObjects = windowObject.getAnnotationListObjects();
                 annotations = annotationListObjects;
             }
+            var windowParameters = {
+                type: Constants.WINDOW,
+                value: {
+                    function: selectedType,
+                    parameters: savedParameters
+                }
+            };
+            self.formUtils.mapParameterValues(windowParameters, windowFormContainer, false);
             self.formUtils.renderAnnotationTemplate("define-annotation", annotations);
-            self.formUtils.addEventListenersForParameterDiv();
-            self.formUtils.addEventListenerForSortWindow(selectedType)
 
-            $('#window-type').change(function () {
-                functionParameters = self.formUtils.getSelectedTypeParameters(this.value, predefinedWindowFunctionNames);
-                selectedType = this.value.toLowerCase();
-                if (parameterValues && selectedType == windowType.toLowerCase()) {
-                    self.formUtils.callToMapParameters(selectedType, functionParameters, parameterValues,
-                        '.window-form-container')
-                } else {
-                    functionParametersWithValues = self.formUtils.createObjectWithValues(functionParameters);
-                    self.formUtils.renderParameters(functionParametersWithValues, Constants.WINDOW,
-                        '.window-form-container');
+            $(windowFormContainer).on("autocompleteselect", '.custom-combobox-input', function (event, ui) {
+                var savedParameterValues = [];
+                var selectedType = ui.item.value.toLowerCase();
+                if (name && self.formUtils.getFunctionNameWithoutParameterOverload(selectedType) === windowType) {
+                    savedParameterValues = savedParameters;
                 }
-                if (selectedType === Constants.SORT) {
-                    self.formUtils.showHideOrderForSort();
-                    self.formUtils.addEventListenerForSortWindow(selectedType)
-                }
+                var currentlySelectedWindow = {
+                    type: Constants.WINDOW,
+                    value: {
+                        function: selectedType,
+                        parameters: savedParameterValues
+                    }
+                };
+                self.formUtils.mapParameterValues(currentlySelectedWindow, windowFormContainer, true);
+                self.formUtils.addAutoCompleteForStreamWindowFunctionAttributes(getAttributes());
+            });
+
+            $(windowFormContainer).on("blur", ".attr-name", function () {
+                self.formUtils.addAutoCompleteForStreamWindowFunctionAttributes(getAttributes());
             });
 
             self.formUtils.initPerfectScroller(formConsole.cid);
+            self.formUtils.addAutoCompleteForStreamWindowFunctionAttributes(getAttributes());
 
             // 'Submit' button action
             $('#' + formConsole.cid).on('click', '#btn-submit', function () {
@@ -181,10 +193,18 @@ define(['require', 'log', 'jquery', 'lodash', 'attribute', 'constants'],
                     return;
                 }
 
-                var windowType = $('.defineFunctionName #window-type').val();
-                if (self.formUtils.validateParameters('.window-form-container', functionParameters)) {
-                    isErrorOccurred = true;
-                    return;
+                if ($(windowFormContainer).find('.display-predefined-parameters').length === 0) {
+                    var predefinedParameters = self.formUtils.getPredefinedParameters(windowFormContainer,
+                        predefinedWindowFunctionNames);
+                    if (self.formUtils.validateParameters(windowFormContainer, predefinedParameters)) {
+                        isErrorOccurred = true;
+                        return;
+                    }
+                } else {
+                    if (self.formUtils.validateUnknownParameters(windowFormContainer)) {
+                        isErrorOccurred = true;
+                        return;
+                    }
                 }
 
                 if (!isErrorOccurred) {
@@ -192,9 +212,8 @@ define(['require', 'log', 'jquery', 'lodash', 'attribute', 'constants'],
                     var textNode = $(element).parent().find('.windowNameNode');
                     textNode.html(windowName);
 
-                    var parameters = self.formUtils.buildWindowParameters('.window-form-container', windowType,
-                        predefinedWindowFunctionNames)
-                    windowObject.setType(windowType);
+                    var parameters = self.formUtils.buildParameterValues(windowFormContainer);
+                    windowObject.setType(self.formUtils.getFunctionNameWithoutParameterOverload($('.custom-combobox-input').val()));
                     windowObject.setParameters(parameters);
 
                     //clear the previously saved attribute list
@@ -204,7 +223,7 @@ define(['require', 'log', 'jquery', 'lodash', 'attribute', 'constants'],
                         var nameValue = $(this).find('.attr-name').val().trim();
                         var typeValue = $(this).find('.attr-type').val();
                         if (nameValue != "") {
-                            var attributeObject = new Attribute({ name: nameValue, type: typeValue });
+                            var attributeObject = new Attribute({name: nameValue, type: typeValue});
                             windowObject.addAttribute(attributeObject)
                         }
                     });

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/source-editor/completion-engine.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/js/source-editor/completion-engine.js
@@ -2914,7 +2914,9 @@ define(["ace/ace", "jquery", "./constants", "./utils", "ace/snippets", "ace/rang
             sourceMaps: {},
             sinkMaps: {},
             windowFunctionNames: {},
-            streamFunctions: {}
+            streamFunctions: {},
+            incrementalAggregators: {},
+            functions: {}
         };
 
         CompletionEngine.isDynamicExtensionsLoaded = false;
@@ -2976,6 +2978,8 @@ define(["ace/ace", "jquery", "./constants", "./utils", "ace/snippets", "ace/rang
                         })();
                         (function () {
                             var snippets = {};
+                            var streamFunctions = [];
+                            var functions = [];
                             CompletionEngine.rawExtensions.store = response.extensions["store"]["stores"];
                             CompletionEngine.rawExtensions.sink = response.extensions["sink"]["sinks"];
                             CompletionEngine.rawExtensions.source = response.extensions["source"]["sources"];
@@ -2983,10 +2987,16 @@ define(["ace/ace", "jquery", "./constants", "./utils", "ace/snippets", "ace/rang
                                 .extensions["sourceMapper"]["sourceMaps"];
                             CompletionEngine.rawExtensions.sinkMaps = response.extensions["sinkMapper"]["sinkMaps"];
                             CompletionEngine.rawExtensions.windowFunctionNames = response.inBuilt["windowProcessors"];
-                            var streamFunctions = [];
+                            CompletionEngine.rawExtensions.incrementalAggregators = response.extensions
+                                ["incrementalAggregator"]["functions"];
                             obtainStreamFunctionsFromResponse(response.extensions, streamFunctions);
                             obtainStreamFunctionsFromResponse(response.inBuilt, streamFunctions);
+                            obtainFunctionFromResponse(response.extensions, functions,
+                                CompletionEngine.rawExtensions.incrementalAggregators);
+                            obtainFunctionFromResponse(response.inBuilt, functions,
+                                CompletionEngine.rawExtensions.incrementalAggregators);
                             CompletionEngine.rawExtensions.streamFunctions = streamFunctions;
+                            CompletionEngine.rawExtensions.functions = functions;
                             for (var namespace in response.extensions) {
                                 if (response.extensions.hasOwnProperty(namespace)) {
                                     var processors = {};
@@ -3088,14 +3098,47 @@ define(["ace/ace", "jquery", "./constants", "./utils", "ace/snippets", "ace/rang
         function obtainStreamFunctionsFromResponse(extensions, streamFunctions) {
             _.forEach(extensions, function (extension) {
                 _.forEach(extension.streamProcessors, function (streamFunction) {
+                    var parameterOverloads;
+                    if (streamFunction.parameterOverloads) {
+                        parameterOverloads = streamFunction.parameterOverloads;
+                    }
                     var streamProcessorFunction = {
                         description: streamFunction.description,
                         examples: streamFunction.examples,
                         name: streamFunction.namespace + ':' + streamFunction.name,
                         parameters: streamFunction.parameters,
+                        parameterOverloads: parameterOverloads,
                         returnAttributes: streamFunction.returnAttributes
-                    }
+                    };
                     streamFunctions.push(streamProcessorFunction);
+                });
+            });
+        }
+
+        /**
+         * @function to obtain the functions from the given extensions
+         * @param {Object} extensions extensions
+         * @param {Object} functions array to hold the stream functions
+         * @param {Object} aggregateFunctions
+         */
+        function obtainFunctionFromResponse(extensions, functions, aggregateFunctions) {
+            _.forEach(extensions, function (extension) {
+                _.forEach(extension.functions, function (normalFunction) {
+                    if (!_.some(aggregateFunctions, normalFunction)){
+                        var parameterOverloads;
+                        if (normalFunction.parameterOverloads) {
+                            parameterOverloads = normalFunction.parameterOverloads;
+                        }
+                        var functionObject = {
+                            description: normalFunction.description,
+                            examples: normalFunction.examples,
+                            name: normalFunction.namespace + ':' + normalFunction.name,
+                            parameters: normalFunction.parameters,
+                            parameterOverloads: parameterOverloads,
+                            returnAttributes: normalFunction.returnAttributes
+                        };
+                        functions.push(functionObject);
+                    }
                 });
             });
         }


### PR DESCRIPTION
## Purpose
> In the drop-down of selecting a window or function type, only the function name can be seen.

## Goals
> Include the parameter names along with the function name.

## Approach
> The parameter names are added to the function name in the drop-down. This fix will be required when parameter overloads are present for a particular function. 
> Depending on the parameters in the selected parameter overload, the parameters will be rendered.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes