### PR TITLE
Implement the prometheus reporter feature from siddhi-io distribution

### DIFF
--- a/components/org.wso2.carbon.si.metrics.core/pom.xml
+++ b/components/org.wso2.carbon.si.metrics.core/pom.xml
@@ -69,6 +69,29 @@
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>
+
+
+        <!--Prometheus-->
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_dropwizard</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_httpserver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.msf4j</groupId>
+            <artifactId>msf4j-core</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -90,11 +113,17 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Export-Package>
-                            org.wso2.carbon.si.metrics.core.*
+                            org.wso2.carbon.si.metrics.core.*,
+                            io.prometheus.client.*,
+                            org.wso2.carbon.si.metrics.prometheus.reporter.*
                         </Export-Package>
                         <Import-Package>
-                            *;resolution:=optional,
+                            org.yaml.snakeyaml.*; version="${org.yaml.snakeyaml.version.range}",
+                            *;resolution:=optional
                         </Import-Package>
+                        <Private-Package>
+                            io.prometheus.client.*,
+                        </Private-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>
                     </instructions>
                 </configuration>

--- a/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/prometheus/reporter/PrometheusMetricsExtension.java
+++ b/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/prometheus/reporter/PrometheusMetricsExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c)  2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c)  2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/prometheus/reporter/PrometheusMetricsExtension.java
+++ b/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/prometheus/reporter/PrometheusMetricsExtension.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c)  2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.si.metrics.prometheus.reporter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.carbon.config.ConfigurationException;
+import org.wso2.carbon.config.provider.ConfigProvider;
+import org.wso2.carbon.metrics.core.MetricManagementService;
+import org.wso2.carbon.metrics.core.MetricService;
+import org.wso2.carbon.metrics.core.reporter.ReporterBuildException;
+import org.wso2.carbon.metrics.core.spi.MetricsExtension;
+import org.wso2.carbon.si.metrics.prometheus.reporter.config.PrometheusMetricsConfig;
+import org.wso2.carbon.si.metrics.prometheus.reporter.config.PrometheusReporterConfig;
+
+/**
+ * * Metrics Extension to support Prometheus Reporter.
+ */
+@Component(
+        name = "org.wso2.carbon.si.metrics.prometheus.reporter.PrometheusMetricsExtension",
+        service = MetricsExtension.class
+)
+public class PrometheusMetricsExtension implements MetricsExtension {
+
+    private static final Logger logger = LoggerFactory.getLogger(PrometheusMetricsExtension.class);
+    List<String> reporterNames = new ArrayList<>();
+
+    @Override
+    public void activate(ConfigProvider configProvider, MetricService metricService,
+                         MetricManagementService metricManagementService) {
+        PrometheusMetricsConfig prometheusMetricsConfig;
+        try {
+            prometheusMetricsConfig = configProvider.getConfigurationObject(PrometheusMetricsConfig.class);
+        } catch (ConfigurationException e) {
+            logger.warn("Error loading Metrics Configuration. Starting Prometheus Reporter " +
+                    "with default parameters.", e);
+            prometheusMetricsConfig = new PrometheusMetricsConfig();
+        }
+        Set<PrometheusReporterConfig> prometheusReporterConfigs = prometheusMetricsConfig.getReporting()
+                .getPrometheus();
+        if (prometheusReporterConfigs != null) {
+            prometheusReporterConfigs.forEach(reporterConfig -> {
+                        try {
+                            metricManagementService.addReporter(reporterConfig);
+                            reporterNames.add(reporterConfig.getName());
+                        } catch (ReporterBuildException e) {
+                            logger.warn("Failed to start prometheus reporter '" + reporterConfig.getName() + "'.", e);
+                        }
+                    }
+            );
+        }
+    }
+
+    @Override
+    public void deactivate(MetricService metricService, MetricManagementService metricManagementService) {
+        if (reporterNames != null) {
+            reporterNames.forEach(metricManagementService::removeReporter);
+        }
+    }
+
+    @Reference(
+            name = "carbon.metrics.service",
+            service = MetricService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetMetricService"
+    )
+    protected void setMetricService(MetricService metricService) {
+        // This extension should be activated only after getting MetricService.
+        // Metrics Component will activate this extension.
+        logger.debug("Metric Service is available as an OSGi service.");
+
+    }
+
+    protected void unsetMetricService(MetricService metricService) {
+        // Ignore
+    }
+}

--- a/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/prometheus/reporter/config/PrometheusMetricsConfig.java
+++ b/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/prometheus/reporter/config/PrometheusMetricsConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.si.metrics.prometheus.reporter.config;
+
+import org.wso2.carbon.config.annotation.Configuration;
+import org.wso2.carbon.config.annotation.Element;
+
+/**
+ * Configuration for Metrics.
+ */
+@Configuration(namespace = "metrics.prometheus", description = "Prometheus reporter config")
+public class PrometheusMetricsConfig {
+
+    @Element(description = "Enable Metrics Configuration")
+    private ReportingConfig reporting = new ReportingConfig();
+
+    public ReportingConfig getReporting() {
+        return reporting;
+    }
+
+}

--- a/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/prometheus/reporter/config/PrometheusReporterConfig.java
+++ b/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/prometheus/reporter/config/PrometheusReporterConfig.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.si.metrics.prometheus.reporter.config;
+
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.carbon.metrics.core.config.model.ReporterConfig;
+import org.wso2.carbon.metrics.core.reporter.ReporterBuilder;
+import org.wso2.carbon.si.metrics.prometheus.reporter.impl.PrometheusReporter;
+
+/**
+ * Configuration for Prometheus Reporter. Implements {@link ReporterBuilder} to construct a {@link PrometheusReporter}.
+ */
+public class PrometheusReporterConfig extends ReporterConfig implements ReporterBuilder<PrometheusReporter> {
+    private static final Logger logger = LoggerFactory.getLogger(PrometheusReporterConfig.class);
+    private String serverURL = "http://0.0.0.0:9080";
+
+    public PrometheusReporterConfig() {
+        super("prometheus");
+    }
+
+    public String getServerURL() {
+        return serverURL;
+    }
+
+    @Override
+    public Optional<PrometheusReporter> build(MetricRegistry metricRegistry, MetricFilter metricFilter) {
+        if (!isEnabled()) {
+            return Optional.empty();
+        }
+        logger.info("Creating Prometheus Reporter '{}' for Metrics at '{}'", getName(), serverURL);
+        return Optional.of(PrometheusReporter.forRegistry(metricRegistry, serverURL).build());
+    }
+
+}

--- a/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/prometheus/reporter/config/ReportingConfig.java
+++ b/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/prometheus/reporter/config/ReportingConfig.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.si.metrics.prometheus.reporter.config;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.wso2.carbon.metrics.core.reporter.ReporterBuilder;
+
+/**
+ * Configuration for all reporters in Metrics Core.
+ */
+
+public class ReportingConfig {
+
+    private Set<PrometheusReporterConfig> prometheus;
+
+    public ReportingConfig() {
+        this.prometheus = new HashSet<>();
+        this.prometheus.add(new PrometheusReporterConfig());
+    }
+
+    public Set<PrometheusReporterConfig> getPrometheus() {
+        return prometheus;
+    }
+
+    public void setPrometheus(Set<PrometheusReporterConfig> prometheus) {
+        this.prometheus = prometheus;
+    }
+
+    public Set<? extends ReporterBuilder> getReporterBuilders() {
+        Set<ReporterBuilder> reporterBuilders = new HashSet<>();
+
+        if (prometheus != null) {
+            reporterBuilders.addAll(prometheus);
+        }
+        return reporterBuilders;
+    }
+}

--- a/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/prometheus/reporter/impl/PrometheusMetricsLabelsMapper.java
+++ b/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/prometheus/reporter/impl/PrometheusMetricsLabelsMapper.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.si.metrics.prometheus.reporter.impl;
+
+import io.prometheus.client.dropwizard.samplebuilder.MapperConfig;
+import java.util.Map;
+
+/**
+ * class which hold metric yaml configuration.
+ */
+public class PrometheusMetricsLabelsMapper {
+
+    private Map<String, MapperConfig> metricsLabelMapping;
+
+    public Map<String, MapperConfig> getMetricsLabelMapping() {
+        return metricsLabelMapping;
+    }
+
+    public void setMetricsLabelMapping(Map<String, MapperConfig> metricsLabelMapping) {
+        this.metricsLabelMapping = metricsLabelMapping;
+    }
+
+    @Override
+    public String toString() {
+        return "YamlConfig{" + "metrics=" + metricsLabelMapping + '}';
+    }
+}

--- a/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/prometheus/reporter/impl/PrometheusReporter.java
+++ b/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/prometheus/reporter/impl/PrometheusReporter.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.si.metrics.prometheus.reporter.impl;
+
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.dropwizard.DropwizardExports;
+import io.prometheus.client.dropwizard.samplebuilder.CustomMappingSampleBuilder;
+import io.prometheus.client.dropwizard.samplebuilder.MapperConfig;
+import io.prometheus.client.dropwizard.samplebuilder.SampleBuilder;
+import io.prometheus.client.exporter.HTTPServer;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.apache.log4j.Logger;
+import org.wso2.carbon.metrics.core.reporter.impl.AbstractReporter;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.CustomClassLoaderConstructor;
+import org.yaml.snakeyaml.introspector.BeanAccess;
+
+/**
+ * A reporter which outputs measurements to prometheus.
+ */
+public class PrometheusReporter extends AbstractReporter {
+
+    private static final Logger log = Logger.getLogger(PrometheusReporter.class);
+    private static final String MAPPINGS_RESOURCE_FILE = "configuration.yaml";
+    private final MetricRegistry metricRegistry;
+    private final MetricFilter metricFilter;
+    private PrometheusReporter prometheusReporter;
+    private CollectorRegistry collectorRegistry;
+    private HTTPServer server;
+    private String reporterName;
+    private String serverURL;
+
+    private PrometheusReporter(String reporterName, MetricRegistry metricRegistry,
+                               MetricFilter metricFilter, String serverURL) {
+        super(reporterName);
+        this.reporterName = reporterName;
+        this.metricRegistry = metricRegistry;
+        this.metricFilter = metricFilter;
+        this.serverURL = serverURL;
+    }
+
+    @Override
+    public void startReporter() {
+
+        prometheusReporter = PrometheusReporter.forRegistry(metricRegistry, serverURL)
+                .filter(metricFilter)
+                .convertRatesTo(TimeUnit.SECONDS)
+                .convertDurationsTo(TimeUnit.MILLISECONDS)
+                .build();
+
+        collectorRegistry = new CollectorRegistry();
+
+        try (InputStream inputStream = this.getClass().getClassLoader().getResourceAsStream(MAPPINGS_RESOURCE_FILE)) {
+
+            Yaml yaml = new Yaml(new CustomClassLoaderConstructor(PrometheusMetricsLabelsMapper.class,
+                    PrometheusMetricsLabelsMapper.class.getClassLoader()));
+            yaml.setBeanAccess(BeanAccess.FIELD);
+            PrometheusMetricsLabelsMapper metricsLabelsMapping = yaml.loadAs(inputStream,
+                                                                                PrometheusMetricsLabelsMapper.class);
+            List<MapperConfig> metricsMappings = new ArrayList<>(
+                                                                metricsLabelsMapping.getMetricsLabelMapping().values());
+            SampleBuilder sampleBuilder = new CustomMappingSampleBuilder(metricsMappings);
+            Collector collector = new DropwizardExports(metricRegistry, sampleBuilder);
+            collectorRegistry.register(collector);
+        } catch (IOException e) {
+            log.error("Unable to read the metrics labels mappings for 'Prometheus Reporter'. " +
+                    "Starting reporter without mappings.");
+        }
+
+        try {
+
+            URL target = new URL(serverURL);
+            InetSocketAddress address = new InetSocketAddress(target.getHost(), target.getPort());
+            server = new HTTPServer(address, collectorRegistry);
+            log.info("Prometheus Server has successfully connected at " + serverURL);
+        } catch (MalformedURLException e) {
+            log.error("Invalid server url '" + serverURL + "' configured for '" + reporterName + "'.", e);
+        } catch (IOException e) {
+            log.error("Failed to start Prometheus reporter '" + reporterName + "' at '" + serverURL + "'.", e);
+        }
+    }
+
+    @Override
+    public void stopReporter() {
+        if (prometheusReporter != null) {
+            disconnect();
+            destroy();
+            prometheusReporter.stop();
+            prometheusReporter = null;
+        }
+    }
+
+    public static PrometheusReporter.Builder forRegistry(MetricRegistry registry, String serverURL) {
+        return new PrometheusReporter.Builder(registry, serverURL);
+    }
+
+    private void disconnect() {
+        if (server != null) {
+            server.stop();
+            log.info("Prometheus Server successfully stopped at " + serverURL);
+        }
+    }
+
+    private void destroy() {
+        if (collectorRegistry != null) {
+            collectorRegistry.clear();
+        }
+    }
+
+    /**
+     * Builds a {@link PrometheusReporter} with the given properties.
+     */
+    public static class Builder {
+        private final MetricRegistry registry;
+        private MetricFilter filter;
+        private String serverURL;
+
+        private Builder(MetricRegistry registry, String serverURL) {
+            this.registry = registry;
+            this.serverURL = serverURL;
+            this.filter = MetricFilter.ALL;
+        }
+
+        public Builder filter(MetricFilter filter) {
+            this.filter = filter;
+            return this;
+        }
+
+        public Builder convertDurationsTo(TimeUnit durationUnit) {
+            return this;
+        }
+
+        public Builder convertRatesTo(TimeUnit rateUnit) {
+            return this;
+        }
+
+        public PrometheusReporter build() {
+            return new PrometheusReporter("prometheus", registry, filter, serverURL);
+        }
+
+    }
+
+}

--- a/components/org.wso2.carbon.si.metrics.core/src/main/resources/configuration.yaml
+++ b/components/org.wso2.carbon.si.metrics.core/src/main/resources/configuration.yaml
@@ -1,0 +1,182 @@
+metricsLabelMapping:
+  query:
+    match: "io.siddhi.SiddhiApps.*.Siddhi.Queries.*.*"
+    name: "siddhi.query.${2}"
+    labels:
+      app: "${0}"
+      type: "query"
+      element: "${1}"
+      metrics: "${2}"
+
+  sourceMapper:
+    match: "io.siddhi.SiddhiApps.*.Siddhi.SourceMappers.*.*"
+    name: "siddhi.sourcemapper.${2}"
+    labels:
+      app: "${0}"
+      type: "sourcemapper"
+      element: "${1}"
+      metrics: "${2}"
+
+  sinkMapper:
+    match: "io.siddhi.SiddhiApps.*.Siddhi.SinkMappers.*.*"
+    name: "siddhi.sinkmapper.${2}"
+    labels:
+      app: "${0}"
+      type: "sinkmapper"
+      element: "${1}"
+      metrics: "${2}"
+
+  source:
+    match: "io.siddhi.SiddhiApps.*.Siddhi.Sources.*.*"
+    name: "siddhi.source.${2}"
+    labels:
+      app: "${0}"
+      type: "source"
+      element: "${1}"
+      metrics: "${2}"
+
+  stream:
+    match: "io.siddhi.SiddhiApps.*.Siddhi.Streams.*.*"
+    name: "siddhi.stream.${2}"
+    labels:
+      app: "${0}"
+      type: "stream"
+      element: "${1}"
+      metrics: "${2}"
+
+  sink:
+    match: "io.siddhi.SiddhiApps.*.Siddhi.Sinks.*.*"
+    name: "siddhi.sink.${2}"
+    labels:
+      app: "${0}"
+      type: "sink"
+      element: "${1}"
+      metrics: "${2}"
+
+  onDemandQuery:
+    match: "io.siddhi.SiddhiApps.*.Siddhi.OnDemandQueries.*.*"
+    name: "siddhi.ondemandquery.${2}"
+    labels:
+      app: "${0}"
+      type: "ondemandquery"
+      element: "${1}"
+      metrics: "${2}"
+
+  tables:
+    match: "io.siddhi.SiddhiApps.*.Siddhi.Tables.*.*"
+    name: "siddhi.table.${2}"
+    labels:
+      app: "${0}"
+      type: "table"
+      element: "${1}"
+      metrics: "${2}"
+
+  windows:
+    match: "io.siddhi.SiddhiApps.*.Siddhi.Windows.*.*"
+    name: "siddhi.window.${2}"
+    labels:
+      app: "${0}"
+      type: "window"
+      element: "${1}"
+      metrics: "${2}"
+
+  triggers:
+    match: "io.siddhi.SiddhiApps.*.Siddhi.Trigger.*.*"
+    name: "siddhi.trigger.${2}"
+    labels:
+      app: "${0}"
+      type: "trigger"
+      element: "${1}"
+      metrics: "${2}"
+
+  aggregation:
+    match: "io.siddhi.SiddhiApps.*.Siddhi.Aggregations.*.*"
+    name: "siddhi.aggregation.${2}"
+    labels:
+      app: "${0}"
+      type: "aggregation"
+      element: "${1}"
+      metrics: "${2}"
+
+  tableOperation:
+    match: "io.siddhi.SiddhiApps.*.Siddhi.Tables.*.*.*"
+    name: "siddhi.table.${3}"
+    labels:
+      app: "${0}"
+      type: "table"
+      element: "${1}"
+      operation: "${2}"
+      metrics: "${3}"
+
+  aggregationOperation:
+    match: "io.siddhi.SiddhiApps.*.Siddhi.Aggregations.*.*.*"
+    name: "siddhi.aggregation.${3}"
+    labels:
+      app: "${0}"
+      type: "aggregation"
+      element: "${1}"
+      operation: "${2}"
+      metrics: "${3}"
+
+  windowOperation:
+    match: "io.siddhi.SiddhiApps.*.Siddhi.Windows.*.*.*"
+    name: "siddhi.window.${3}"
+    labels:
+      app: "${0}"
+      type: "window"
+      element: "${1}"
+      operation: "${2}"
+      metrics: "${3}"
+
+  sinkOperation:
+    match: "io.siddhi.SiddhiApps.*.Siddhi.Sinks.*.*.*"
+    name: "siddhi.sink.${3}"
+    labels:
+      app: "${0}"
+      type: "sink"
+      element: "${1}"
+      operation: "${2}"
+      metrics: "${3}"
+
+  sourceOperation:
+    match: "io.siddhi.SiddhiApps.*.Siddhi.Sources.*.*.*"
+    name: "siddhi.source.${3}"
+    labels:
+      app: "${0}"
+      type: "source"
+      element: "${1}"
+      operation: "${2}"
+      metrics: "${3}"
+
+  sinkMapperOperationType:
+    match: "io.siddhi.SiddhiApps.*.Siddhi.SinkMappers.*.*.*.*"
+    name: "siddhi.sinkmapper.${4}"
+    labels:
+      app: "${0}"
+      type: "sinkmapper"
+      element: "${1}"
+      operation: "${2}"
+      operationType: "${3}"
+      metrics: "${4}"
+
+  sourceMapperOperationType:
+    match: "io.siddhi.SiddhiApps.*.Siddhi.SourceMappers.*.*.*.*"
+    name: "siddhi.sourcemapper.${4}"
+    labels:
+      app: "${0}"
+      type: "sourcemapper"
+      element: "${1}"
+      operation: "${2}"
+      operationType: "${3}"
+      metrics: "${4}"
+
+  sinkOperationType:
+    match: "io.siddhi.SiddhiApps.*.Siddhi.Sinks.*.*.*.*"
+    name: "siddhi.sink.${4}"
+    labels:
+      app: "${0}"
+      type: "sink"
+      element: "${1}"
+      operation: "${2}"
+      operationType: "${3}"
+      metrics: "${4}"

--- a/components/org.wso2.carbon.si.metrics.core/src/test/java/org/wso2/carbon/si/metrics/core/MetricsConfigTest.java
+++ b/components/org.wso2.carbon.si.metrics.core/src/test/java/org/wso2/carbon/si/metrics/core/MetricsConfigTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c)  2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.si.metrics.core;
+
+import org.wso2.carbon.si.metrics.prometheus.reporter.config.PrometheusMetricsConfig;
+import org.wso2.carbon.si.metrics.prometheus.reporter.config.PrometheusReporterConfig;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.config.ConfigurationException;
+
+/**
+ * Test Cases for {@link PrometheusMetricsConfig}.
+ */
+public class MetricsConfigTest {
+
+    private static PrometheusMetricsConfig prometheusMetricsConfig;
+
+    @BeforeClass
+    private void load() throws ConfigurationException {
+        prometheusMetricsConfig = TestUtils.getConfigProvider("metrics-prometheus.yaml")
+                .getConfigurationObject(PrometheusMetricsConfig.class);
+    }
+
+    @Test
+    public void testPrometheusConfigLoad() {
+        PrometheusReporterConfig config = prometheusMetricsConfig.getReporting().getPrometheus().iterator().next();
+        Assert.assertEquals(config.getName(), "prometheus");
+        Assert.assertTrue(config.isEnabled());
+        Assert.assertEquals(config.getServerURL(), "http://localhost:9005");
+    }
+}

--- a/components/org.wso2.carbon.si.metrics.core/src/test/java/org/wso2/carbon/si/metrics/core/MetricsConfigTest.java
+++ b/components/org.wso2.carbon.si.metrics.core/src/test/java/org/wso2/carbon/si/metrics/core/MetricsConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c)  2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c)  2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -17,6 +17,8 @@
  */
 package org.wso2.carbon.si.metrics.core;
 
+import org.wso2.carbon.si.metrics.core.util.TestConstants;
+import org.wso2.carbon.si.metrics.core.util.TestUtils;
 import org.wso2.carbon.si.metrics.prometheus.reporter.config.PrometheusMetricsConfig;
 import org.wso2.carbon.si.metrics.prometheus.reporter.config.PrometheusReporterConfig;
 import org.testng.Assert;
@@ -33,14 +35,14 @@ public class MetricsConfigTest {
 
     @BeforeClass
     private void load() throws ConfigurationException {
-        prometheusMetricsConfig = TestUtils.getConfigProvider("metrics-prometheus.yaml")
+        prometheusMetricsConfig = TestUtils.getConfigProvider(TestConstants.PROMETHEUS_CONFIG_FILE_NAME)
                 .getConfigurationObject(PrometheusMetricsConfig.class);
     }
 
     @Test
     public void testPrometheusConfigLoad() {
         PrometheusReporterConfig config = prometheusMetricsConfig.getReporting().getPrometheus().iterator().next();
-        Assert.assertEquals(config.getName(), "prometheus");
+        Assert.assertEquals(config.getName(), TestConstants.PROMETHEUS_REPORTER_NAME);
         Assert.assertTrue(config.isEnabled());
         Assert.assertEquals(config.getServerURL(), "http://localhost:9005");
     }

--- a/components/org.wso2.carbon.si.metrics.core/src/test/java/org/wso2/carbon/si/metrics/core/ReporterTest.java
+++ b/components/org.wso2.carbon.si.metrics.core/src/test/java/org/wso2/carbon/si/metrics/core/ReporterTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c)  2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.si.metrics.core;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Test;
+import org.wso2.carbon.config.ConfigurationException;
+import org.wso2.carbon.metrics.core.MetricManagementService;
+import org.wso2.carbon.metrics.core.Metrics;
+
+/**
+ * Test Cases for Reporters.
+ */
+
+public class ReporterTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(ReporterTest.class);
+    protected static Metrics metrics;
+    protected static MetricManagementService metricManagementService;
+
+    @BeforeSuite
+    protected static void init() throws ConfigurationException {
+        metrics = new Metrics(TestUtils.getConfigProvider("metrics-prometheus.yaml"));
+        metrics.activate();
+        metricManagementService = metrics.getMetricManagementService();
+    }
+
+    @AfterSuite
+    protected static void destroy() throws Exception {
+        logger.info("Deactivating Metrics");
+        metrics.deactivate();
+    }
+
+    @BeforeClass
+    private void stopReporters() {
+        metricManagementService.stopReporters();
+    }
+
+    @Test
+    public void testInvalidReporter() {
+        try {
+            metricManagementService.startReporter("INVALID");
+            Assert.fail("The reporter should not be started");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof IllegalArgumentException);
+        }
+    }
+
+    @Test
+    public void testPrometheusReporter() throws InterruptedException {
+        metricManagementService.startReporter("prometheus");
+        Assert.assertTrue(metricManagementService.isReporterRunning("prometheus"));
+        metricManagementService.report();
+        Thread.sleep(10000);
+        metricManagementService.stopReporter("prometheus");
+        Assert.assertFalse(metricManagementService.isReporterRunning("prometheus"));
+    }
+}

--- a/components/org.wso2.carbon.si.metrics.core/src/test/java/org/wso2/carbon/si/metrics/core/ReporterTest.java
+++ b/components/org.wso2.carbon.si.metrics.core/src/test/java/org/wso2/carbon/si/metrics/core/ReporterTest.java
@@ -27,6 +27,8 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.config.ConfigurationException;
 import org.wso2.carbon.metrics.core.MetricManagementService;
 import org.wso2.carbon.metrics.core.Metrics;
+import org.wso2.carbon.si.metrics.core.util.TestConstants;
+import org.wso2.carbon.si.metrics.core.util.TestUtils;
 
 /**
  * Test Cases for Reporters.
@@ -40,7 +42,7 @@ public class ReporterTest {
 
     @BeforeSuite
     protected static void init() throws ConfigurationException {
-        metrics = new Metrics(TestUtils.getConfigProvider("metrics-prometheus.yaml"));
+        metrics = new Metrics(TestUtils.getConfigProvider(TestConstants.PROMETHEUS_CONFIG_FILE_NAME));
         metrics.activate();
         metricManagementService = metrics.getMetricManagementService();
     }
@@ -68,11 +70,11 @@ public class ReporterTest {
 
     @Test
     public void testPrometheusReporter() throws InterruptedException {
-        metricManagementService.startReporter("prometheus");
-        Assert.assertTrue(metricManagementService.isReporterRunning("prometheus"));
+        metricManagementService.startReporter(TestConstants.PROMETHEUS_REPORTER_NAME);
+        Assert.assertTrue(metricManagementService.isReporterRunning(TestConstants.PROMETHEUS_REPORTER_NAME));
         metricManagementService.report();
         Thread.sleep(10000);
-        metricManagementService.stopReporter("prometheus");
-        Assert.assertFalse(metricManagementService.isReporterRunning("prometheus"));
+        metricManagementService.stopReporter(TestConstants.PROMETHEUS_REPORTER_NAME);
+        Assert.assertFalse(metricManagementService.isReporterRunning(TestConstants.PROMETHEUS_REPORTER_NAME));
     }
 }

--- a/components/org.wso2.carbon.si.metrics.core/src/test/java/org/wso2/carbon/si/metrics/core/StatisticsTestCase.java
+++ b/components/org.wso2.carbon.si.metrics.core/src/test/java/org/wso2/carbon/si/metrics/core/StatisticsTestCase.java
@@ -43,6 +43,7 @@ import io.siddhi.core.util.EventPrinter;
 import io.siddhi.core.util.statistics.EventBufferHolder;
 
 import java.util.concurrent.TimeUnit;
+import org.wso2.carbon.si.metrics.core.util.TestUtils;
 
 /**
  * Test case for carbon metrics inside siddhi.
@@ -52,11 +53,11 @@ public class StatisticsTestCase {
     private int count;
     private boolean eventArrived;
     protected static Metrics metrics;
-    
+
     protected static MetricService metricService;
-    
+
     protected static MetricManagementService metricManagementService;
-    
+
     @BeforeSuite
     protected void initMetrics() throws Exception {
         // Initialize the Metrics
@@ -66,7 +67,7 @@ public class StatisticsTestCase {
         metricService = metrics.getMetricService();
         metricManagementService = metrics.getMetricManagementService();
     }
-    
+
     @BeforeMethod
     public void init() {
         metricManagementService.setRootLevel(Level.ALL);
@@ -77,12 +78,12 @@ public class StatisticsTestCase {
         SPMetricsDataHolder.getInstance().setMetricManagementService(metricManagementService);
         metricManagementService.startReporter("Console");
     }
-    
+
     @AfterSuite
     protected static void destroy() throws Exception {
         metrics.deactivate();
     }
-    
+
     @Test
     public void statisticsMetricsFactory() throws InterruptedException {
         StatisticsConfiguration statisticsConfiguration = new StatisticsConfiguration(new SPMetricsFactory());
@@ -94,7 +95,7 @@ public class StatisticsTestCase {
                 .getFactory().createThroughputTracker("test.throughput", new SPStatisticsManager(
                         "MetricsTest"));
         AssertJUnit.assertEquals("test.throughput", throughputTracker.getName());
-        
+
         SPMemoryUsageMetric memoryUsageTracker = (SPMemoryUsageMetric) statisticsConfiguration
                 .getFactory()
                 .createMemoryUsageTracker(new SPStatisticsManager("MetricsTest"));
@@ -108,7 +109,7 @@ public class StatisticsTestCase {
             public long getBufferedEvents() {
                 return 1;
             }
-            
+
             @Override
             public boolean containsBufferedEvents() {
                 return true;
@@ -117,7 +118,7 @@ public class StatisticsTestCase {
         bufferedEventsTracker.registerEventBufferHolder(eventBufferHolder, "test.size");
         AssertJUnit.assertEquals("test.size", bufferedEventsTracker.getName(eventBufferHolder));
     }
-    
+
     @Test
     public void statisticsTest1() throws InterruptedException {
         log.info("statistics test 1");
@@ -139,7 +140,7 @@ public class StatisticsTestCase {
                 "from cseEventStream[volume > 90] " +
                 "select * " +
                 "insert into outputStream ;";
-        
+
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(siddhiApp);
         siddhiAppRuntime.addCallback("outputStream", new StreamCallback() {
             @Override
@@ -153,7 +154,7 @@ public class StatisticsTestCase {
                 }
             }
         });
-        
+
         InputHandler inputHandler = siddhiAppRuntime.getInputHandler("cseEventStream");
         siddhiAppRuntime.start();
         for (int i = 0; i < 1; i++) {
@@ -190,13 +191,13 @@ public class StatisticsTestCase {
         AssertJUnit.assertEquals("INFO", metricManagementService.getMetricLevel(name3).name());
         AssertJUnit.assertEquals("INFO", metricManagementService.getMetricLevel(name4).name());
         AssertJUnit.assertEquals("INFO", metricManagementService.getMetricLevel(name5).name());
-        
+
         AssertJUnit.assertTrue(eventArrived);
         AssertJUnit.assertEquals(3, count);
         metricManagementService.stopReporter("Console");
         siddhiAppRuntime.shutdown();
     }
-    
+
     @Test
     public void asyncTest5() throws InterruptedException {
         log.info("async test 5");
@@ -222,7 +223,7 @@ public class StatisticsTestCase {
                 "insert into outputStream ;";
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(siddhiApp);
         siddhiAppRuntime.addCallback("outputStream", new StreamCallback() {
-            
+
             @Override
             public void receive(Event[] events) {
                 EventPrinter.print(events);
@@ -236,9 +237,9 @@ public class StatisticsTestCase {
                     count++;
                 }
             }
-            
+
         });
-        
+
         InputHandler inputHandler = siddhiAppRuntime.getInputHandler("cseEventStream");
         siddhiAppRuntime.start();
         inputHandler.send(new Object[] {"WSO2", 55.6f, 100});
@@ -257,14 +258,14 @@ public class StatisticsTestCase {
         AssertJUnit.assertTrue(eventArrived);
         metricManagementService.stopReporter("Console");
     }
-    
+
     private class mockmoryObject {
         String name;
-        
+
         public mockmoryObject(String name) {
             this.name = name;
         }
-        
+
         String getName() {
             return name;
         }

--- a/components/org.wso2.carbon.si.metrics.core/src/test/java/org/wso2/carbon/si/metrics/core/util/TestConstants.java
+++ b/components/org.wso2.carbon.si.metrics.core/src/test/java/org/wso2/carbon/si/metrics/core/util/TestConstants.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.si.metrics.core.util;
+
+public class TestConstants {
+
+    public static final String PROMETHEUS_CONFIG_FILE_NAME = "metrics-prometheus.yaml";
+    public static final String PROMETHEUS_REPORTER_NAME = "prometheus";
+
+}

--- a/components/org.wso2.carbon.si.metrics.core/src/test/java/org/wso2/carbon/si/metrics/core/util/TestUtils.java
+++ b/components/org.wso2.carbon.si.metrics.core/src/test/java/org/wso2/carbon/si/metrics/core/util/TestUtils.java
@@ -1,22 +1,21 @@
 /*
- *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied. See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
- *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
-package org.wso2.carbon.si.metrics.core;
+package org.wso2.carbon.si.metrics.core.util;
 
 
 import org.wso2.carbon.config.ConfigurationException;

--- a/components/org.wso2.carbon.si.metrics.core/src/test/resources/META-INF/services/org.wso2.carbon.metrics.core.spi.MetricsExtension
+++ b/components/org.wso2.carbon.si.metrics.core/src/test/resources/META-INF/services/org.wso2.carbon.metrics.core.spi.MetricsExtension
@@ -1,0 +1,1 @@
+org.wso2.carbon.si.metrics.prometheus.reporter.PrometheusMetricsExtension

--- a/components/org.wso2.carbon.si.metrics.core/src/test/resources/conf/metrics-prometheus.yaml
+++ b/components/org.wso2.carbon.si.metrics.core/src/test/resources/conf/metrics-prometheus.yaml
@@ -1,0 +1,9 @@
+# Configuration file to test metrics with prometheus reporter
+
+# Carbon Metrics Configuration Parameters
+metrics.prometheus:
+  reporting:
+    prometheus:
+      - name: prometheus
+        enabled: true
+        serverURL: "http://localhost:9005"

--- a/components/org.wso2.carbon.si.metrics.core/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.si.metrics.core/src/test/resources/testng.xml
@@ -24,7 +24,8 @@
     <test name="carbon-analytics-metrics-tests" preserve-order="true" parallel="false">
         <classes>
             <class name="org.wso2.carbon.si.metrics.core.StatisticsTestCase"/>
-
+            <class name="org.wso2.carbon.si.metrics.core.MetricsConfigTest"/>
+            <class name="org.wso2.carbon.si.metrics.core.ReporterTest"/>
         </classes>
     </test>
 </suite>

--- a/pom.xml
+++ b/pom.xml
@@ -1580,6 +1580,29 @@
                 <artifactId>json-smart</artifactId>
                 <version>${net.minidev.version}</version>
             </dependency>
+
+            <!-- Prometheus Reporter dependencies -->
+            <dependency>
+                <groupId>io.prometheus</groupId>
+                <artifactId>simpleclient</artifactId>
+                <version>${prometheus.simpleclient.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.prometheus</groupId>
+                <artifactId>simpleclient_dropwizard</artifactId>
+                <version>${prometheus.simpleclient.dropwizard.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-core</artifactId>
+                <version>${dropwizard.metrics.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.prometheus</groupId>
+                <artifactId>simpleclient_httpserver</artifactId>
+                <version>${prometheus.simpleclient.httpserver.version}</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 
@@ -1830,6 +1853,12 @@
         <siddhi.io.nats.version>2.0.6</siddhi.io.nats.version>
         <org.testcontainers.version>1.8.0</org.testcontainers.version>
         <net.minidev.version>2.2</net.minidev.version>
+
+        <!-- Prometheus dependency version-->
+        <prometheus.simpleclient.version>0.8.0</prometheus.simpleclient.version>
+        <prometheus.simpleclient.dropwizard.version>0.8.0</prometheus.simpleclient.dropwizard.version>
+        <dropwizard.metrics.version>3.1.2</dropwizard.metrics.version>
+        <prometheus.simpleclient.httpserver.version>0.8.0</prometheus.simpleclient.httpserver.version>
 
         <xerces.version>2.12.0</xerces.version>
     </properties>


### PR DESCRIPTION
## Purpose
$subject

## Documentation

In order to enable prometheus stats reporting enable `wso2.metrics` in server deployment.yaml located in `{SI_HOME}/conf/server/deployment.yaml` and add the prometheus endpoint configurations as shown below

```yaml
wso2.metrics:
  enabled: true
 

metrics.prometheus:
  reporting:
    prometheus:
      - name: prometheus
        enabled: true
        serverURL: "http://localhost:9005"
```

In order to enable siddhi app-level statistics you have to add the annotation `@app:statistics` to the beginning of the siddhi app as shown below,

```sql
@App:name("sample")
@app:statistics(reporter = 'prometheus')

-- siddhi app logic
```

## Test environment
JDK 1.8.0_211
