### PR TITLE
[Extension Installer] Add implementation for extension usage detection from Siddhi app

### DIFF
--- a/components/org.wso2.carbon.siddhi.extensions.installer.core/findbugs-exclude.xml
+++ b/components/org.wso2.carbon.siddhi.extensions.installer.core/findbugs-exclude.xml
@@ -27,4 +27,10 @@
         <Field name="instructions"/>
         <Bug pattern="UUF_UNUSED_FIELD"/>
     </Match>
+    <!-- The following field is only read from the ultimate response -->
+    <Match>
+        <Class name="org.wso2.carbon.siddhi.extensions.installer.core.models.SiddhiAppExtensionUsage"/>
+        <Field name="usingSiddhiElement"/>
+        <Bug pattern="URF_UNREAD_FIELD"/>
+    </Match>
 </FindBugsFilter>

--- a/components/org.wso2.carbon.siddhi.extensions.installer.core/pom.xml
+++ b/components/org.wso2.carbon.siddhi.extensions.installer.core/pom.xml
@@ -67,6 +67,28 @@
             <groupId>commons-io.wso2</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
+
+        <!-- Siddhi Dependencies -->
+        <dependency>
+            <groupId>org.wso2.orbit.org.antlr</groupId>
+            <artifactId>antlr4-runtime</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.siddhi</groupId>
+            <artifactId>siddhi-query-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.siddhi</groupId>
+            <artifactId>siddhi-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.siddhi</groupId>
+            <artifactId>siddhi-query-compiler</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.siddhi</groupId>
+            <artifactId>siddhi-annotations</artifactId>
+        </dependency>
     </dependencies>
 
     <properties>
@@ -88,6 +110,7 @@
             org.wso2.carbon.kernel;version="${carbon.kernel.package.import.version.range}",
             org.wso2.carbon.utils; version="${carbon.utils.version}",
             org.wso2.msf4j;version="${msf4j.import.version.range}",
+            io.siddhi.*;version="${siddhi.version.range}",
             *;resolution:=optional
         </import.package>
         <carbon.component>

