### PR TITLE
Handle exception while reading window stats

### DIFF
--- a/components/org.wso2.carbon.status.dashboard.core/src/main/java/org/wso2/carbon/status/dashboard/core/dbhandler/StatusDashboardMetricsDBHandler.java
+++ b/components/org.wso2.carbon.status.dashboard.core/src/main/java/org/wso2/carbon/status/dashboard/core/dbhandler/StatusDashboardMetricsDBHandler.java
@@ -381,8 +381,12 @@ public class StatusDashboardMetricsDBHandler {
                                     componentElements[0], componentElements[1], true).size() > 0) {
                         
                     }
-                    componentMetrics.setTotalEvents(getEventsCount(componentElements[0], componentElements[1],
-                            carbonId, appName, timeInterval));
+                    try {
+                        componentMetrics.setTotalEvents(getEventsCount(componentElements[0], componentElements[1],
+                                carbonId, appName, timeInterval));
+                    } catch (Throwable t) {
+                        logger.debug("Error occurred: " + t.getMessage(), t);
+                    }
                     metricElement = new MetricElement();
                     componentMetrics.setName(componentElements[1]);
                     typeMetrics.setType(componentElements[0]);


### PR DESCRIPTION
## Purpose
Reading Siddhi app statistics within the Status dashboard is failing when the Siddhi app contains a `window`. This PR fixes that issue.

## Goals
Handle the exception, hence it won't affect retrieving other statistics. 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes