### PR TITLE
Fix editor console content does not keep indentations

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/css/console.css
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/css/console.css
@@ -17,9 +17,9 @@
     width: calc(100% - 35px) !important;
 }
 
-.output-console-content .INFO { color: #03a9f4; }
-.output-console-content .INFO-LOGGER { color: #e7dfe0; }
-.output-console-content .ERROR { color: #f44336; }
+.output-console-content .INFO { color: #03a9f4; white-space: pre-wrap; }
+.output-console-content .INFO-LOGGER { color: #e7dfe0; white-space: pre-wrap; }
+.output-console-content .ERROR { color: #f44336; white-space: pre-wrap; }
 
 .output-headers-bar{
     background: #232323;


### PR DESCRIPTION
## Purpose
Show editor console content with returned indentations

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes