### PR TITLE
Allow delimiter separated values to have single or double quotes

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/Constants.java
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/java/org/wso2/carbon/siddhi/editor/core/util/Constants.java
@@ -112,7 +112,7 @@ public class Constants {
     public static final String OPERATOR_PREREQ_YAML_NAME = "k8-prerequisites.yaml";
     public static final String ERROR = "error";
     public static final String WARNING = "warning";
-    public static final String REGEX_TO_KEEP_QUOTES = "(?=(?:[^\\\"]*\\\"[^\\\"]*\\\")*[^\\\"]*$)";
+    public static final String REGEX_TO_KEEP_QUOTES = "(?=(?:[^(\"|')]*(\"|')[^(\"|')]*(\"|'))*[^(\"|')]*$)";
     static final Map<String, Class<?>> SUPER_CLASS_MAP;
     static final Map<String, String> PACKAGE_NAME_MAP;
 


### PR DESCRIPTION
## Purpose
CSV values can have delimiter separated values within single quotes or double quotes

## Goals
Provide more flexibility

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
