### PR TITLE
Extract domain from header 

### DIFF
--- a/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/impl/LoginApiServiceImpl.java
+++ b/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/impl/LoginApiServiceImpl.java
@@ -49,6 +49,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.zip.DeflaterOutputStream;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.NewCookie;
@@ -109,6 +110,8 @@ public class LoginApiServiceImpl extends LoginApiService {
             idPClientProperties.put(IdPClientConstants.APP_NAME, trimmedAppName);
             idPClientProperties.put(IdPClientConstants.GRANT_TYPE, grantType);
             idPClientProperties.put(IdPClientConstants.REMEMBER_ME, rememberMe.toString());
+            String domain = AuthUtil.getDomainFromHeader(request);
+            idPClientProperties.put("Domain", domain);
             String refToken;
             if (IdPClientConstants.REFRESH_GRANT_TYPE.equals(grantType)) {
                 refToken = AuthUtil

--- a/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/impl/LoginApiServiceImpl.java
+++ b/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/impl/LoginApiServiceImpl.java
@@ -49,7 +49,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.zip.DeflaterOutputStream;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.NewCookie;
@@ -110,8 +109,7 @@ public class LoginApiServiceImpl extends LoginApiService {
             idPClientProperties.put(IdPClientConstants.APP_NAME, trimmedAppName);
             idPClientProperties.put(IdPClientConstants.GRANT_TYPE, grantType);
             idPClientProperties.put(IdPClientConstants.REMEMBER_ME, rememberMe.toString());
-            String domain = AuthUtil.getDomainFromHeader(request);
-            idPClientProperties.put("Domain", domain);
+            idPClientProperties.put("Domain", AuthUtil.getDomainFromHeader(request));
             String refToken;
             if (IdPClientConstants.REFRESH_GRANT_TYPE.equals(grantType)) {
                 refToken = AuthUtil

--- a/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/util/AuthUtil.java
+++ b/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/util/AuthUtil.java
@@ -17,7 +17,9 @@
  */
 package org.wso2.carbon.analytics.auth.rest.api.util;
 
+import org.wso2.carbon.analytics.idp.client.core.api.IdPClient;
 import org.wso2.carbon.streaming.integrator.common.utils.SPConstants;
+import org.wso2.msf4j.Request;
 
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -106,5 +108,14 @@ public class AuthUtil {
                     .append(AuthRESTAPIConstants.DEFAULT_EXPIRES_COOKIE).append(COOKIE_VALUE_SEPERATOR);
         }
         return new NewCookie(name, stringBuilder.toString());
+    }
+
+    public static String getDomainFromHeader(Request request) {
+
+       String tenantDomain = request.getHeader("X-WSO2-Tenant");
+        if(tenantDomain == null) {
+            tenantDomain = "carbon.super";
+        }
+        return tenantDomain;
     }
 }

--- a/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/util/AuthUtil.java
+++ b/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/util/AuthUtil.java
@@ -110,6 +110,12 @@ public class AuthUtil {
         return new NewCookie(name, stringBuilder.toString());
     }
 
+    /**
+     * Set tenant domain via X-WSO2-Tenant header. This method is specifically implemented to
+     * support custom URLs for dashboard portal in api-cloud.
+     * @param request
+     * @return value of X-WSO2-Tenant header.
+     */
     public static String getDomainFromHeader(Request request) {
 
        String tenantDomain = request.getHeader("X-WSO2-Tenant");

--- a/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/util/AuthUtil.java
+++ b/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/util/AuthUtil.java
@@ -17,7 +17,6 @@
  */
 package org.wso2.carbon.analytics.auth.rest.api.util;
 
-import org.wso2.carbon.analytics.idp.client.core.api.IdPClient;
 import org.wso2.carbon.streaming.integrator.common.utils.SPConstants;
 import org.wso2.msf4j.Request;
 

--- a/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/util/AuthUtil.java
+++ b/components/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/util/AuthUtil.java
@@ -117,8 +117,8 @@ public class AuthUtil {
      */
     public static String getDomainFromHeader(Request request) {
 
-       String tenantDomain = request.getHeader("X-WSO2-Tenant");
-        if(tenantDomain == null) {
+        String tenantDomain = request.getHeader("X-WSO2-Tenant");
+        if (tenantDomain == null) {
             tenantDomain = "carbon.super";
         }
         return tenantDomain;


### PR DESCRIPTION
## Purpose

API cloud supports custom URLs via header 'x-wso2-tenant'. In order to support this functionality for in carbon-5, this change is being added. 