### PR TITLE
Modify Siddhi data provider to use OnDemandQuery

### DIFF
--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/siddhi/SiddhiProvider.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/siddhi/SiddhiProvider.java
@@ -33,8 +33,6 @@ import io.siddhi.core.SiddhiAppRuntime;
 import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.query.api.definition.Attribute;
-import io.siddhi.query.api.execution.query.StoreQuery;
-import io.siddhi.query.compiler.SiddhiCompiler;
 import io.siddhi.query.compiler.exception.SiddhiParserException;
 
 import java.util.ArrayList;
@@ -79,9 +77,8 @@ public class SiddhiProvider extends AbstractDataProvider {
         SiddhiAppRuntime siddhiAppRuntime = getSiddhiAppRuntime();
         siddhiAppRuntime.setPurgingEnabled(false);
         siddhiAppRuntime.start();
-        StoreQuery storeQuery = SiddhiCompiler.parseStoreQuery(siddhiDataProviderConfig.getQueryData()
-                .getAsJsonObject().get(QUERY).getAsString());
-        Attribute[] outputAttributeList = siddhiAppRuntime.getStoreQueryOutputAttributes(storeQuery);
+        String onDemandQuery = siddhiDataProviderConfig.getQueryData().getAsJsonObject().get(QUERY).getAsString();
+        Attribute[] outputAttributeList = siddhiAppRuntime.getOnDemandQueryOutputAttributes(onDemandQuery);
         metadata = new DataSetMetadata(outputAttributeList.length);
         Attribute outputAttribute;
         for (int i = 0; i < outputAttributeList.length; i++) {


### PR DESCRIPTION
## Purpose
This PR modifies the Siddhi data provider component to use `OnDemandQuery` instead of `StoreQuery` to fix the `String index out of range` exception.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
https://github.com/siddhi-io/siddhi/pull/1588