### PR TITLE
Get time as Timestamp value

### DIFF
--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/rdbms/RDBMSStreamingDataProvider.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/rdbms/RDBMSStreamingDataProvider.java
@@ -71,7 +71,7 @@ public class RDBMSStreamingDataProvider extends AbstractRDBMSDataProvider {
                             } else if (metadata.getTypes()[i].equals(DataSetMetadata.Types.ORDINAL)) {
                                 rowData[i] = resultSet.getString(i + 1);
                             } else if (metadata.getTypes()[i].equals(DataSetMetadata.Types.TIME)) {
-                                rowData[i] = resultSet.getDouble(i + 1);
+                                rowData[i] = resultSet.getTimestamp(i + 1);
                             } else {
                                 if (LOGGER.isDebugEnabled()) {
                                     LOGGER.debug("Meta Data type not defined, added value of the given column as a " +


### PR DESCRIPTION
## Purpose
When retrieving time value from RDBMS, get time as Timestamp value rather than as Double.