### PR TITLE
Add DataProviderAuthorizer to secure websocket communication

### DIFF
--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/DataProviderAuthorizer.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/DataProviderAuthorizer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.data.provider;
+
+import org.wso2.carbon.data.provider.bean.DataProviderConfigRoot;
+import org.wso2.carbon.data.provider.exception.DataProviderException;
+
+/**
+ * Data provider Authorizer interface.
+ */
+public interface DataProviderAuthorizer {
+
+    /**
+     * Prevents unauthorized access to data provider.
+     *
+     * @param dataProviderConfigRoot data provider configuration.
+     * @return authorization results.
+     * @throws DataProviderException if the authorization failed due to exception.
+     */
+    boolean authorize(DataProviderConfigRoot dataProviderConfigRoot) throws DataProviderException;
+}

--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/DefaultDataProviderAuthorizer.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/DefaultDataProviderAuthorizer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.data.provider;
+
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.carbon.data.provider.bean.DataProviderConfigRoot;
+import org.wso2.carbon.data.provider.exception.DataProviderException;
+
+/**
+ * Default implementation for Data provider Authorizer.
+ */
+@Component(
+        service = DataProviderAuthorizer.class,
+        immediate = true
+)
+public class DefaultDataProviderAuthorizer implements DataProviderAuthorizer {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultDataProviderAuthorizer.class);
+    @Override
+    public boolean authorize(DataProviderConfigRoot dataProviderConfigRoot) throws DataProviderException {
+        LOGGER.debug("Authorized via the '{}' class.", this.getClass().getName());
+        return true;
+    }
+}