--- a/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/config/mapping/models/ExtensionConfig.java
+++ b/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/config/mapping/models/ExtensionConfig.java
@@ -35,7 +35,8 @@ public class ExtensionConfig {
 
     public List<DependencyConfig> getManuallyInstallableDependencies() {
         return dependencies.stream()
-            .filter(dependency -> !dependency.isAutoDownloadable())
+            .filter(dependency ->
+                !dependency.isAutoDownloadable())
             .collect(Collectors.toList());
     }
 

--- a/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/config/mapping/models/ExtensionConfig.java
+++ b/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/config/mapping/models/ExtensionConfig.java
@@ -18,7 +18,8 @@
 
 package org.wso2.carbon.siddhi.extensions.installer.core.config.mapping.models;
 
-import java.util.Collections;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -28,26 +29,28 @@ import java.util.stream.Collectors;
  */
 public class ExtensionConfig {
 
-    private Map<String, String> extension;
-    private List<DependencyConfig> dependencies;
+    private Map<String, String> extension = new HashMap<>();
+    private ExtensionIdentifierConfig identifier;
+    private List<DependencyConfig> dependencies = new ArrayList<>();
 
     public List<DependencyConfig> getManuallyInstallableDependencies() {
-        if (dependencies != null) {
-            return dependencies.stream().filter(dependency -> !dependency.isAutoDownloadable())
-                .collect(Collectors.toList());
-        }
-        return Collections.emptyList();
+        return dependencies.stream()
+            .filter(dependency -> !dependency.isAutoDownloadable())
+            .collect(Collectors.toList());
     }
 
     public List<DependencyConfig> getAutoDownloadableDependencies() {
-        if (dependencies != null) {
-            return dependencies.stream().filter(DependencyConfig::isAutoDownloadable).collect(Collectors.toList());
-        }
-        return Collections.emptyList();
+        return dependencies.stream()
+            .filter(DependencyConfig::isAutoDownloadable)
+            .collect(Collectors.toList());
     }
 
     public Map<String, String> getExtensionInfo() {
         return extension;
+    }
+
+    public ExtensionIdentifierConfig getIdentifier() {
+        return identifier;
     }
 
     public List<DependencyConfig> getDependencies() {

--- a/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/config/mapping/models/ExtensionConfig.java
+++ b/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/config/mapping/models/ExtensionConfig.java
@@ -35,8 +35,7 @@ public class ExtensionConfig {
 
     public List<DependencyConfig> getManuallyInstallableDependencies() {
         return dependencies.stream()
-            .filter(dependency ->
-                !dependency.isAutoDownloadable())
+            .filter(dependency -> !dependency.isAutoDownloadable())
             .collect(Collectors.toList());
     }
 

--- a/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/config/mapping/models/ExtensionIdentifierConfig.java
+++ b/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/config/mapping/models/ExtensionIdentifierConfig.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.siddhi.extensions.installer.core.config.mapping.models;
+
+import java.util.Set;
+
+/**
+ * Denotes a special identifier for an extension.
+ * This is applicable when an extension's name cannot be directly matched with a
+ * {@link org.wso2.carbon.siddhi.extensions.installer.core.models.SiddhiAppExtensionUsage}.
+ */
+public class ExtensionIdentifierConfig {
+    private String type;
+    private String uniqueAttribute;
+    private String uniqueAttributeValue;
+    private String uniqueAttributeValueRegex;
+    private Set<String> alternativeTypes;
+
+    public boolean isUniqueAttributeValueValid() {
+        return type != null && uniqueAttribute != null && uniqueAttributeValue != null;
+    }
+
+    public boolean isUniqueAttributeValueRegexValid() {
+        return type != null && uniqueAttribute != null && uniqueAttributeValueRegex != null;
+    }
+
+    public boolean isAlternativeTypeValid() {
+        return alternativeTypes != null && !alternativeTypes.isEmpty();
+    }
+
+    public Set<String> getAlternativeTypes() {
+        return alternativeTypes;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getUniqueAttribute() {
+        return uniqueAttribute;
+    }
+
+    public String getUniqueAttributeValue() {
+        return uniqueAttributeValue;
+    }
+
+    public String getUniqueAttributeValueRegex() {
+        return uniqueAttributeValueRegex;
+    }
+}

--- a/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/execution/DependencyRetriever.java
+++ b/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/execution/DependencyRetriever.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.siddhi.extensions.installer.core.execution;
 
+import org.wso2.carbon.siddhi.extensions.installer.core.config.mapping.models.ExtensionConfig;
 import org.wso2.carbon.siddhi.extensions.installer.core.exceptions.ExtensionsInstallerException;
 import org.wso2.carbon.siddhi.extensions.installer.core.models.enums.ExtensionInstallationStatus;
 
@@ -49,6 +50,16 @@ public interface DependencyRetriever {
      * @throws ExtensionsInstallerException Failed to retrieve installation status.
      */
     Map<String, Object> getExtensionStatusFor(String extensionId) throws ExtensionsInstallerException;
+
+    /**
+     * Retrieves installation status of the given extension object.
+     * Possible installation statuses are {@link ExtensionInstallationStatus}.
+     *
+     * @param extension Configuration of an extension.
+     * @return Map containing extension information and its installation status.
+     * @throws ExtensionsInstallerException Failed to retrieve installation status.
+     */
+    Map<String, Object> getExtensionStatus(ExtensionConfig extension) throws ExtensionsInstallerException;
 
     /**
      * Retrieves statuses of all the dependencies, of the extension that has the given id.

--- a/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/execution/DependencyRetrieverImpl.java
+++ b/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/execution/DependencyRetrieverImpl.java
@@ -62,7 +62,8 @@ public class DependencyRetrieverImpl implements DependencyRetriever {
         return getExtensionStatus(extension);
     }
 
-    private Map<String, Object> getExtensionStatus(ExtensionConfig extension) throws ExtensionsInstallerException {
+    @Override
+    public Map<String, Object> getExtensionStatus(ExtensionConfig extension) throws ExtensionsInstallerException {
         return ResponseEntityCreator.createExtensionStatusResponse(
             extension, getExtensionInstallationStatus(extension));
     }

--- a/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/execution/SiddhiAppExtensionUsageDetector.java
+++ b/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/execution/SiddhiAppExtensionUsageDetector.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.siddhi.extensions.installer.core.execution;
+
+import org.wso2.carbon.siddhi.extensions.installer.core.exceptions.ExtensionsInstallerException;
+
+import java.util.Map;
+
+/**
+ * Interface which describes methods, that are used to detect extension usages in a Siddhi app.
+ */
+public interface SiddhiAppExtensionUsageDetector {
+
+    /**
+     * Returns the installation statuses of all extensions,
+     * that have been used in the Siddhi app - that has the given body.
+     *
+     * @param siddhiAppString Body of the Siddhi app, which will be used to detect extension usages.
+     * @return Status of all the extensions used in the Siddhi app that has the given body.
+     * @throws ExtensionsInstallerException Failed to retrieve installation status of an extension.
+     */
+    Map<String, Map<String, Object>> getUsedExtensionStatuses(String siddhiAppString)
+        throws ExtensionsInstallerException;
+
+}

--- a/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/execution/SiddhiAppExtensionUsageDetectorImpl.java
+++ b/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/execution/SiddhiAppExtensionUsageDetectorImpl.java
@@ -60,9 +60,7 @@ public class SiddhiAppExtensionUsageDetectorImpl implements SiddhiAppExtensionUs
                 String extensionId = usedExtension.getExtensionInfo().get(NAME_KEY);
                 if (extensionId != null) {
                     ResponseEntityCreator.addUsedExtensionStatusResponse(
-                        usage,
-                        extensionId,
-                        dependencyRetriever.getExtensionStatus(usedExtension),
+                        usage, extensionId, dependencyRetriever.getExtensionStatus(usedExtension),
                         usedExtensionStatuses);
                 }
             }

--- a/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/execution/SiddhiAppExtensionUsageDetectorImpl.java
+++ b/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/execution/SiddhiAppExtensionUsageDetectorImpl.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.siddhi.extensions.installer.core.execution;
+
+import org.wso2.carbon.siddhi.extensions.installer.core.config.mapping.models.ExtensionConfig;
+import org.wso2.carbon.siddhi.extensions.installer.core.config.mapping.models.ExtensionIdentifierConfig;
+import org.wso2.carbon.siddhi.extensions.installer.core.exceptions.ExtensionsInstallerException;
+import org.wso2.carbon.siddhi.extensions.installer.core.models.SiddhiAppExtensionUsage;
+import org.wso2.carbon.siddhi.extensions.installer.core.util.ResponseEntityCreator;
+import org.wso2.carbon.siddhi.extensions.installer.core.util.SiddhiAppUsageExtractor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Detects extensions that have been used in Siddhi apps.
+ */
+public class SiddhiAppExtensionUsageDetectorImpl implements SiddhiAppExtensionUsageDetector {
+
+    private static final String TYPE_KEY = "type";
+    private static final String NAME_KEY = "name";
+
+    /**
+     * Extension configurations, denoted by extension Id.
+     */
+    private final Map<String, ExtensionConfig> extensionConfigs;
+
+    public SiddhiAppExtensionUsageDetectorImpl(Map<String, ExtensionConfig> extensionConfigs) {
+        this.extensionConfigs = extensionConfigs;
+    }
+
+    @Override
+    public Map<String, Map<String, Object>> getUsedExtensionStatuses(String siddhiAppString)
+        throws ExtensionsInstallerException {
+        List<SiddhiAppExtensionUsage> usages = SiddhiAppUsageExtractor.extractUsages(siddhiAppString);
+        Map<String, Map<String, Object>> usedExtensionStatuses = new HashMap<>();
+        DependencyRetriever dependencyRetriever = new DependencyRetrieverImpl(extensionConfigs);
+        for (SiddhiAppExtensionUsage usage : usages) {
+            ExtensionConfig usedExtension = detectUsedExtension(usage);
+            if (usedExtension != null) {
+                String extensionId = usedExtension.getExtensionInfo().get(NAME_KEY);
+                if (extensionId != null) {
+                    ResponseEntityCreator.addUsedExtensionStatusResponse(
+                        usage,
+                        extensionId,
+                        dependencyRetriever.getExtensionStatus(usedExtension),
+                        usedExtensionStatuses);
+                }
+            }
+        }
+        return usedExtensionStatuses;
+    }
+
+    /**
+     * Matches and returns the extension which has been used by the given Siddhi app extension usage.
+     * Extension is matched in the following order:
+     * 1. Match by unique attribute value (if specified).
+     * 2. Match by regex of a unique attribute value (if specified).
+     * 3. Match by alternative type (if specified).
+     * 4. Match by name.
+     *
+     * @param usage Extension usage in a Siddhi app.
+     * @return Extension config object when a match is found, otherwise null.
+     */
+    private ExtensionConfig detectUsedExtension(SiddhiAppExtensionUsage usage) {
+        return matchByUniqueAttributeValue(usage)
+            .orElse(matchByUniqueAttributeValueRegex(usage)
+                .orElse(matchByAlternativeType(usage)
+                    .orElse(matchByName(usage)
+                        .orElse(null))));
+    }
+
+    /**
+     * Returns an optional extension config object,
+     * when the given usage matches an extension by a unique attribute's value,
+     * as specified in the extension's {@link ExtensionIdentifierConfig}.
+     * Extensions of different variations, that share the same value for 'type' in Siddhi,
+     * but are identifiable based on a unique attribute's value fall under this category.
+     * Eg:
+     * - type='rdbms' (common).
+     * - jdbc.driver.name='com.mysql.jdbc.Driver' for MySQL.
+     * - jdbc.driver.name='org.postgresql.Driver' for Postgres.
+     *
+     * @param usage Extension usage in a Siddhi app.
+     * @return Optional Extension config object if found.
+     */
+    private Optional<ExtensionConfig> matchByUniqueAttributeValue(SiddhiAppExtensionUsage usage) {
+        Optional<Map.Entry<String, ExtensionConfig>> matchedExtensionEntry =
+            extensionConfigs.entrySet().stream()
+                .filter(extension -> {
+                    ExtensionIdentifierConfig extensionIdentifier = extension.getValue().getIdentifier();
+                    if (extensionIdentifier != null && extensionIdentifier.isUniqueAttributeValueValid()) {
+                        String uniqueAttribute = extensionIdentifier.getUniqueAttribute();
+                        String uniqueAttributeValue = extensionIdentifier.getUniqueAttributeValue();
+                        return (Objects.equals(usage.getProperties().get(TYPE_KEY), extensionIdentifier.getType()) &&
+                            Objects.equals(usage.getProperties().get(uniqueAttribute), uniqueAttributeValue));
+                    }
+                    return false;
+                })
+                .findFirst();
+        return matchedExtensionEntry.map(Map.Entry::getValue);
+    }
+
+    /**
+     * Returns an optional extension config object,
+     * when the given usage matches an extension by the regex of a unique attribute's value,
+     * as specified in the extension's {@link ExtensionIdentifierConfig}.
+     * Extensions of different variations, that share the same value for 'type' in Siddhi,
+     * but are identifiable based on the regex of a unique attribute's value fall under this category.
+     * Eg:
+     * - type='cdc' (common).
+     * - url='jdbc:mysql://...' for MySQL.
+     * - url='jdbc:postgresql://...' for Postgres.
+     *
+     * @param usage Extension usage in a Siddhi app.
+     * @return Optional Extension config object if found.
+     */
+    private Optional<ExtensionConfig> matchByUniqueAttributeValueRegex(SiddhiAppExtensionUsage usage) {
+        Optional<Map.Entry<String, ExtensionConfig>> matchedExtensionEntry =
+            extensionConfigs.entrySet().stream()
+                .filter(extension -> {
+                    ExtensionIdentifierConfig extensionIdentifier = extension.getValue().getIdentifier();
+                    if (extensionIdentifier != null && extensionIdentifier.isUniqueAttributeValueRegexValid()) {
+                        String uniqueAttribute = extensionIdentifier.getUniqueAttribute();
+                        String uniqueAttributeValueRegex = extensionIdentifier.getUniqueAttributeValueRegex();
+                        return (
+                            Objects.equals(usage.getProperties().get(TYPE_KEY), extensionIdentifier.getType()) &&
+                                usage.getProperties().get(uniqueAttribute) != null &&
+                                usage.getProperties().get(uniqueAttribute).matches(uniqueAttributeValueRegex));
+                    }
+                    return false;
+                })
+                .findFirst();
+        return matchedExtensionEntry.map(Map.Entry::getValue);
+    }
+
+    /**
+     * Returns an optional extension config object,
+     * when the given usage matches an extension by an alternative type, as specified in the extension's
+     * {@link ExtensionIdentifierConfig}.
+     * Extensions such that, the same extension is denoted by different values for 'type' in Siddhi
+     * fall under this category.
+     * Eg:
+     * All of the following denote the 'http' extension.
+     * - type='http'.
+     * - type='http-service-response'.
+     * - type='http-call-response'.
+     *
+     * @param usage Extension usage in a Siddhi app.
+     * @return Optional Extension config object if found.
+     */
+    private Optional<ExtensionConfig> matchByAlternativeType(SiddhiAppExtensionUsage usage) {
+        Optional<Map.Entry<String, ExtensionConfig>> matchedExtensionEntry =
+            extensionConfigs.entrySet().stream()
+                .filter(extension -> {
+                    ExtensionIdentifierConfig extensionIdentifier = extension.getValue().getIdentifier();
+                    if (extensionIdentifier != null && extensionIdentifier.isAlternativeTypeValid()) {
+                        return extensionIdentifier.getAlternativeTypes().contains(usage.getProperties().get(TYPE_KEY));
+                    }
+                    return false;
+                })
+                .findFirst();
+        return matchedExtensionEntry.map(Map.Entry::getValue);
+    }
+
+    /**
+     * Returns an optional extension config object,
+     * when the given usage's 'type' is same as the extension's name.
+     * Extensions that don't have a special {@link ExtensionIdentifierConfig} will be matched by name.
+     * Eg: type='ibmmq' matches the extension with 'ibmmq' as its name.
+     *
+     * @param usage Extension usage in a Siddhi app.
+     * @return Optional Extension config object if found.
+     */
+    private Optional<ExtensionConfig> matchByName(SiddhiAppExtensionUsage usage) {
+        Optional<Map.Entry<String, ExtensionConfig>> matchedExtensionEntry =
+            extensionConfigs.entrySet().stream()
+                .filter(extension -> {
+                    String extensionName = extension.getValue().getExtensionInfo().get(NAME_KEY);
+                    return (extensionName != null &&
+                        Objects.equals(extensionName, usage.getProperties().get(TYPE_KEY)));
+                }).findFirst();
+        return matchedExtensionEntry.map(Map.Entry::getValue);
+    }
+
+}

--- a/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/execution/SiddhiAppExtensionUsageDetectorImpl.java
+++ b/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/execution/SiddhiAppExtensionUsageDetectorImpl.java
@@ -115,8 +115,7 @@ public class SiddhiAppExtensionUsageDetectorImpl implements SiddhiAppExtensionUs
                             Objects.equals(usage.getProperties().get(uniqueAttribute), uniqueAttributeValue));
                     }
                     return false;
-                })
-                .findFirst();
+                }).findFirst();
         return matchedExtensionEntry.map(Map.Entry::getValue);
     }
 
