### PR TITLE
Allow metrics service to be accessible at source/sink

### DIFF
--- a/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/core/internal/MetricsManager.java
+++ b/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/core/internal/MetricsManager.java
@@ -52,7 +52,7 @@ public class MetricsManager implements StatisticsManager {
         return componentName;
     }
 
-    public SPMetricsManagement getMetricsManagement() {
+    public MetricsManagement getMetricsManagement() {
         return metricsManagement;
     }
 }

--- a/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/core/internal/SPMetricsManagement.java
+++ b/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/core/internal/SPMetricsManagement.java
@@ -98,4 +98,12 @@ public class SPMetricsManagement {
             componentMap.remove(siddhiAppName);
         }
     }
+
+    public Map<String, List<String>> getComponentMap() {
+        return componentMap;
+    }
+
+    public MetricService getMetricService() {
+        return metricService;
+    }
 }

--- a/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/core/internal/SPStatisticsManager.java
+++ b/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/core/internal/SPStatisticsManager.java
@@ -32,24 +32,28 @@ public class SPStatisticsManager implements StatisticsManager {
         this.componentName = componentName;
         this.metricsManagement = SPMetricsManagement.getInstance();
     }
-    
+
     @Override
     public void startReporting() {
         this.metricsManagement.startMetrics(componentName);
     }
-    
+
     @Override
     public void stopReporting() {
         this.metricsManagement.stopMetrics(componentName);
     }
-    
+
     @Override
     public void cleanup() {
         this.metricsManagement.cleanUpMetrics(componentName);
     }
-    
+
     public String getComponentName() {
         return componentName;
     }
 
+    public SPMetricsManagement getMetricsManagement() {
+        return metricsManagement;
+    }
 }
+


### PR DESCRIPTION
## Purpose
This will allow source and sink to access the metrics service using the SiddhiAppContext object which is provided as a parameter in the init() method

## Usage

In order to access the carbon metrics service you have to add `org.wso2.carbon.si.metrics.core` as a dependency to the siddhi extension.

```xml
<dependency>
    <groupId>org.wso2.carbon.analytics</groupId>
    <artifactId>org.wso2.carbon.si.metrics.core</artifactId>
    <version>{carbon.analytics.version}</version>
</dependency>
```

Creating and registering metrics in the init() method of Extensions

```java
Counter sampleCounter = ((MetricsManager)siddhiAppContext.getStatisticsManager())
                .getMetricsManagement().getMetricService()
                .counter(String.format("io.siddhi.SiddhiApps.%s.Siddhi.Sinks.%s.%s", siddhiAppContext.getName(), sourceEventListener.getStreamDefinition().getId(), "eventCount"), Level.INFO);
```

## Test environment
JDK v1.8.0_211