### PR TITLE
Allow csv values to have delimeters character inside quotes

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/EditorMicroservice.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/internal/EditorMicroservice.java
@@ -1441,7 +1441,19 @@ public class EditorMicroservice implements Microservice {
                     }
                 }
                 if (null != (firstLine = bufferedReader.readLine())) {
-                    attributeValueList = firstLine.split(csvConfig.getDelimiter());
+                    String splitRegex = csvConfig.getDelimiter() + Constants.REGEX_TO_KEEP_QUOTES;
+                    attributeValueList = firstLine.split(splitRegex, -1);
+                    if (csvConfig.isHeaderExist() && attributeNameList.length != attributeValueList.length) {
+                        String message = "Header attribute length : " + attributeNameList.length +
+                                " and corresponding value length : " + attributeValueList.length + " does not match ";
+                        log.error(message);
+                        errorResponse.addProperty(Constants.ERROR, message);
+                        return Response
+                                .serverError()
+                                .entity(errorResponse)
+                                .type(MediaType.APPLICATION_JSON)
+                                .build();
+                    }
                     return Response.ok().entity(MetaInfoRetrieverUtils.createResponseForCSV(attributeNameList,
                             attributeValueList)).build();
                 } else {

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/Constants.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/Constants.java
@@ -112,6 +112,7 @@ public class Constants {
     public static final String OPERATOR_PREREQ_YAML_NAME = "k8-prerequisites.yaml";
     public static final String ERROR = "error";
     public static final String WARNING = "warning";
+    public static final String REGEX_TO_KEEP_QUOTES = "(?=(?:[^\\\"]*\\\"[^\\\"]*\\\")*[^\\\"]*$)";
     static final Map<String, Class<?>> SUPER_CLASS_MAP;
     static final Map<String, String> PACKAGE_NAME_MAP;
 


### PR DESCRIPTION
## Purpose
Allow delimeter value to be exist within double quotes

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes