### PR TITLE
Add SSO support for Business Rules

### DIFF
--- a/components/org.wso2.carbon.business.rules.web/src/api/AuthenticationAPI.js
+++ b/components/org.wso2.carbon.business.rules.web/src/api/AuthenticationAPI.js
@@ -26,6 +26,8 @@ import BusinessRulesUtilityFunctions from '../utils/BusinessRulesUtilityFunction
 // Auth Utils
 import AuthManager from '../utils/AuthManager';
 
+const REFRESH_TOKEN_COOKIE = 'PRT';
+
 /**
  * Authentication API base path
  */
@@ -34,7 +36,12 @@ const basePath = window.location.origin;
 /**
  * Password grant type
  */
-const passwordGrantType = 'password';
+const GRANT_TYPE_PASSWORD = 'password';
+
+/**
+ * Refresh Token grant type
+ */
+const GRANT_TYPE_REFRESH = 'refresh_token';
 
 /**
  * App context starting from forward slash
@@ -66,13 +73,13 @@ export default class AuthenticationAPI {
         return AuthenticationAPI
             .getHttpClient()
             .post(`/login/${appContext}`, Qs.stringify({
-                grantType: 'refresh_token',
+                grantType: GRANT_TYPE_REFRESH,
                 rememberMe: true,
             }), {
                 headers: {
                     'Content-Type': MediaType.APPLICATION_WWW_FORM_URLENCODED,
-                    Authorization: 'Bearer ' + AuthManager.getCookie('RTK'),
-                    Accept: MediaType.APPLICATION_JSON,
+                    'Authorization': "Bearer " + AuthManager.getCookie(REFRESH_TOKEN_COOKIE),
+                    'Accept': MediaType.APPLICATION_JSON
                 },
             });
     }
@@ -84,13 +91,13 @@ export default class AuthenticationAPI {
      * @param {boolean} rememberMe      Remember me flag
      * @returns {AxiosPromise}          Response after the login
      */
-    static login(username, password, rememberMe = false) {
+    static login(username, password, rememberMe = false, grantType = GRANT_TYPE_PASSWORD) {
         return AuthenticationAPI
             .getHttpClient()
             .post(`/login/${appContext}`, Qs.stringify({
                 username,
                 password,
-                grantType: passwordGrantType,
+                grantType,
                 rememberMe,
                 appId: 'br_' + BusinessRulesUtilityFunctions.generateGUID(),
             }), {
@@ -113,5 +120,20 @@ export default class AuthenticationAPI {
                     Authorization: `Bearer ${token}`,
                 },
             });
+    }
+
+    static ssoLogout(accessToken, idToken) {
+        return AuthenticationAPI.getHttpClient()
+            .get(`/logout/slo/${appContext}`, {
+                headers: {
+                    Authorization: `Bearer ${accessToken}`,
+                    Fid: idToken,
+                },
+            });
+    }
+
+    static getAuthType() {
+        return AuthenticationAPI.getHttpClient()
+            .get('/login/auth-type');
     }
 }

--- a/components/org.wso2.carbon.business.rules.web/src/api/AuthenticationAPI.js
+++ b/components/org.wso2.carbon.business.rules.web/src/api/AuthenticationAPI.js
@@ -25,23 +25,12 @@ import { MediaType } from '../constants/AuthConstants';
 import BusinessRulesUtilityFunctions from '../utils/BusinessRulesUtilityFunctions';
 // Auth Utils
 import AuthManager from '../utils/AuthManager';
-
-const REFRESH_TOKEN_COOKIE = 'PRT';
+import { Constants } from '../components/auth/Constants';
 
 /**
  * Authentication API base path
  */
 const basePath = window.location.origin;
-
-/**
- * Password grant type
- */
-const GRANT_TYPE_PASSWORD = 'password';
-
-/**
- * Refresh Token grant type
- */
-const GRANT_TYPE_REFRESH = 'refresh_token';
 
 /**
  * App context starting from forward slash
@@ -73,12 +62,12 @@ export default class AuthenticationAPI {
         return AuthenticationAPI
             .getHttpClient()
             .post(`/login/${appContext}`, Qs.stringify({
-                grantType: GRANT_TYPE_REFRESH,
+                grantType: Constants.GRANT_TYPE_REFRESH,
                 rememberMe: true,
             }), {
                 headers: {
                     'Content-Type': MediaType.APPLICATION_WWW_FORM_URLENCODED,
-                    'Authorization': "Bearer " + AuthManager.getCookie(REFRESH_TOKEN_COOKIE),
+                    'Authorization': "Bearer " + AuthManager.getCookie(Constants.REFRESH_TOKEN_COOKIE),
                     'Accept': MediaType.APPLICATION_JSON
                 },
             });
@@ -91,7 +80,7 @@ export default class AuthenticationAPI {
      * @param {boolean} rememberMe      Remember me flag
      * @returns {AxiosPromise}          Response after the login
      */
-    static login(username, password, rememberMe = false, grantType = GRANT_TYPE_PASSWORD) {
+    static login(username, password, rememberMe = false, grantType = Constants.GRANT_TYPE_PASSWORD) {
         return AuthenticationAPI
             .getHttpClient()
             .post(`/login/${appContext}`, Qs.stringify({

--- a/components/org.wso2.carbon.business.rules.web/src/components/auth/Constants.jsx
+++ b/components/org.wso2.carbon.business.rules.web/src/components/auth/Constants.jsx
@@ -31,4 +31,7 @@ export const Constants = {
   SESSION_USER_COOKIE: 'BR_USER',
 
   REFERRER_KEY: 'referrer',
+
+  GRANT_TYPE_PASSWORD: 'password',
+  GRANT_TYPE_REFRESH: 'refresh_token',
 };

--- a/components/org.wso2.carbon.business.rules.web/src/components/auth/Constants.jsx
+++ b/components/org.wso2.carbon.business.rules.web/src/components/auth/Constants.jsx
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+import React, { Component } from 'react';
+
+export const Constants = {
+  AUTH_TYPE_UNKNOWN: 'unknown',
+  AUTH_TYPE_DEFAULT: 'default',
+  AUTH_TYPE_SSO: 'sso',
+
+  // Cookies
+  REFRESH_TOKEN_COOKIE: 'PRT',
+  ID_TOKEN_COOKIE: 'ORT',
+  USER_DTO_COOKIE: 'USER_DTO',
+  SESSION_USER_COOKIE: 'BR_USER',
+
+  REFERRER_KEY: 'referrer',
+};

--- a/components/org.wso2.carbon.business.rules.web/src/components/auth/Login.jsx
+++ b/components/org.wso2.carbon.business.rules.web/src/components/auth/Login.jsx
@@ -87,7 +87,6 @@ export default class Login extends Component {
       });
   }
 
-
   /**
    * Get the referrer URL for the redirection after successful login.
    * @returns {string | string}
@@ -330,7 +329,6 @@ export default class Login extends Component {
       </div>
     );
   }
-
 
   render() {
     const { authenticated, authType } = this.state;

--- a/components/org.wso2.carbon.business.rules.web/src/components/auth/Login.jsx
+++ b/components/org.wso2.carbon.business.rules.web/src/components/auth/Login.jsx
@@ -130,10 +130,11 @@ export default class Login extends Component {
    * Initializes the SSO authentication flow.
    */
   initSSOAuthenticationFlow() {
-    if (AuthManager.isSSOAuthenticated()) {
+    const userCookie = AuthManager.getSSOUserCookie();
+    if (userCookie) {
       const {
         authUser, pID, lID, validityPeriod, iID,
-      } = AuthManager.getSSOUserCookie();
+      } = userCookie;
       localStorage.setItem('rememberMe', true);
       localStorage.setItem('username', authUser);
       AuthManager.setUser({

--- a/components/org.wso2.carbon.business.rules.web/src/components/auth/Login.jsx
+++ b/components/org.wso2.carbon.business.rules.web/src/components/auth/Login.jsx
@@ -41,7 +41,6 @@ import { Constants } from './Constants';
  */
 const appContext = window.contextPath;
 
-
 const styles = {
   cookiePolicy: {
     padding: '10px',

--- a/components/org.wso2.carbon.business.rules.web/src/components/auth/Logout.jsx
+++ b/components/org.wso2.carbon.business.rules.web/src/components/auth/Logout.jsx
@@ -21,6 +21,7 @@ import React, { Component } from 'react';
 import { Redirect } from 'react-router-dom';
 // Auth Utils
 import AuthManager from '../../utils/AuthManager';
+import { Constants } from './Constants';
 
 /**
  * App context.
@@ -34,19 +35,28 @@ export default class Logout extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      redirectToLogin: false,
+      redirectUrl: '',
     };
   }
 
   componentDidMount() {
-    AuthManager.logout()
-      .then(() => this.setState({ redirectToLogin: true }));
+    AuthManager.getAuthType()
+      .then((response) => {
+        if (response.data.authType === Constants.AUTH_TYPE_SSO) {
+          AuthManager.ssoLogout().then((redirectUrl) => {
+            location.href = redirectUrl;
+          });
+        } else {
+          AuthManager.logout()
+            .then(() => {
+              this.setState({ redirectUrl: '/login' });
+            });
+        }
+      });
   }
 
   render() {
-    if (this.state.redirectToLogin) {
-      return <Redirect to={{ pathname: '/login' }} />;
-    }
-    return null;
+    const { redirectUrl } = this.state;
+    return <Redirect to={{ pathname: redirectUrl }} />;
   }
 }

--- a/components/org.wso2.carbon.business.rules.web/src/utils/AuthManager.js
+++ b/components/org.wso2.carbon.business.rules.web/src/utils/AuthManager.js
@@ -21,7 +21,6 @@ import Qs from 'qs';
 import AuthenticationAPI from '../api/AuthenticationAPI';
 import { Constants } from '../components/auth/Constants';
 
-
 /**
  * Name of the session cookie
  */
@@ -241,9 +240,6 @@ export default class AuthManager {
                 .catch(error => reject(error));
         });
     }
-
-
-
 
     /**
      * Logs out the user by revoking tokens and clearing the session

--- a/components/org.wso2.carbon.business.rules.web/src/utils/AuthManager.js
+++ b/components/org.wso2.carbon.business.rules.web/src/utils/AuthManager.js
@@ -123,15 +123,6 @@ export default class AuthManager {
     }
 
     /**
-     * Check if SSO authenticated.
-     *
-     * @returns {boolean}
-     */
-    static isSSOAuthenticated() {
-        return !!this.getSSOUserCookie();
-    }
-
-    /**
      * Checks whether remember me has been set or not
      * @returns {boolean}       Remember me status
      */


### PR DESCRIPTION
## Purpose
This PR will add SSO support for business rules component ( OIDC )

## Approach
Configuration similar to below needs to be added to the deployment.yaml of the dashboard profile.
```yaml
auth.configs:
  type: apim
  ssoEnabled: true
  properties:
    adminScope: apim_analytics:admin_carbon.super
    allScopes: apim_analytics:admin apim_analytics:product_manager apim_analytics:api_developer apim_analytics:app_developer apim_analytics:devops_engineer apim_analytics:analytics_viewer apim_analytics:everyone openid apim:api_view apim:subscribe
    adminServiceBaseUrl: https://localhost:9443
    adminUsername: admin
    adminPassword: admin
    kmDcrUrl: https://localhost:9443/client-registration/v0.15/register
    kmTokenUrlForRedirection: https://localhost:9443/oauth2
    kmTokenUrl: https://localhost:9443/oauth2
    kmUsername: admin
    kmPassword: admin
    portalAppContext: analytics-dashboard
    businessRulesAppContext : business-rules
    cacheTimeout: 900
    baseUrl: https://localhost:9643
    grantType: authorization_code
    publisherUrl: https://localhost:9443
    #storeUrl: https://localhost:9443
```