### PR TITLE
[Extension Installer] Download bundles initially to the 'bundles' directory instead of 'lib' directory

### DIFF
--- a/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/constants/ExtensionsInstallerConstants.java
+++ b/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/constants/ExtensionsInstallerConstants.java
@@ -33,6 +33,7 @@ public class ExtensionsInstallerConstants {
         Utils.getRuntimePath().normalize().toString() + "/resources/extensionsInstaller/extensionDependencies.json";
     private static final String CARBON_HOME = Utils.getCarbonHome().normalize().toString();
     public static final String RUNTIME_JARS_LOCATION = CARBON_HOME + "/jars";
+    public static final String RUNTIME_BUNDLES_LOCATION = CARBON_HOME + "/bundles";
     public static final String RUNTIME_LIB_LOCATION = CARBON_HOME + "/lib";
     public static final String SAMPLES_LIB_LOCATION = CARBON_HOME + "/samples/sample-clients/lib";
 

--- a/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/execution/DependencyInstallerImpl.java
+++ b/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/execution/DependencyInstallerImpl.java
@@ -213,17 +213,14 @@ public class DependencyInstallerImpl implements DependencyInstaller {
         if (lookupRegex != null) {
             boolean hasFailures = false;
             for (UsageConfig usage : dependency.getUsages()) {
-                // Delete jar(s) for the usage from the final directory.
+                // Delete jar(s) for the usage, from the directory where they are finally put to after conversion.
                 boolean deletedInFinalDirectory =
                     deleteMatchingJars(lookupRegex, ExtensionsInstallerUtils.getBundleLocation(usage));
-                hasFailures = !deletedInFinalDirectory;
+                // Delete jar(s) for the usage, from the initial download directory (before conversion).
+                boolean deletedInInitialDirectory =
+                    deleteMatchingJars(lookupRegex, ExtensionsInstallerUtils.getInstallationLocation(usage));
 
-                // Only for non-bundle usages, delete jar(s) from the initial directory as well.
-                if (usage.getType() == UsageType.JAR) {
-                    boolean deletedInInitialDirectory =
-                        deleteMatchingJars(lookupRegex, ExtensionsInstallerUtils.getInstallationLocation(usage));
-                    hasFailures = hasFailures || !deletedInInitialDirectory;
-                }
+                hasFailures = !deletedInFinalDirectory || !deletedInInitialDirectory;
             }
             return !hasFailures;
         } else {

--- a/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/execution/DependencyRetrieverImpl.java
+++ b/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/execution/DependencyRetrieverImpl.java
@@ -85,8 +85,14 @@ public class DependencyRetrieverImpl implements DependencyRetriever {
         String lookupRegex = dependency.getLookupRegex();
         if (lookupRegex != null) {
             for (UsageConfig usage : dependency.getUsages()) {
-                String usageDirectoryPath = ExtensionsInstallerUtils.getBundleLocation(usage);
-                if (!doesUsageFileExist(lookupRegex, usageDirectoryPath)) {
+                // Whether jar(s) for the usage exist in the directory where they are finally put to after conversion.
+                boolean existsInFinalDirectory =
+                    doesUsageFileExist(lookupRegex, ExtensionsInstallerUtils.getBundleLocation(usage));
+                // Whether jar(s) for the usage exist in the initial download directory (before conversion).
+                boolean existsInInitialDirectory =
+                    doesUsageFileExist(lookupRegex, ExtensionsInstallerUtils.getInstallationLocation(usage));
+
+                if (!existsInFinalDirectory || !existsInInitialDirectory) {
                     return false;
                 }
             }

--- a/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/util/ExtensionsInstallerUtils.java
+++ b/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/util/ExtensionsInstallerUtils.java
@@ -138,8 +138,6 @@ public class ExtensionsInstallerUtils {
 
     /**
      * Returns the directory path, where the jar for the given usage is initially put during an installation.
-     * Only for bundles, this location will be same as the location retrieved through
-     * {@link #getBundleLocation(UsageConfig)}.
      *
      * @param usage Configuration of a dependency's usage.
      * @return Directory path for installation.
@@ -153,7 +151,7 @@ public class ExtensionsInstallerUtils {
                 if (usageType == UsageType.JAR) {
                     return ExtensionsInstallerConstants.RUNTIME_JARS_LOCATION;
                 } else if (usageType == UsageType.BUNDLE) {
-                    return ExtensionsInstallerConstants.RUNTIME_LIB_LOCATION;
+                    return ExtensionsInstallerConstants.RUNTIME_BUNDLES_LOCATION;
                 }
                 throw new ExtensionsInstallerException(
                     String.format("Invalid value: %s for usage type.", usageType));


### PR DESCRIPTION
## Purpose
> - $subject
> - Adding a confirmation popup when un-installing an extension, which shares dependencies with other extensions. (The back end has been already done in https://github.com/wso2/carbon-analytics/pull/1803)

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes