### PR TITLE
Fix the issue Business rules does not support PostgresSQL datasources

### DIFF
--- a/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/datasource/QueryExecutor.java
+++ b/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/datasource/QueryExecutor.java
@@ -183,8 +183,7 @@ public class QueryExecutor {
             statement = getStatementForRetrievingBusinessRule(conn, uuid);
             resultSet = statement.executeQuery();
             while (resultSet.next()) {
-                Blob blob = resultSet.getBlob(2);
-                byte[] bdata = blob.getBytes(1, (int) blob.length());
+                byte[] bdata = resultSet.getBytes(2);
 
                 JsonObject jsonObject = gson.fromJson(new String(bdata, Charset.forName("UTF-8")), JsonObject
                         .class).getAsJsonObject();
@@ -236,8 +235,7 @@ public class QueryExecutor {
             resultSet = statement.executeQuery();
             while (resultSet.next()) {
                 String businessRuleUUID = resultSet.getString(1);
-                Blob blob = resultSet.getBlob(2);
-                byte[] bdata = blob.getBytes(1, (int) blob.length());
+                byte[] bdata = resultSet.getBytes(2);
 
                 JsonObject jsonObject = gson.fromJson(new String(bdata, Charset.forName("UTF-8")),
                         JsonObject.class).getAsJsonObject();
@@ -288,8 +286,7 @@ public class QueryExecutor {
             resultSet = statement.executeQuery();
             while (resultSet.next()) {
                 Integer deploymentStatus = resultSet.getInt(3);
-                Blob blob = resultSet.getBlob(2);
-                byte[] bdata = blob.getBytes(1, (int) blob.length());
+                byte[] bdata = resultSet.getBytes(2);
 
                 JsonObject jsonObject = gson.fromJson(new String(bdata, Charset.forName("UTF-8")),
                         JsonObject.class).getAsJsonObject();

--- a/components/org.wso2.carbon.business.rules.core/src/main/resources/queries.yaml
+++ b/components/org.wso2.carbon.business.rules.core/src/main/resources/queries.yaml
@@ -99,3 +99,23 @@ queries:
       ADD_RULE_TEMPLATE: INSERT INTO rule_templates VALUES (?)
       RETRIEVE_ALL_RULE_TEMPLATES: SELECT * FROM rule_templates
       DELETE_RULE_TEMPLATE: DELETE FROM rule_templates WHERE rule_templates.uuid = ?
+  -
+   type: postgresql
+   version: default
+   mappings:
+      CHECK_FOR_BUSINESS_RULES_TABLE: SELECT 1 FROM business_rules LIMIT 1
+      CREATE_BUSINESS_RULES_TABLE: CREATE TABLE business_rules ( uuid varchar(255) PRIMARY KEY, business_rule BYTEA, deployment_status int, artifact_count int )
+      ADD_BUSINESS_RULE: INSERT INTO business_rules VALUES (?, ?, ?, ?)
+      UPDATE_BUSINESS_RULE: UPDATE business_rules SET business_rule = ?, deployment_status = ? WHERE business_rules.uuid = ?
+      UPDATE_DEPLOYMENT_STATUS: UPDATE business_rules SET deployment_status = ? WHERE business_rules.uuid = ?
+      UPDATE_ARTIFACT_COUNT: UPDATE business_rules SET artifact_count = ? WHERE business_rules.uuid = ?
+      RETRIEVE_BUSINESS_RULE: SELECT uuid, business_rule, deployment_status FROM business_rules WHERE business_rules.uuid = ?
+      RETRIEVE_ALL: SELECT * FROM business_rules
+      RETRIEVE_ARTIFACT_COUNT: SELECT artifact_count FROM business_rules WHERE business_rules.uuid = ?
+      RETRIEVE_DEPLOYMENT_STATUS: SELECT deployment_status FROM business_rules WHERE business_rules.uuid = ?
+      DELETE_BUSINESS_RULE: DELETE FROM business_rules WHERE business_rules.uuid = ?
+      CHECK_FOR_RULE_TEMPLATES_TABLE: SELECT 1 FROM rule_templates LIMIT 1
+      CREATE_RULE_TEMPLATES_TABLE: CREATE TABLE rule_templates ( uuid varchar(255))
+      ADD_RULE_TEMPLATE: INSERT INTO rule_templates VALUES (?)
+      RETRIEVE_ALL_RULE_TEMPLATES: SELECT * FROM rule_templates
+      DELETE_RULE_TEMPLATE: DELETE FROM rule_templates WHERE rule_templates.uuid = ?


### PR DESCRIPTION
## Purpose
This PR will provide the capability to use the business Rules in Postgress DB

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
Oracle JDK 1.8 / Mac OS 10.15.4 