### PR TITLE
Fix bundle symbolic name in apache.commons.fileupload bundle

### DIFF
--- a/features/org.wso2.carbon.event.simulator.core.feature/pom.xml
+++ b/features/org.wso2.carbon.event.simulator.core.feature/pom.xml
@@ -206,7 +206,7 @@
                                     <version>${apache.commons.csv.version}</version>
                                 </bundle>
                                 <bundle>
-                                    <symbolicName>org.apache.commons.fileupload</symbolicName>
+                                    <symbolicName>org.apache.commons.commons-fileupload</symbolicName>
                                     <version>${apache.commons.fileupload.version}</version>
                                 </bundle>
                                 <bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -1741,7 +1741,7 @@
         <owasp.encoder.version>1.2.0.wso2v2</owasp.encoder.version>
         <apache.httpcomponents.version>4.3.1.wso2v1</apache.httpcomponents.version>
         <apache.commons.csv.version>1.4</apache.commons.csv.version>
-        <apache.commons.fileupload.version>1.3.2</apache.commons.fileupload.version>
+        <apache.commons.fileupload.version>1.4</apache.commons.fileupload.version>
         <fabricator.wso2v1.version>2.1.4.wso2v1</fabricator.wso2v1.version>
         <generex.wso2v1.version>1.0.0.wso2v1</generex.wso2v1.version>
         <mysql.connector.version>5.1.38</mysql.connector.version>


### PR DESCRIPTION
## Purpose
Fix bundle symbolic name in apache.commons.fileupload bundle.
When upgrading from 1.3 to 1.4 build failed as the bundle symbolic name has changed in v1.4.

## Test environment
TODO
 
