### PR TITLE
Add backward compatibility to SI docker image with old kernel

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/ExportUtils.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/ExportUtils.java
@@ -19,6 +19,9 @@
 package org.wso2.carbon.siddhi.editor.core.internal;
 
 import io.siddhi.core.stream.input.source.Source;
+import java.nio.file.InvalidPathException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.config.ConfigurationException;
@@ -168,7 +171,7 @@ public class ExportUtils {
         }
         if (EXPORT_TYPE_KUBERNETES.equals(exportType)) {
             zipFileName = "siddhi-kubernetes.zip";
-            zipFileRoot = "siddhi-kubernetes" +  File.separator;
+            zipFileRoot = "siddhi-kubernetes" + File.separator;
             if (exportAppsRequest.getKubernetesConfiguration() != null) {
                 KubernetesConfig kubernetesConfig = getKubernetesConfigs(
                         exportAppsRequest.getKubernetesConfiguration()
@@ -210,8 +213,11 @@ public class ExportUtils {
 
             // Write JARs to the zip file
             if (exportAppsRequest.getJars() != null && exportAppsRequest.getJars().size() > 0) {
+                // TODO: 3/2/20 Once the new Streaming integrator is released with carbon kernel bump revert these
+                //  changes
+
                 jarsAdded = true;
-                String jarRootDir = Paths.get(Constants.CARBON_HOME, JARS_DIR).toString();
+                String jarRootDir = Paths.get(Constants.CARBON_HOME, "lib/").toString();
                 String jarEntryRootDir = Paths.get(zipFileRoot, JARS_DIR).toString();
                 Path tempDockerJarDirPath = Paths.get(tempDockerDirectoryPath.toString(), JARS_DIR);
                 if (buildDocker && !Files.exists(tempDockerJarDirPath)) {
@@ -224,18 +230,38 @@ public class ExportUtils {
                 }
 
                 for (String jar : exportAppsRequest.getJars()) {
-                    Path jarPath = Paths.get(jarRootDir, jar);
-                    ZipEntry jarEntry = new ZipEntry(Paths.get(jarEntryRootDir, jar).toString());
-                    if (Files.isReadable(jarPath)) {
-                        zipOutputStream.putNextEntry(jarEntry);
-                        byte[] jarData = Files.readAllBytes(jarPath);
-                        zipOutputStream.write(jarData, 0, jarData.length);
-                        zipOutputStream.closeEntry();
-                        if (buildDocker) {
-                            Files.write(Paths.get(tempDockerJarDirPath.toString(), jar), jarData);
-                        }
+
+                    Pattern originalJarPattern = Pattern.compile("(.*).jar$");
+                    Matcher matcher = originalJarPattern.matcher(jar);
+
+                    String convertedJarName = "";
+                    if (matcher.find()) {
+                        convertedJarName = matcher.group(1).replace("-", "_").concat("_1.0.0.jar");
                     } else {
-                        log.error("JAR file" + jarPath.toString() + " is not readable.");
+                        log.error("JAR file is not valid.");
+                    }
+
+
+                    try {
+                        Path jarPath = Paths.get(jarRootDir, convertedJarName);
+                        ZipEntry jarEntry = new ZipEntry(Paths.get(jarEntryRootDir, jar).toString());
+                        if (Files.isReadable(jarPath)) {
+                            zipOutputStream.putNextEntry(jarEntry);
+                            byte[] jarData = Files.readAllBytes(jarPath);
+                            zipOutputStream.write(jarData, 0, jarData.length);
+                            zipOutputStream.closeEntry();
+                            if (buildDocker) {
+                                Files.write(Paths.get(tempDockerJarDirPath.toString(), jar), jarData);
+                            }
+                        } else {
+                            log.error("JAR file" + jarPath.toString() + " is not readable.");
+                            throw new DockerGenerationException("Jar file provided has not been converted to an OSGi " +
+                                    "bundle. Please do a restart of the server to proceed");
+                        }
+                    } catch (InvalidPathException e) {
+                        throw new DockerGenerationException("Jar file provided has not been converted to an OSGi " +
+                                "bundle. Please do a restart of the server to proceed", e);
+
                     }
                 }
             }
@@ -432,7 +458,7 @@ public class ExportUtils {
             } else {
                 // Add Docker README.md
                 StringBuilder portBindingStr = new StringBuilder();
-                for (int port: exposePorts) {
+                for (int port : exposePorts) {
                     portBindingStr.append("-p ");
                     portBindingStr.append(port);
                     portBindingStr.append(":");
@@ -487,7 +513,7 @@ public class ExportUtils {
      *
      * @return Path
      */
-    public Path getTempDockerPath()  {
+    public Path getTempDockerPath() {
         if (tempDockerDirectoryPath != null) {
             return tempDockerDirectoryPath;
         } else {


### PR DESCRIPTION
## Purpose
SI base image still uses the old version of carbon-kernel which doesn't support jars/bundles directories this would make the SI tooling to support that version until a new docker image is released.

## Test environment
JDK 1.8.0_211