--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/bean/DataProviderConfigRoot.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/bean/DataProviderConfigRoot.java
@@ -25,6 +25,9 @@ import com.google.gson.JsonElement;
  */
 public class DataProviderConfigRoot {
     private String topic;
+    private String widgetName;
+    private String username;
+    private String dashboardId;
     private String providerName;
     private String action;
     private JsonElement dataProviderConfiguration;
@@ -38,6 +41,9 @@ public class DataProviderConfigRoot {
 
     public DataProviderConfigRoot() {
         this.topic = "";
+        this.widgetName = "";
+        this.username = "";
+        this.dashboardId = "";
         this.providerName = "";
         this.action = "";
         this.dataProviderConfiguration = null;
@@ -49,6 +55,30 @@ public class DataProviderConfigRoot {
 
     public void setTopic(String topic) {
         this.topic = topic;
+    }
+
+    public String getWidgetName() {
+        return widgetName;
+    }
+
+    public void setWidgetName(String widgetName) {
+        this.widgetName = widgetName;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getDashboardId() {
+        return dashboardId;
+    }
+
+    public void setDashboardId(String dashboardId) {
+        this.dashboardId = dashboardId;
     }
 
     public String getProviderName() {

--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/endpoint/DataProviderEndPoint.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/endpoint/DataProviderEndPoint.java
@@ -126,12 +126,12 @@ public class DataProviderEndPoint implements WebSocketEndpoint {
         DataProviderConfigRoot dataProviderConfigRoot = new Gson().fromJson(message, DataProviderConfigRoot.class);
         String authoringClassName;
         try {
-            Object webSocketConfiguration
-                    = getDataProviderHelper().getConfigProvider().getConfigurationObject(WEB_SOCKET_CONFIG_HEADER);
+            Map webSocketConfiguration
+                    = (Map)getDataProviderHelper().getConfigProvider().getConfigurationObject(WEB_SOCKET_CONFIG_HEADER);
             if (webSocketConfiguration != null) {
                 JSONObject webSocketConfigJSON = new JSONObject(new Gson().toJson(webSocketConfiguration));
                 if (!webSocketConfigJSON.has(WEB_SOCKET_AUTHORIZING_CLASS_CONFIG_HEADER)) {
-                    throw new Exception("Web socket authorizing class cannot be found in the deployment yaml file.");
+                    throw new Exception("Web socket authorizing class cannot be found in the deployment.yaml file.");
                 }
                 authoringClassName = (String) webSocketConfigJSON.get(WEB_SOCKET_AUTHORIZING_CLASS_CONFIG_HEADER);
             } else {
@@ -144,8 +144,7 @@ public class DataProviderEndPoint implements WebSocketEndpoint {
                 throw new Exception("Cannot find the Data Provider Authorizer class for the given class name: "
                         + authoringClassName + ".");
             }
-            boolean authorizerResult
-                    = dataProviderAuthorizer.authorize(dataProviderConfigRoot);
+            boolean authorizerResult = dataProviderAuthorizer.authorize(dataProviderConfigRoot);
             if (!authorizerResult) {
                 throw new Exception("Access denied to data provider.");
             }

--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/endpoint/DataProviderEndPoint.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/endpoint/DataProviderEndPoint.java
@@ -18,6 +18,7 @@
 package org.wso2.carbon.data.provider.endpoint;
 
 import com.google.gson.Gson;
+import org.json.JSONObject;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
@@ -27,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import org.wso2.carbon.config.provider.ConfigProvider;
 import org.wso2.carbon.data.provider.AbstractDataProvider;
 import org.wso2.carbon.data.provider.DataProvider;
+import org.wso2.carbon.data.provider.DataProviderAuthorizer;
 import org.wso2.carbon.data.provider.bean.DataProviderConfigRoot;
 import org.wso2.carbon.data.provider.siddhi.SiddhiProvider;
 import org.wso2.carbon.datasource.core.api.DataSourceService;
@@ -56,6 +58,10 @@ import static org.wso2.carbon.data.provider.utils.DataProviderValueHolder.getDat
 public class DataProviderEndPoint implements WebSocketEndpoint {
     private static final Logger LOGGER = LoggerFactory.getLogger(DataProviderEndPoint.class);
     private static final Map<String, WebSocketConnection> sessionMap = new ConcurrentHashMap<>();
+    private static final String WEB_SOCKET_CONFIG_HEADER = "data.provider.configs";
+    private static final String WEB_SOCKET_AUTHORIZING_CLASS_CONFIG_HEADER = "authorizingClass";
+    private static final String DEFAULT_WEBSOCKET_AUTHORIZING_CLASS
+            = "org.wso2.carbon.data.provider.DefaultDataProviderAuthorizer";
 
     @Reference(
             name = "org.wso2.carbon.datasource.DataSourceService",
@@ -84,6 +90,21 @@ public class DataProviderEndPoint implements WebSocketEndpoint {
         getDataProviderHelper().setConfigProvider(null);
     }
 
+    @Reference(service = DataProviderAuthorizer.class,
+            cardinality = ReferenceCardinality.AT_LEAST_ONE,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetDataProviderAuthorizer")
+    protected void setDataProviderAuthorizer(DataProviderAuthorizer dataProviderAuthorizer) {
+        getDataProviderHelper()
+                .setDataProviderAuthorizer(dataProviderAuthorizer.getClass().getName(), dataProviderAuthorizer);
+        LOGGER.debug("Data Provider Authorizer '{}' registered.", dataProviderAuthorizer.getClass().getName());
+    }
+
+    protected void unsetDataProviderAuthorizer(DataProviderAuthorizer dataProviderAuthorizer) {
+        getDataProviderHelper().removeDataProviderAuthorizerClass(dataProviderAuthorizer.getClass().getName());
+        LOGGER.debug("Data Provider Authorizer '{}' unregistered.", dataProviderAuthorizer.getClass().getName());
+    }
+
     /**
      * Handle initiation of the connection map the session object in the session map.
      *
@@ -103,6 +124,43 @@ public class DataProviderEndPoint implements WebSocketEndpoint {
     @OnMessage
     public void onMessage(String message, WebSocketConnection webSocketConnection) {
         DataProviderConfigRoot dataProviderConfigRoot = new Gson().fromJson(message, DataProviderConfigRoot.class);
+        String authoringClassName;
+        try {
+            Object webSocketConfiguration
+                    = getDataProviderHelper().getConfigProvider().getConfigurationObject(WEB_SOCKET_CONFIG_HEADER);
+            if (webSocketConfiguration != null) {
+                JSONObject webSocketConfigJSON = new JSONObject(new Gson().toJson(webSocketConfiguration));
+                if (!webSocketConfigJSON.has(WEB_SOCKET_AUTHORIZING_CLASS_CONFIG_HEADER)) {
+                    throw new Exception("Web socket authorizing class cannot be found in the deployment yaml file.");
+                }
+                authoringClassName = (String) webSocketConfigJSON.get(WEB_SOCKET_AUTHORIZING_CLASS_CONFIG_HEADER);
+            } else {
+                authoringClassName = DEFAULT_WEBSOCKET_AUTHORIZING_CLASS;
+            }
+            DataProviderAuthorizer dataProviderAuthorizer;
+            try {
+                dataProviderAuthorizer = getDataProviderHelper().getDataProviderAuthorizer(authoringClassName);
+            } catch (NullPointerException e) {
+                throw new Exception("Cannot find the Data Provider Authorizer class for the given class name: "
+                        + authoringClassName + ".");
+            }
+            boolean authorizerResult
+                    = dataProviderAuthorizer.authorize(dataProviderConfigRoot);
+            if (!authorizerResult) {
+                throw new Exception("Access denied to data provider.");
+            }
+        } catch (Exception e) {
+            try {
+                sendText(webSocketConnection.getChannelId(), e.getMessage());
+            } catch (IOException e1) {
+                //ignore
+            }
+            LOGGER.error("Error occurred while authorizing the access to data provider. " + dataProviderConfigRoot
+                    .getProviderName() + ". " + e.getMessage(), e);
+            onError(e);
+            return;
+        }
+
         try {
             if (dataProviderConfigRoot.getAction().equalsIgnoreCase(DataProviderConfigRoot.Types.SUBSCRIBE.toString()
             )) {

--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/utils/DataProviderValueHolder.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/utils/DataProviderValueHolder.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.data.provider.utils;
 
 import org.wso2.carbon.config.provider.ConfigProvider;
 import org.wso2.carbon.data.provider.DataProvider;
+import org.wso2.carbon.data.provider.DataProviderAuthorizer;
 import org.wso2.carbon.datasource.core.api.DataSourceService;
 
 import java.util.Map;
@@ -35,6 +36,7 @@ public class DataProviderValueHolder {
     private ConfigProvider configProvider = null;
     private Map<String, Map<String, DataProvider>> sessionDataProviderMap = new ConcurrentHashMap<>();
     private Map<String, Class> dataProviderClassMap = new ConcurrentHashMap<>();
+    private Map<String, DataProviderAuthorizer> dataProviderAuthorizerClassMap = new ConcurrentHashMap<>();
 
     public static DataProviderValueHolder getDataProviderHelper() {
         return dataProviderHelper;
@@ -56,6 +58,15 @@ public class DataProviderValueHolder {
         this.configProvider = configProvider;
     }
 
+    public DataProviderAuthorizer getDataProviderAuthorizer(String dataProviderAuthorizerClassName) {
+        return this.dataProviderAuthorizerClassMap.get(dataProviderAuthorizerClassName);
+    }
+
+    public void setDataProviderAuthorizer(String dataProviderAuthorizerClassName,
+                                          DataProviderAuthorizer dataProviderAuthorizer) {
+        this.dataProviderAuthorizerClassMap.put(dataProviderAuthorizerClassName, dataProviderAuthorizer);
+    }
+
     public void setDataProvider(String providerName, DataProvider dataProvider) {
         this.dataProviderClassMap.put(providerName, dataProvider.getClass());
     }
@@ -74,6 +85,10 @@ public class DataProviderValueHolder {
 
     public void removeDataProviderClass(String providerName) {
         this.dataProviderClassMap.remove(providerName);
+    }
+
+    public void removeDataProviderAuthorizerClass(String dataProviderAuthorizerClassName) {
+        this.dataProviderAuthorizerClassMap.remove(dataProviderAuthorizerClassName);
     }
 
     public void removeSessionData(String sessionId) {


### PR DESCRIPTION
## Purpose
Add DataProviderAuthorizer to secure WebSocket communication.

## Goals
Add security to web socket connections used in the data provider.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes