### PR TITLE
[Extensions Installer] Handle PatternSyntaxException when the provided regex is invalid

### DIFF
--- a/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/execution/DependencyInstallerImpl.java
+++ b/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/execution/DependencyInstallerImpl.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
 /**
@@ -244,6 +245,8 @@ public class DependencyInstallerImpl implements DependencyInstaller {
             }
         } catch (IOException e) {
             LOGGER.error(String.format("Failed to list matching files for lookup regex: %s.", lookupRegex));
+        } catch (PatternSyntaxException e) {
+            LOGGER.error(String.format("Lookup regex: %s is invalid.", lookupRegex));
         }
         return allJarsDeleted;
     }

--- a/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/execution/DependencyRetrieverImpl.java
+++ b/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/execution/DependencyRetrieverImpl.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
+import java.util.regex.PatternSyntaxException;
 
 /**
  * Reads information related to the installation of extension dependencies. Used for retrieving extension statuses.
@@ -108,6 +109,8 @@ public class DependencyRetrieverImpl implements DependencyRetriever {
             throw new ExtensionsInstallerException(
                 String.format("Failed when matching files for regex pattern: %s in directory: %s.",
                     regexPattern, directoryPath), e);
+        } catch (PatternSyntaxException e) {
+            throw new ExtensionsInstallerException(String.format("Regex pattern: %s is invalid.", regexPattern), e);
         }
     }
 

--- a/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/internal/SiddhiExtensionsInstallerMicroservice.java
+++ b/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/internal/SiddhiExtensionsInstallerMicroservice.java
@@ -58,6 +58,8 @@ import static org.wso2.carbon.siddhi.extensions.installer.core.util.ResponseEnti
 @Path("/siddhi-extensions")
 public class SiddhiExtensionsInstallerMicroservice implements Microservice {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(SiddhiExtensionsInstallerMicroservice.class);
+
     private Map<String, ExtensionConfig> extensionConfigs;
 
     public SiddhiExtensionsInstallerMicroservice() {
@@ -76,6 +78,7 @@ public class SiddhiExtensionsInstallerMicroservice implements Microservice {
                 .type(MediaType.APPLICATION_JSON)
                 .build();
         } catch (ExtensionsInstallerException e) {
+            LOGGER.error("Failed to get installation statuses of all the extensions.", e);
             return Response
                 .status(Response.Status.INTERNAL_SERVER_ERROR)
                 .entity(e.getMessage())
@@ -95,6 +98,7 @@ public class SiddhiExtensionsInstallerMicroservice implements Microservice {
                 .type(MediaType.APPLICATION_JSON)
                 .build();
         } catch (ExtensionsInstallerException e) {
+            LOGGER.error(String.format("Failed to get installation status of extension: %s.", extensionId), e);
             return Response
                 .status(Response.Status.INTERNAL_SERVER_ERROR)
                 .entity(e.getMessage())
@@ -114,6 +118,8 @@ public class SiddhiExtensionsInstallerMicroservice implements Microservice {
                 .type(MediaType.APPLICATION_JSON)
                 .build();
         } catch (ExtensionsInstallerException e) {
+            LOGGER.error(String.format(
+                "Failed to get installation statuses of dependencies, of extension: %s.", extensionId), e);
             return Response
                 .status(Response.Status.INTERNAL_SERVER_ERROR)
                 .entity(e.getMessage())
@@ -136,6 +142,7 @@ public class SiddhiExtensionsInstallerMicroservice implements Microservice {
                 .type(MediaType.APPLICATION_JSON)
                 .build();
         } catch (ExtensionsInstallerException e) {
+            LOGGER.error(String.format("Failed to install dependencies for extension: %s.", extensionId), e);
             return Response
                 .status(Response.Status.INTERNAL_SERVER_ERROR)
                 .entity(e.getMessage())
@@ -155,6 +162,8 @@ public class SiddhiExtensionsInstallerMicroservice implements Microservice {
                 .type(MediaType.APPLICATION_JSON)
                 .build();
         } catch (ExtensionsInstallerException e) {
+            LOGGER.error(
+                String.format("Failed to get dependency sharing extensions for extension: %s.", extensionId), e);
             return Response
                 .status(Response.Status.INTERNAL_SERVER_ERROR)
                 .entity(e.getMessage())
@@ -177,6 +186,7 @@ public class SiddhiExtensionsInstallerMicroservice implements Microservice {
                 .type(MediaType.APPLICATION_JSON)
                 .build();
         } catch (ExtensionsInstallerException e) {
+            LOGGER.error(String.format("Failed to un-install dependencies for extension: %s.", extensionId), e);
             return Response
                 .status(Response.Status.INTERNAL_SERVER_ERROR)
                 .entity(e.getMessage())

--- a/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/util/ExtensionsInstallerUtils.java
+++ b/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/util/ExtensionsInstallerUtils.java
@@ -40,6 +40,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.PatternSyntaxException;
 
 /**
  * Contains utility methods that are used in Siddhi Extensions Installer.
@@ -110,9 +111,11 @@ public class ExtensionsInstallerUtils {
      * @param regexPattern  Regex pattern for file name.
      * @param directoryPath Path of the directory.
      * @return List of matching files.
-     * @throws IOException Failure occurred while walking the file tree.
+     * @throws IOException            Failure occurred while walking the file tree.
+     * @throws PatternSyntaxException The provided regex pattern is invalid.
      */
-    public static List<Path> listMatchingFiles(String regexPattern, String directoryPath) throws IOException {
+    public static List<Path> listMatchingFiles(String regexPattern, String directoryPath)
+        throws IOException, PatternSyntaxException {
         final String PATH_MATCHER_SYNTAX = "regex:";
         Path path = Paths.get(directoryPath);
         final PathMatcher matcher = FileSystems.getDefault().getPathMatcher(PATH_MATCHER_SYNTAX + regexPattern);


### PR DESCRIPTION
## Purpose
- $subject. 
> - A dependency's lookup regex - which is invalid (that fails to compile - such as `jnats[_-])2.6.5(.+).jar`) will cause the front end to freeze, when trying to load installation status of all the extensions; and doesn't provide any logs to the user.
> - This is because, the caused `PatternSyntaxException` is a run-time exception. 
> - This PR introduces catching the `PatternSyntaxException` and logging that the regex pattern is invalid.
- Logging internal server errors before returning their respective HTTP 500 responses.