### PR TITLE
[Extensions Installer] Validate SAMPLES_LIB location to accept only JAR as the usage type

### DIFF
--- a/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/util/ExtensionsInstallerUtils.java
+++ b/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/util/ExtensionsInstallerUtils.java
@@ -158,12 +158,12 @@ public class ExtensionsInstallerUtils {
                 throw new ExtensionsInstallerException(
                     String.format("Invalid value: %s for usage type.", usageType));
             } else if (usedBy == UsedByType.SAMPLES) {
-                if (usageType == UsageType.BUNDLE) {
+                if (usageType == UsageType.JAR) {
                     return ExtensionsInstallerConstants.SAMPLES_LIB_LOCATION;
-                } else if (usageType == UsageType.JAR) {
+                } else if (usageType == UsageType.BUNDLE) {
                     throw new ExtensionsInstallerException(
                         String.format("Usage type: %s is not applicable when used by: %s.",
-                            UsageType.JAR, UsedByType.SAMPLES));
+                            UsageType.BUNDLE, UsedByType.SAMPLES));
                 }
                 throw new ExtensionsInstallerException(
                     String.format("Invalid value: %s for usage type.", usageType));


### PR DESCRIPTION
##Purpose
> When dropping extension dependencies (i.e. jar files) to the `<CARBON_HOME>/samples/sample-clients/lib` directory, we should place the _non-bundle jar_ files there. The particular validation had been wrongly implemented previously, to allow only _bundles_ in the  `<CARBON_HOME>/samples/sample-clients/lib` directory. This PR corrects the validation to allow only _jars_ in the particular directory.

## Goals
> Fixing validation of allowed type in `SAMPLES_LIB` directory.