### PR TITLE
Fix tests and bump Siddhi to 5.1.1

### DIFF
--- a/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/core/internal/SPMetricsManagement.java
+++ b/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/core/internal/SPMetricsManagement.java
@@ -80,7 +80,12 @@ public class SPMetricsManagement {
     public void stopMetrics(String siddhiAppName) {
         List<String> registeredComponents = componentMap.get(siddhiAppName);
         for (String component : registeredComponents) {
-            this.metricManagementService.setMetricLevel(component, OFF);
+            try {
+                this.metricManagementService.setMetricLevel(component, OFF);
+            } catch (IllegalArgumentException e) {
+                // Error: given metric is not available. Do nothing!
+                log.debug("Invalid metric name: " + component, e);
+            }
         }
     }
 

--- a/components/org.wso2.carbon.si.metrics.core/src/test/java/org/wso2/carbon/si/metrics/core/StatisticsTestCase.java
+++ b/components/org.wso2.carbon.si.metrics.core/src/test/java/org/wso2/carbon/si/metrics/core/StatisticsTestCase.java
@@ -118,10 +118,8 @@ public class StatisticsTestCase {
         AssertJUnit.assertEquals("test.size", bufferedEventsTracker.getName(eventBufferHolder));
     }
     
-    @Test (enabled = false)
+    @Test
     public void statisticsTest1() throws InterruptedException {
-        // This test case has been disabled since it has a issue on enabling/disabling metrics at the Siddhi side.
-        // Issue: https://github.com/wso2/carbon-analytics/issues/1709
         log.info("statistics test 1");
         SiddhiManager siddhiManager = new SiddhiManager();
         StatisticsConfiguration statisticsConfiguration = new StatisticsConfiguration(new SPMetricsFactory());
@@ -162,29 +160,28 @@ public class StatisticsTestCase {
             inputHandler.send(new Object[] {"WSO2", 55.6f, 100});
             inputHandler.send(new Object[] {"IBM", 75.6f, 100});
         }
-        
+
+        // Following memory metrics were removed from here since they are no longer enabled by default.
+        // - io.siddhi.SiddhiApps.MetricsTest.Siddhi.Queries.query1.memory
+        // - io.siddhi.SiddhiApps.MetricsTest.Siddhi.Queries.query2.memory
+
         String name1 = MetricService.name("io.siddhi.SiddhiApps.MetricsTest",
-                "Siddhi.Queries.query1.memory");
-        String name2 = MetricService.name("io.siddhi.SiddhiApps.MetricsTest",
-                "Siddhi.Queries.query2.memory");
-        String name3 = MetricService.name("io.siddhi.SiddhiApps.MetricsTest",
                 "Siddhi.Streams.cseEventStream.throughput");
-        String name4 = MetricService.name("io.siddhi.SiddhiApps.MetricsTest",
+        String name2 = MetricService.name("io.siddhi.SiddhiApps.MetricsTest",
                 "Siddhi.Streams.cseEventStream2.throughput");
-        String name5 = MetricService.name("io.siddhi.SiddhiApps.MetricsTest",
+        String name3 = MetricService.name("io.siddhi.SiddhiApps.MetricsTest",
                 "Siddhi.Streams.outputStream.throughput");
-        String name6 = MetricService.name("io.siddhi.SiddhiApps.MetricsTest",
+        String name4 = MetricService.name("io.siddhi.SiddhiApps.MetricsTest",
                 "Siddhi.Queries.query1.latency");
-        String name7 = MetricService.name("io.siddhi.SiddhiApps.MetricsTest",
+        String name5 = MetricService.name("io.siddhi.SiddhiApps.MetricsTest",
                 "Siddhi.Queries.query2.latency");
         Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> {
-            boolean condition = metricManagementService.getMetricLevel(name1).name() != null &&
+            boolean condition =
+                    metricManagementService.getMetricLevel(name1).name() != null &&
                     metricManagementService.getMetricLevel(name2).name() != null &&
                     metricManagementService.getMetricLevel(name3).name() != null &&
                     metricManagementService.getMetricLevel(name4).name() != null &&
-                    metricManagementService.getMetricLevel(name5).name() != null &&
-                    metricManagementService.getMetricLevel(name6).name() != null &&
-                    metricManagementService.getMetricLevel(name7).name() != null;
+                    metricManagementService.getMetricLevel(name5).name() != null;
             return condition;
         });
         Assert.assertTrue(metricManagementService.isReporterRunning("Console"));
@@ -193,8 +190,6 @@ public class StatisticsTestCase {
         AssertJUnit.assertEquals("INFO", metricManagementService.getMetricLevel(name3).name());
         AssertJUnit.assertEquals("INFO", metricManagementService.getMetricLevel(name4).name());
         AssertJUnit.assertEquals("INFO", metricManagementService.getMetricLevel(name5).name());
-        AssertJUnit.assertEquals("INFO", metricManagementService.getMetricLevel(name6).name());
-        AssertJUnit.assertEquals("INFO", metricManagementService.getMetricLevel(name7).name());
         
         AssertJUnit.assertTrue(eventArrived);
         AssertJUnit.assertEquals(3, count);

--- a/components/org.wso2.carbon.streaming.integrator.core/src/main/java/org/wso2/carbon/streaming/integrator/core/ha/HACoordinationSourceHandlerManager.java
+++ b/components/org.wso2.carbon.streaming.integrator.core/src/main/java/org/wso2/carbon/streaming/integrator/core/ha/HACoordinationSourceHandlerManager.java
@@ -42,7 +42,7 @@ public class HACoordinationSourceHandlerManager extends SourceHandlerManager {
     }
 
     @Override
-    public SourceHandler generateSourceHandler(String sourceType) {
-        return new HACoordinationSourceHandler(throughputTracker, sourceType);
+    public SourceHandler generateSourceHandler() {
+        return new HACoordinationSourceHandler(throughputTracker, this.getSourceType());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1549,8 +1549,8 @@
 
     <properties>
         <carbon.analytics.version>3.0.0-SNAPSHOT</carbon.analytics.version>
-        <siddhi.version>5.1.1-SNAPSHOT</siddhi.version>
-        <siddhi.bundle.version>5.1.1-SNAPSHOT</siddhi.bundle.version>
+        <siddhi.version>5.1.1</siddhi.version>
+        <siddhi.bundle.version>5.1.1</siddhi.bundle.version>
         <siddhi.version.range>[5.0.0, 6.0.0)</siddhi.version.range>
         <carbon.analytics-common.version>6.1.26</carbon.analytics-common.version>
         <carbon.analytics-common.version.range>[6.0.66, 6.2.0)</carbon.analytics-common.version.range>


### PR DESCRIPTION
## Purpose
This PR fixes failing statistics test cases and bump Siddhi to version 5.1.1 which introduces passing `sourceType` to `SourceHandler`s.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes