### PR TITLE
Update link to the AWS S3 dependency.

### DIFF
--- a/features/org.wso2.carbon.siddhi.extensions.installer.core.feature/src/main/resources/extensionsInstaller/extensionDependencies.json
+++ b/features/org.wso2.carbon.siddhi.extensions.installer.core.feature/src/main/resources/extensionsInstaller/extensionDependencies.json
@@ -1387,7 +1387,7 @@
         "version": "1.0.0",
         "download": {
           "autoDownloadable": true,
-          "url": "https://repo1.maven.org/maven2/io/siddhi/extension/io/s3/siddhi-io-s3/1.0.0/siddhi-io-s3-1.0.0.jar"
+          "url": "https://repo1.maven.org/maven2/io/siddhi/extension/io/s3/siddhi-io-s3/1.0.2/siddhi-io-s3-1.0.2.jar"
         },
         "usages": [
           {


### PR DESCRIPTION
## Purpose
> Update link to the latest AWS S3 version in `extensionDependencies.json` since Samples are using the latest version and `extensionDependencies.json` pointing the older version.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes