### PR TITLE
Fix the issue of running siddhi apps not stopping at refresh 

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/EditorMicroservice.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/EditorMicroservice.java
@@ -211,7 +211,7 @@ public class EditorMicroservice implements Microservice {
         String jsonString;
         try {
             String siddhiApp = validationRequest.getSiddhiApp();
-            if (validationRequest.getVariables().size() != 0) {
+            if (validationRequest.getVariables() != null && validationRequest.getVariables().size() != 0) {
                 siddhiApp = SourceEditorUtils.populateSiddhiAppWithVars(validationRequest.getVariables(), siddhiApp);
             }
 


### PR DESCRIPTION
## Purpose
Fix the issue of running siddhi apps not stopping at refresh, occurs because validate service expects variables attribute to be present in the json sent in the validate request

## Approach
Add null check for validate service

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes