### PR TITLE
Add auto extensions installation capability to SI server

### DIFF
--- a/components/org.wso2.carbon.siddhi.extensions.installer.core/pom.xml
+++ b/components/org.wso2.carbon.siddhi.extensions.installer.core/pom.xml
@@ -114,7 +114,8 @@
             *;resolution:=optional
         </import.package>
         <carbon.component>
-            osgi.service; objectClass="org.wso2.msf4j.Microservice"; serviceCount="1"
+            osgi.service; objectClass="org.wso2.carbon.siddhi.extensions.installer.core.internal.SiddhiExtensionsInstallerMicroservice",
+            osgi.service; objectClass="org.wso2.msf4j.Microservice"
         </carbon.component>
     </properties>
 

--- a/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/config/mapping/models/DownloadConfig.java
+++ b/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/config/mapping/models/DownloadConfig.java
@@ -35,4 +35,7 @@ public class DownloadConfig {
         return url;
     }
 
+    public String getInstructions() {
+        return instructions;
+    }
 }

--- a/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/util/MissingExtensionsInstaller.java
+++ b/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/util/MissingExtensionsInstaller.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.siddhi.extensions.installer.core.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.carbon.siddhi.extensions.installer.core.config.mapping.models.DependencyConfig;
+import org.wso2.carbon.siddhi.extensions.installer.core.exceptions.ExtensionsInstallerException;
+import org.wso2.carbon.siddhi.extensions.installer.core.execution.DependencyInstaller;
+import org.wso2.carbon.siddhi.extensions.installer.core.execution.SiddhiAppExtensionUsageDetector;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Installs extensions that are used in Siddhi apps, but have not been installed.
+ */
+public class MissingExtensionsInstaller {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MissingExtensionsInstaller.class);
+
+    private MissingExtensionsInstaller() {
+        // Prevents Instantiation.
+    }
+
+    /**
+     * Installs extensions that are used in the given Siddhi app, but have not been installed.
+     *
+     * @param siddhiAppBody       Body of a Siddhi app.
+     * @param siddhiAppName       Name of the Siddhi app.
+     * @param usageDetector       Siddhi app usage detector, which detects extension usages from the
+     *                            Siddhi app.
+     * @param dependencyInstaller Dependency installer, which installs dependencies related to extensions.
+     * @throws ExtensionsInstallerException Failure occurred when installing missing extensions.
+     */
+    public static void installMissingExtensions(String siddhiAppBody,
+                                                String siddhiAppName,
+                                                SiddhiAppExtensionUsageDetector usageDetector,
+                                                DependencyInstaller dependencyInstaller)
+        throws ExtensionsInstallerException {
+        Map<String, Map<String, Object>> usedExtensions = usageDetector.getUsedExtensionStatuses(siddhiAppBody);
+        Set<String> nonInstalledExtensionKeys = ResponseEntityCreator.extractNonInstalledExtensionKeys(usedExtensions);
+        if (!nonInstalledExtensionKeys.isEmpty()) {
+            LOGGER.info(String.format(
+                "Installing extensions: %s for Siddhi app: '%s'.", nonInstalledExtensionKeys, siddhiAppName));
+            Map<String, Map<String, Object>> installationResponse =
+                dependencyInstaller.installDependenciesFor(nonInstalledExtensionKeys);
+            notifyIncompleteInstallations(installationResponse);
+            notifyManuallyRequiredInstallations(installationResponse);
+            LOGGER.warn(String.format(
+                "Extensions installation finished for Siddhi app: '%s'. Please restart the server.", siddhiAppName));
+        }
+    }
+
+    private static void notifyIncompleteInstallations(Map<String, Map<String, Object>> installationResponse) {
+        Set<String> nonSuccessfulInstallations =
+            ResponseEntityCreator.extractIncompleteInstallations(installationResponse);
+        if (!nonSuccessfulInstallations.isEmpty()) {
+            // Notify about installations, whose installation statuses are anything other than successful.
+            LOGGER.error(String.format("Installations were not complete for extensions: %s.",
+                nonSuccessfulInstallations));
+        }
+    }
+
+    private static void notifyManuallyRequiredInstallations(Map<String, Map<String, Object>> installationResponse) {
+        Map<String, List<DependencyConfig>> manuallyRequiredInstallations =
+            ResponseEntityCreator.extractManuallyInstallableDependencies(installationResponse);
+        if (!manuallyRequiredInstallations.isEmpty()) {
+            // Notify about each extension's manually installable dependency.
+            int extensionCounter = 1;
+            StringBuilder manuallyInstallMessage = new StringBuilder();
+            for (Map.Entry<String, List<DependencyConfig>> extensionEntry : manuallyRequiredInstallations.entrySet()) {
+                // Gather extension's details.
+                manuallyInstallMessage.append(extensionCounter);
+                manuallyInstallMessage.append(". Extension: ");
+                manuallyInstallMessage.append(extensionEntry.getKey());
+                manuallyInstallMessage.append(System.lineSeparator());
+                // Gather dependencies' details.
+                manuallyInstallMessage.append("Dependencies:");
+                manuallyInstallMessage.append(System.lineSeparator());
+                for (DependencyConfig manuallyInstallableDependency : extensionEntry.getValue()) {
+                    manuallyInstallMessage.append("- ");
+                    manuallyInstallMessage.append(manuallyInstallableDependency.getRepresentableName());
+                    manuallyInstallMessage.append(":");
+                    manuallyInstallMessage.append(System.lineSeparator());
+                    if (manuallyInstallableDependency.getDownload() != null) {
+                        String instructions = manuallyInstallableDependency.getDownload().getInstructions();
+                        if (instructions != null) {
+                            instructions = instructions.replaceAll("<br/>", System.lineSeparator());
+                            manuallyInstallMessage.append(instructions);
+                            manuallyInstallMessage.append(System.lineSeparator());
+                        }
+                    }
+                }
+                manuallyInstallMessage.append(System.lineSeparator());
+                extensionCounter++;
+            }
+            LOGGER.info(String.format(
+                "Please follow the instructions and install the following dependencies manually:%n%n%s",
+                manuallyInstallMessage.toString()));
+        }
+    }
+}

--- a/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/util/ResponseEntityCreator.java
+++ b/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/util/ResponseEntityCreator.java
@@ -29,10 +29,14 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
- * Contains methods that organize data to create responses, for requests sent to
- * {@link org.wso2.carbon.siddhi.extensions.installer.core.internal.SiddhiExtensionsInstallerMicroservice}.
+ * Contains methods that organize data to create responses for requests sent to
+ * {@link org.wso2.carbon.siddhi.extensions.installer.core.internal.SiddhiExtensionsInstallerMicroservice},
+ * and to extract data from such responses.
  */
 public class ResponseEntityCreator {
 
@@ -48,6 +52,7 @@ public class ResponseEntityCreator {
     private static final String EXTENSION_STATUS_KEY = "extensionStatus";
     private static final String DEPENDENCY_INFO_KEY = "dependencyInfo";
     private static final String DEPENDENCY_IS_INSTALLED_KEY = "isInstalled";
+    private static final String EXTENSION_KEY = "extension";
     private static final String USAGES_KEY = "usages";
 
     private ResponseEntityCreator() {
@@ -195,7 +200,7 @@ public class ResponseEntityCreator {
             Map<String, Object> extensionAndUsages = new HashMap<>();
             List<SiddhiAppExtensionUsage> usages = new ArrayList<>();
             usages.add(siddhiAppExtensionUsage);
-            extensionAndUsages.put(EXTENSION_STATUS_KEY, extensionStatusResponse);
+            extensionAndUsages.put(EXTENSION_KEY, extensionStatusResponse);
             extensionAndUsages.put(USAGES_KEY, usages);
             usedExtensionStatuses.put(extensionId, extensionAndUsages);
         } else {
@@ -206,6 +211,76 @@ public class ResponseEntityCreator {
                 usages.add(siddhiAppExtensionUsage);
             }
         }
+    }
+
+    /**
+     * Extracts keys of extensions - whose installation status is anything other than installed,
+     * from the given map of extensions used in a Siddhi app.
+     *
+     * @param usedExtensionStatuses A map that contains installation statuses of multiple extensions.
+     * @return Keys of extensions - whose installation status is anything other than installed.
+     */
+    public static Set<String> extractNonInstalledExtensionKeys(Map<String, Map<String, Object>> usedExtensionStatuses) {
+        return usedExtensionStatuses.entrySet().stream().filter(
+            usedExtensionStatusEntry -> {
+                Object extensionDetails = usedExtensionStatusEntry.getValue().get(EXTENSION_KEY);
+                if (extensionDetails != null) {
+                    Object extensionStatus = ((Map<String, Object>) extensionDetails).get(EXTENSION_STATUS_KEY);
+                    if (extensionStatus != null) {
+                        return !Objects.equals(extensionStatus, ExtensionInstallationStatus.INSTALLED);
+                    }
+                }
+                /*
+                Ideally we will not reach here.
+                This would mean that, enough information to install a particular extension is not present.
+                Therefore, the extension will not be considered for installation.
+                 */
+                return false;
+            }).map(Map.Entry::getKey).collect(Collectors.toSet());
+    }
+
+    /**
+     * Extracts keys of extensions - whose installations were not successful, from the given map of
+     * installation responses.
+     *
+     * @param installationResponses A map that contains installation responses of multiple extensions.
+     * @return Keys of extensions - whose installations were not successful.
+     */
+    public static Set<String> extractIncompleteInstallations(
+        Map<String, Map<String, Object>> installationResponses) {
+        return installationResponses.entrySet().stream().filter(
+            installationResponseEntry -> {
+                Map<String, Object> installationResponse = installationResponseEntry.getValue();
+                if (installationResponse.containsKey(ACTION_STATUS_KEY)) {
+                    return !Objects.equals(
+                        installationResponse.get(ACTION_STATUS_KEY), ExtensionInstallationStatus.INSTALLED);
+                }
+                /*
+                Ideally we will not reach here.
+                This would mean that, an extension's installation haven't returned a status.
+                Therefore, the extension will be considered as not installed.
+                 */
+                return true;
+            }).map(Map.Entry::getKey).collect(Collectors.toSet());
+    }
+
+    /**
+     * Extracts manually installable dependencies (if any) from each entry of the given map of installation responses.
+     *
+     * @param installationResponses A map that contains installation responses of multiple extensions.
+     * @return A map that contains manually installable dependencies of extensions.
+     */
+    public static Map<String, List<DependencyConfig>> extractManuallyInstallableDependencies(
+        Map<String, Map<String, Object>> installationResponses) {
+        Map<String, List<DependencyConfig>> manuallyInstallableDependencies = new HashMap<>();
+        for (Map.Entry<String, Map<String, Object>> installationResponseEntry : installationResponses.entrySet()) {
+            if (installationResponseEntry.getValue().containsKey(MANUALLY_INSTALLABLE_DEPENDENCIES_KEY)) {
+                manuallyInstallableDependencies.put(installationResponseEntry.getKey(),
+                    (List<DependencyConfig>) (installationResponseEntry.getValue()
+                        .get(MANUALLY_INSTALLABLE_DEPENDENCIES_KEY)));
+            }
+        }
+        return manuallyInstallableDependencies;
     }
 
 }

--- a/components/org.wso2.carbon.streaming.integrator.core/pom.xml
+++ b/components/org.wso2.carbon.streaming.integrator.core/pom.xml
@@ -119,6 +119,11 @@
             <groupId>org.wso2.carbon.analytics</groupId>
             <artifactId>org.wso2.carbon.streaming.integrator.common</artifactId>
         </dependency>
+        <!-- Extension Installer -->
+        <dependency>
+            <groupId>org.wso2.carbon.analytics</groupId>
+            <artifactId>org.wso2.carbon.siddhi.extensions.installer.core</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.wso2.orbit.io.swagger</groupId>
@@ -254,6 +259,7 @@
             org.wso2.carbon.kernel;version="${carbon.kernel.package.import.version.range}",
             io.siddhi.*;version="${siddhi.version.range}",
             org.wso2.carbon.streaming.integrator.common.*;version="${carbon.analytics.version.range}",
+            org.wso2.carbon.siddhi.extensions.installer.core.*;version="${carbon.analytics.version.range}",
             org.wso2.msf4j.*;version="${msf4j.import.version.range}",
             org.wso2.carbon.analytics.permissions.*; version="${carbon.analytics-common.version.range}",
             org.wso2.carbon.database.query.manager.*; version="${carbon.analytics-common.version.range}",
@@ -264,6 +270,7 @@
         <carbon.component>
             osgi.service; objectClass="org.wso2.msf4j.Microservice"; serviceCount="2",
             osgi.service; objectClass="javax.ws.rs.ext.ExceptionMapper";serviceCount="5",
+            osgi.service; objectClass="org.wso2.carbon.siddhi.extensions.installer.core.internal.SiddhiExtensionsInstallerMicroservice",
             osgi.service; objectClass="org.wso2.carbon.deployment.engine.Deployer",
             osgi.service; objectClass="org.wso2.carbon.streaming.integrator.core.SiddhiAppRuntimeService"
         </carbon.component>

--- a/components/org.wso2.carbon.streaming.integrator.core/src/main/java/org/wso2/carbon/streaming/integrator/core/internal/ServiceComponent.java
+++ b/components/org.wso2.carbon.streaming.integrator.core/src/main/java/org/wso2/carbon/streaming/integrator/core/internal/ServiceComponent.java
@@ -44,6 +44,7 @@ import org.wso2.carbon.kernel.CarbonRuntime;
 import org.wso2.carbon.kernel.config.model.CarbonConfiguration;
 import org.wso2.carbon.si.metrics.core.MetricsFactory;
 import org.wso2.carbon.si.metrics.core.internal.MetricsDataHolder;
+import org.wso2.carbon.siddhi.extensions.installer.core.internal.SiddhiExtensionsInstallerMicroservice;
 import org.wso2.carbon.streaming.integrator.common.EventStreamService;
 import org.wso2.carbon.streaming.integrator.common.HAStateChangeListener;
 import org.wso2.carbon.streaming.integrator.common.SiddhiAppRuntimeService;
@@ -80,6 +81,12 @@ import static org.wso2.carbon.streaming.integrator.core.impl.utils.Constants.PER
 public class ServiceComponent {
 
     private static final Logger log = LoggerFactory.getLogger(ServiceComponent.class);
+
+    /**
+     * This flag denotes whether extensions used in Siddhi apps should be automatically installed or not.
+     */
+    private static final String AUTO_INSTALL_EXTENSIONS_FLAG = "autoInstallExtensions";
+
     private ServiceRegistration streamServiceRegistration;
     private ServiceRegistration siddhiAppRuntimeServiceRegistration;
     private ScheduledFuture<?> scheduledFuture = null;
@@ -443,6 +450,30 @@ public class ServiceComponent {
 
     protected void unregisterHAStateChangeListener(HAStateChangeListener haStateChangeListener) {
         StreamProcessorDataHolder.removeHAStateChangeListener(haStateChangeListener);
+    }
+
+    /**
+     * The bind method, which gets called for Siddhi Extensions Installer microservice registration
+     * that satisfies the policy.
+     *
+     * @param extensionsInstallerMicroservice Siddhi Extensions Installer microservice
+     */
+    @Reference(
+        name = "org.wso2.carbon.siddhi.extensions.installer.core.internal.SiddhiExtensionsInstallerMicroservice",
+        service = SiddhiExtensionsInstallerMicroservice.class,
+        cardinality = ReferenceCardinality.MANDATORY,
+        policy = ReferencePolicy.DYNAMIC,
+        unbind = "unsetExtensionInstaller"
+    )
+    protected void setExtensionInstaller(SiddhiExtensionsInstallerMicroservice extensionsInstallerMicroservice) {
+        if ("true".equalsIgnoreCase(System.getProperty(AUTO_INSTALL_EXTENSIONS_FLAG))) {
+            log.warn("Auto installation of Siddhi extensions is enabled.");
+            StreamProcessorDataHolder.setExtensionsInstaller(extensionsInstallerMicroservice);
+        }
+    }
+
+    protected void unsetExtensionInstaller(SiddhiExtensionsInstallerMicroservice extensionsInstallerMicroservice) {
+        StreamProcessorDataHolder.setExtensionsInstaller(null);
     }
 
 }

--- a/components/org.wso2.carbon.streaming.integrator.core/src/main/java/org/wso2/carbon/streaming/integrator/core/internal/StreamProcessorDataHolder.java
+++ b/components/org.wso2.carbon.streaming.integrator.core/src/main/java/org/wso2/carbon/streaming/integrator/core/internal/StreamProcessorDataHolder.java
@@ -31,6 +31,7 @@ import org.wso2.carbon.config.provider.ConfigProvider;
 import org.wso2.carbon.databridge.commons.ServerEventListener;
 import org.wso2.carbon.datasource.core.api.DataSourceService;
 import org.wso2.carbon.kernel.CarbonRuntime;
+import org.wso2.carbon.siddhi.extensions.installer.core.internal.SiddhiExtensionsInstallerMicroservice;
 import org.wso2.carbon.streaming.integrator.common.HAStateChangeListener;
 import org.wso2.carbon.streaming.integrator.core.NodeInfo;
 import org.wso2.carbon.streaming.integrator.core.ha.HAManager;
@@ -57,6 +58,7 @@ public class StreamProcessorDataHolder {
     private static NodeInfo nodeInfo;
     private static RecordTableHandlerManager recordTableHandlerManager;
     private static PermissionProvider permissionProvider;
+    private static SiddhiExtensionsInstallerMicroservice extensionsInstaller;
     private CarbonRuntime carbonRuntime;
     private BundleContext bundleContext;
     private ConfigProvider configProvider;
@@ -262,5 +264,13 @@ public class StreamProcessorDataHolder {
 
     public static void setIsStatisticsEnabled(boolean isStatisticsEnabled) {
         StreamProcessorDataHolder.isStatisticsEnabled = isStatisticsEnabled;
+    }
+
+    public static SiddhiExtensionsInstallerMicroservice getExtensionsInstaller() {
+        return extensionsInstaller;
+    }
+
+    public static void setExtensionsInstaller(SiddhiExtensionsInstallerMicroservice extensionsInstaller) {
+        StreamProcessorDataHolder.extensionsInstaller = extensionsInstaller;
     }
 }

--- a/components/org.wso2.carbon.streaming.integrator.core/src/main/java/org/wso2/carbon/streaming/integrator/core/internal/StreamProcessorDeployer.java
+++ b/components/org.wso2.carbon.streaming.integrator.core/src/main/java/org/wso2/carbon/streaming/integrator/core/internal/StreamProcessorDeployer.java
@@ -92,6 +92,10 @@ public class StreamProcessorDeployer implements Deployer {
                         siddhiAppName = StreamProcessorDataHolder.getStreamProcessorService().
                                 getSiddhiAppName(siddhiApp);
                         if (siddhiAppFileNameWithoutExtension.equals(siddhiAppName)) {
+                            if (StreamProcessorDataHolder.getExtensionsInstaller() != null) {
+                                StreamProcessorDataHolder.getExtensionsInstaller()
+                                    .installMissingExtensions(siddhiApp, siddhiAppName);
+                            }
                             StreamProcessorDataHolder.getStreamProcessorService().deploySiddhiApp(siddhiApp,
                                     siddhiAppName);
                         } else {

--- a/components/si-distribution/pom.xml
+++ b/components/si-distribution/pom.xml
@@ -149,6 +149,13 @@
             <type>zip</type>
         </dependency>
 
+        <!-- Extension Installer -->
+        <dependency>
+            <groupId>org.wso2.carbon.analytics</groupId>
+            <artifactId>org.wso2.carbon.siddhi.extensions.installer.core.feature</artifactId>
+            <type>zip</type>
+        </dependency>
+
         <dependency>
             <groupId>org.wso2.carbon.analytics</groupId>
             <artifactId>org.wso2.carbon.siddhi.store.api.rest.feature</artifactId>
@@ -480,6 +487,12 @@
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
 
+                                <!-- Extension Installer -->
+                                <feature>
+                                    <id>org.wso2.carbon.siddhi.extensions.installer.core.feature</id>
+                                    <version>${carbon.analytics.version}</version>
+                                </feature>
+
                                 <!-- Authentication feature -->
                                 <feature>
                                     <id>org.wso2.carbon.analytics.msf4j.interceptor.common.feature</id>
@@ -698,6 +711,12 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.siddhi.store.api.rest.feature</id>
+                                    <version>${carbon.analytics.version}</version>
+                                </feature>
+
+                                <!-- Extension Installer -->
+                                <feature>
+                                    <id>org.wso2.carbon.siddhi.extensions.installer.core.feature</id>
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
 


### PR DESCRIPTION
## Purpose
> This PR introduces the capability of auto detecting extensions used in Siddhi apps, and installing them before deploying the Siddhi apps in SI server runtime. Resolves: https://github.com/wso2/streaming-integrator/issues/99

In order to auto detect and install extensions, a user has to do the following:
1. Copy the Siddhi app(s) to the deployment directory.
2. Start SI server with the `autoInstallExtensions` flag. i.e:
```./wso2si-1.0.1-SNAPSHOT/bin/server.sh -DautoInstallExtensions```
3. Optionally, manually install dependencies (if any. The instructions will be displayed in the command line).
4. Restart SI server, this time, no need of the flag. i.e: 
```./wso2si-1.0.1-SNAPSHOT/bin/server.sh```

## Goals
> Auto installing extensions used in Siddhi apps, in SI server runtime.

## Related PRs
> - Add Extension Installer to SI server: https://github.com/wso2/streaming-integrator/pull/101
> - Extension usage detection from Siddhi app: https://github.com/wso2/carbon-analytics/pull/1840
> - Install multiple extensions at once: https://github.com/wso2/carbon-analytics/pull/1842
> - Kernel version bump: https://github.com/wso2/streaming-integrator/pull/100