@@ -148,8 +147,7 @@ public class SiddhiAppExtensionUsageDetectorImpl implements SiddhiAppExtensionUs
                                 usage.getProperties().get(uniqueAttribute).matches(uniqueAttributeValueRegex));
                     }
                     return false;
-                })
-                .findFirst();
+                }).findFirst();
         return matchedExtensionEntry.map(Map.Entry::getValue);
     }
 
@@ -177,8 +175,7 @@ public class SiddhiAppExtensionUsageDetectorImpl implements SiddhiAppExtensionUs
                         return extensionIdentifier.getAlternativeTypes().contains(usage.getProperties().get(TYPE_KEY));
                     }
                     return false;
-                })
-                .findFirst();
+                }).findFirst();
         return matchedExtensionEntry.map(Map.Entry::getValue);
     }
 

--- a/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/models/SiddhiAppExtensionUsage.java
+++ b/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/models/SiddhiAppExtensionUsage.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.siddhi.extensions.installer.core.models;
+
+import io.siddhi.query.api.SiddhiElement;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Denotes the usage of an extension in a Siddhi app.
+ * This carries information about a Siddhi element, which is the user of an extension,
+ * along with its extracted properties that will be helpful in identifying the usage.
+ */
+public class SiddhiAppExtensionUsage {
+    private Map<String, String> properties = new HashMap<>();
+    private SiddhiElement usingSiddhiElement;
+
+    public SiddhiAppExtensionUsage(Map<String, String> properties, SiddhiElement usingSiddhiElement) {
+        this.properties = properties;
+        this.usingSiddhiElement = usingSiddhiElement;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+}

--- a/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/util/ResponseEntityCreator.java
+++ b/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/util/ResponseEntityCreator.java
@@ -21,9 +21,11 @@ package org.wso2.carbon.siddhi.extensions.installer.core.util;
 import org.wso2.carbon.siddhi.extensions.installer.core.config.mapping.models.DependencyConfig;
 import org.wso2.carbon.siddhi.extensions.installer.core.config.mapping.models.ExtensionConfig;
 import org.wso2.carbon.siddhi.extensions.installer.core.execution.DependencyRetriever;
+import org.wso2.carbon.siddhi.extensions.installer.core.models.SiddhiAppExtensionUsage;
 import org.wso2.carbon.siddhi.extensions.installer.core.models.enums.ExtensionInstallationStatus;
 import org.wso2.carbon.siddhi.extensions.installer.core.models.enums.ExtensionUnInstallationStatus;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,6 +48,7 @@ public class ResponseEntityCreator {
     private static final String EXTENSION_STATUS_KEY = "extensionStatus";
     private static final String DEPENDENCY_INFO_KEY = "dependencyInfo";
     private static final String DEPENDENCY_IS_INSTALLED_KEY = "isInstalled";
+    private static final String USAGES_KEY = "usages";
 
     private ResponseEntityCreator() {
         // Prevents instantiation.
@@ -172,6 +175,37 @@ public class ResponseEntityCreator {
         details.put(DEPENDENCY_INFO_KEY, dependency);
         details.put(DEPENDENCY_IS_INSTALLED_KEY, isInstalled);
         return details;
+    }
+
+    /**
+     * Adds the given siddhi app usage and the corresponding extension status,
+     * to the given map - which contains all the used extensions and their statuses.
+     *
+     * @param siddhiAppExtensionUsage Element of the Siddhi app, which uses the extension.
+     * @param extensionId             Unique id of the extension.
+     * @param extensionStatusResponse Installation status response of the extension.
+     * @param usedExtensionStatuses   The map, which maintains all used extensions and their statuses.
+     */
+    public static void addUsedExtensionStatusResponse(SiddhiAppExtensionUsage siddhiAppExtensionUsage,
+                                                      String extensionId,
+                                                      Map<String, Object> extensionStatusResponse,
+                                                      Map<String, Map<String, Object>> usedExtensionStatuses) {
+        if (!usedExtensionStatuses.containsKey(extensionId)) {
+            // This is the first usage of the extension.
+            Map<String, Object> extensionAndUsages = new HashMap<>();
+            List<SiddhiAppExtensionUsage> usages = new ArrayList<>();
+            usages.add(siddhiAppExtensionUsage);
+            extensionAndUsages.put(EXTENSION_STATUS_KEY, extensionStatusResponse);
+            extensionAndUsages.put(USAGES_KEY, usages);
+            usedExtensionStatuses.put(extensionId, extensionAndUsages);
+        } else {
+            // This extension has been already used. Add this as the next usage.
+            List<SiddhiAppExtensionUsage> usages =
+                (List<SiddhiAppExtensionUsage>) (usedExtensionStatuses.get(extensionId).get(USAGES_KEY));
+            if (usages != null) {
+                usages.add(siddhiAppExtensionUsage);
+            }
+        }
     }
 
 }

--- a/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/util/SiddhiAppUsageExtractor.java
+++ b/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/util/SiddhiAppUsageExtractor.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.siddhi.extensions.installer.core.util;
+
+import io.siddhi.query.api.SiddhiApp;
+import io.siddhi.query.api.annotation.Annotation;
+import io.siddhi.query.api.annotation.Element;
+import io.siddhi.query.api.definition.StreamDefinition;
+import io.siddhi.query.compiler.SiddhiCompiler;
+import org.wso2.carbon.siddhi.extensions.installer.core.models.SiddhiAppExtensionUsage;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Extracts usages of extensions from Siddhi apps.
+ */
+public class SiddhiAppUsageExtractor {
+
+    private static final String NAMESPACE_KEY = "namespace";
+    private static final String SOURCE_NAMESPACE = "source";
+    private static final String SINK_NAMESPACE = "sink";
+
+    private SiddhiAppUsageExtractor() {
+        // Prevents instantiation.
+    }
+
+    /**
+     * Extracts usages of extensions from the Siddhi app, that has the given body.
+     *
+     * @param siddhiAppString Body of a Siddhi app.
+     * @return Extension usages that are present in the Siddhi app.
+     */
+    public static List<SiddhiAppExtensionUsage> extractUsages(String siddhiAppString) {
+        SiddhiApp siddhiApp = SiddhiCompiler.parse(siddhiAppString);
+        return extractUsagesFromStreams(siddhiApp);
+    }
+
+    private static List<SiddhiAppExtensionUsage> extractUsagesFromStreams(SiddhiApp siddhiApp) {
+        List<SiddhiAppExtensionUsage> usages = new ArrayList<>();
+        Map<String, StreamDefinition> streamDefinitions = siddhiApp.getStreamDefinitionMap();
+        for (Map.Entry<String, StreamDefinition> streamDefinitionEntry : streamDefinitions.entrySet()) {
+            List<Annotation> streamAnnotations = streamDefinitionEntry.getValue().getAnnotations();
+            if (!streamAnnotations.isEmpty()) {
+                usages.addAll(extractStreamAnnotationInfo(streamAnnotations, SOURCE_NAMESPACE));
+                usages.addAll(extractStreamAnnotationInfo(streamAnnotations, SINK_NAMESPACE));
+            }
+        }
+        return usages;
+    }
+
+    private static List<SiddhiAppExtensionUsage> extractStreamAnnotationInfo(List<Annotation> streamAnnotations,
+                                                                             String namespace) {
+        List<Annotation> namespaceAnnotations = streamAnnotations.stream()
+            .filter(annotation -> annotation.getName().equalsIgnoreCase(namespace))
+            .collect(Collectors.toList());
+
+        List<SiddhiAppExtensionUsage> siddhiAppExtensionUsages = new ArrayList<>();
+        for (Annotation namespaceAnnotation : namespaceAnnotations) {
+            Map<String, String> annotationProperties = new HashMap<>();
+            annotationProperties.put(NAMESPACE_KEY, namespace);
+            for (Element element : namespaceAnnotation.getElements()) {
+                annotationProperties.put(element.getKey(), element.getValue());
+            }
+            siddhiAppExtensionUsages.add(new SiddhiAppExtensionUsage(annotationProperties, namespaceAnnotation));
+        }
+        return siddhiAppExtensionUsages;
+    }
+
+}

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -45,6 +45,11 @@
         <Bug pattern="UUF_UNUSED_FIELD"/>
     </Match>
     <Match>
+        <Class name="org.wso2.carbon.siddhi.extensions.installer.core.models.SiddhiAppExtensionUsage"/>
+        <Field name="usingSiddhiElement"/>
+        <Bug pattern="URF_UNREAD_FIELD"/>
+    </Match>
+    <Match>
         <Class name="org.wso2.carbon.business.rules.templates.editor.core.internal.TemplatesEditorMicroservice"/>
         <Bug pattern="OBL_UNSATISFIED_OBLIGATION"/>
     </Match>


### PR DESCRIPTION
## Purpose
$subject, from `@source`, `@sink`, and `@store` annotations.

**WIP:**
> - Add implementation to install multiple extensions at once.

To support extension detection, the following _optional_ extension identifiers have been introduced to the extensions installer's configuration file.

> An extension for a particular usage in a Siddhi app, is matched in the same order of the below mentioned identifiers. When no match is found after checking by all of these identifiers, match by name is done (the existing implementation).

**1. Unique Attribute Value Identifier**
Extensions that share the common `type`, but identifiable based on values of unique attributes.
eg:
- `type='rdbms'` (common).
- `jdbc.driver.name='com.mysql.jdbc.Driver'` for MySQL.
- `jdbc.driver.name='org.postgresql.Driver'` for Postgres.

Sample configuration:
```
"rdbms-mysql": {
    "extension": {...},

    "identifier": {
      "type": "rdbms",
      "uniqueAttribute": "jdbc.driver.name",
      "uniqueAttributeValue": "com.mysql.jdbc.Driver"
    },

    "dependencies": [...]
}
```

**2. Unique Attribute Value Regex Identifier**
Extensions that share the common `type`, but identifiable based on the regex of values of unique attributes.
eg:
- `type='cdc'` (common).
- `url='jdbc:mysql://...'` for MySQL.
- `url='jdbc:postgresql://...'` for Postgres.

Sample configuration:
```
"cdc-mysql": {
    "extension": {...},

    "identifier": {
      "type": "cdc",
      "uniqueAttribute": "url",
      "uniqueAttributeValueRegex": "jdbc:mysql:(.+)"
    },

    "dependencies": [...]
}
```

**3. Alternative Type Identifier**
Extensions such that, same extension is denoted by different `type`s.
eg:
All of the following denote the `http` extension.
- `type='http'`
- `type='http-service-response'`
- `type='http-call-response'`

Sample configuration:
```
"http": {
    "extension": {...},

    "identifier": {
      "alternativeTypes": [
        "http-call",
        "http-request",
        "http-response",
        "http-service-response",
        "http-call-response",
        "http-request",
        "http-response",
        "http-service"
      ]
    },

    "dependencies": [...]
}
```

## Goals
> Improving user experience in installing extensions.

## Related Issues
> https://github.com/wso2/streaming-integrator/issues/85