### PR TITLE
Add metadata type check when casting incremental column

### DIFF
--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/rdbms/RDBMSStreamingDataProvider.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/rdbms/RDBMSStreamingDataProvider.java
@@ -80,7 +80,8 @@ public class RDBMSStreamingDataProvider extends AbstractRDBMSDataProvider {
                                 rowData[i] = resultSet.getObject(i + 1);
                             }
                             if (metadata.getNames()[i].equalsIgnoreCase(getRdbmsProviderConfig()
-                                    .getIncrementalColumn())) {
+                                    .getIncrementalColumn()) &&
+                                    !metadata.getTypes()[i].equals(DataSetMetadata.Types.TIME)) {
                                 if (lastRecordValue < (double) rowData[i]) {
                                     lastRecordValue = (double) rowData[i];
                                 }


### PR DESCRIPTION
## Purpose
When a column of type 'Time' is set as the incremental column, casting the timestamp value to a double results in an error.  This error can be eliminated by avoiding casting to double if the type is 'Time'.