### PR TITLE
Add custom mapping configuration for prometheus

### DIFF
--- a/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/prometheus/reporter/config/CustomGraphiteNamePattern.java
+++ b/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/prometheus/reporter/config/CustomGraphiteNamePattern.java
@@ -1,0 +1,77 @@
+package org.wso2.carbon.si.metrics.prometheus.reporter.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class CustomGraphiteNamePattern {
+
+    private Pattern pattern;
+    private String patternStr;
+
+    /**
+     * Creates a new GraphiteNamePattern from the given simplified glob pattern.
+     *
+     * @param pattern The glob style pattern to be used.
+     */
+    CustomGraphiteNamePattern(final String pattern) {
+        initializePattern(pattern);
+    }
+
+    /**
+     * Matches the metric name against the pattern.
+     *
+     * @param metricName The metric name to be tested.
+     * @return {@code true} if the name is matched, {@code false} otherwise.
+     */
+    boolean matches(final String metricName) {
+        return metricName != null && pattern.matcher(metricName).matches();
+    }
+
+    /**
+     * Extracts parameters from the given metric name based on the pattern.
+     * The resulting map has keys named as '${n}' where n is the 0 based position in the pattern.
+     * E.g.:
+     * pattern: org.test.controller.*.status.*
+     * extractParameters("org.test.controller.gather.status.400") ->
+     * {${0} -> "gather", ${1} -> "400"}
+     *
+     * @param metricName The metric name to extract parameters from.
+     * @return A parameter map where keys are named '${n}' where n is 0 based parameter position in the pattern.
+     */
+    Map<String, String> extractParameters(final String metricName) {
+        final Matcher matcher = this.pattern.matcher(metricName);
+        final Map<String, String> params = new HashMap<String, String>();
+        if (matcher.find()) {
+            for (int i = 1; i <= matcher.groupCount(); i++) {
+                params.put(String.format("${%d}", i - 1), matcher.group(i));
+            }
+        }
+
+        return params;
+    }
+
+    /**
+     * Turns the GLOB pattern into a REGEX.
+     *
+     * @param pattern The pattern to use
+     */
+    private void initializePattern(String pattern) {
+        pattern = pattern.replace("(.*)", "~"); //replace (.*) to avoid replacing * by ([^.]*)
+        final String[] split = pattern.split(Pattern.quote("*"), -1);
+        final StringBuilder escapedPattern = new StringBuilder(Pattern.quote(split[0]));
+        for (int i = 1; i < split.length; i++) {
+            String quoted = Pattern.quote(split[i]);
+            escapedPattern.append("([^.]*)").append(quoted);
+        }
+
+        final String regex = "^" + escapedPattern.toString() + "$";
+        this.patternStr = regex.replace("~", "\\E(.*)\\Q");
+        this.pattern = Pattern.compile(patternStr);
+    }
+
+    String getPatternString() {
+        return this.patternStr;
+    }
+}

--- a/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/prometheus/reporter/config/CustomGraphiteNamePattern.java
+++ b/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/prometheus/reporter/config/CustomGraphiteNamePattern.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.wso2.carbon.si.metrics.prometheus.reporter.config;
 
 import java.util.HashMap;

--- a/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/prometheus/reporter/config/CustomMapperConfig.java
+++ b/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/prometheus/reporter/config/CustomMapperConfig.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.wso2.carbon.si.metrics.prometheus.reporter.config;
 
 import java.util.HashMap;

--- a/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/prometheus/reporter/config/CustomMapperConfig.java
+++ b/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/prometheus/reporter/config/CustomMapperConfig.java
@@ -1,0 +1,116 @@
+package org.wso2.carbon.si.metrics.prometheus.reporter.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+
+/**
+ * POJO containing info on how to map a graphite metric to a prometheus one.
+ */
+public class CustomMapperConfig {
+
+    // Labels validation.
+    private static final String LABEL_REGEX = "^[a-zA-Z_][a-zA-Z0-9_]+$";
+    private static final Pattern LABEL_PATTERN = Pattern.compile(LABEL_REGEX);
+
+    /**
+     * Regex used to match incoming metric name.
+     * Uses a simplified glob syntax where only '*' and (.*) are allowed.
+     * E.g:
+     * org.company.controller.*.status.*
+     * Will be used to match
+     * org.company.controller.controller1.status.200
+     * and
+     * org.company.controller.controller2.status.400
+     *
+     * org.company.controller.(.*).status.*
+     * Will be used to match
+     * org.company.controller.controller1.status.200
+     * and
+     * org.company.controller.main.controller1.status.200
+     */
+    private String match;
+    private String name;
+    private Map<String, String> labels = new HashMap<String, String>();
+
+    public CustomMapperConfig() {
+        // empty constructor
+    }
+
+    // for tests
+    public CustomMapperConfig(final String match) {
+        this.match = match;
+    }
+
+    public CustomMapperConfig(final String match, final String name, final Map<String, String> labels) {
+        this.name = name;
+        this.match = match;
+        validateLabels(labels);
+        this.labels = labels;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("MapperConfig{match=%s, name=%s, labels=%s}", match, name, labels);
+    }
+
+    public String getMatch() {
+        return match;
+    }
+
+    public void setMatch(final String match) {
+        this.match = match;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+
+    }
+
+    public Map<String, String> getLabels() {
+        return labels;
+    }
+
+    public void setLabels(final Map<String, String> labels) {
+        validateLabels(labels);
+        this.labels = labels;
+    }
+
+    private void validateLabels(final Map<String, String> labels)
+    {
+        if (labels != null) {
+            for (final String key : labels.keySet()) {
+                if (!LABEL_PATTERN.matcher(key).matches()) {
+                    throw new IllegalArgumentException(String.format("Label [%s] does not match required pattern %s", match, LABEL_PATTERN));
+                }
+            }
+
+        }
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        final CustomMapperConfig that = (CustomMapperConfig) o;
+
+        if (!Objects.equals(match, that.match)) return false;
+        if (!Objects.equals(name, that.name)) return false;
+        return Objects.equals(labels, that.labels);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = match != null ? match.hashCode() : 0;
+        result = 31 * result + (name != null ? name.hashCode() : 0);
+        result = 31 * result + (labels != null ? labels.hashCode() : 0);
+        return result;
+    }
+}

--- a/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/prometheus/reporter/config/CustomMappingBuilder.java
+++ b/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/prometheus/reporter/config/CustomMappingBuilder.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.wso2.carbon.si.metrics.prometheus.reporter.config;
 
 import io.prometheus.client.Collector;

--- a/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/prometheus/reporter/config/CustomMappingBuilder.java
+++ b/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/prometheus/reporter/config/CustomMappingBuilder.java
@@ -1,0 +1,108 @@
+package org.wso2.carbon.si.metrics.prometheus.reporter.config;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.dropwizard.samplebuilder.DefaultSampleBuilder;
+import io.prometheus.client.dropwizard.samplebuilder.SampleBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * SampleBuilder implementation to allow Dropwizard metrics to be translated to Prometheus metrics including
+ * custom labels and names.
+ */
+public class CustomMappingBuilder implements SampleBuilder {
+    private final List<CustomMappingBuilder.CompiledMapperConfig> compiledMapperConfigs;
+    private final DefaultSampleBuilder defaultMetricSampleBuilder = new DefaultSampleBuilder();
+
+    public CustomMappingBuilder(final List<CustomMapperConfig> mapperConfigs) {
+        if (mapperConfigs == null || mapperConfigs.isEmpty()) {
+            throw new IllegalArgumentException("CustomMappingSampleBuilder needs some mapper configs!");
+        }
+
+        this.compiledMapperConfigs = new ArrayList<>(mapperConfigs.size());
+        for (CustomMapperConfig config : mapperConfigs) {
+            this.compiledMapperConfigs.add(new CustomMappingBuilder.CompiledMapperConfig(config));
+        }
+    }
+
+    @Override
+    public Collector.MetricFamilySamples.Sample createSample(final String dropwizardName, final String nameSuffix, final List<String> additionalLabelNames, final List<String> additionalLabelValues, final double value) {
+        if (dropwizardName == null) {
+            throw new IllegalArgumentException("Dropwizard metric name cannot be null");
+        }
+
+        CustomMappingBuilder.CompiledMapperConfig matchingConfig = null;
+        for (CustomMappingBuilder.CompiledMapperConfig config : this.compiledMapperConfigs) {
+            if (config.pattern.matches(dropwizardName)) {
+                matchingConfig = config;
+                break;
+            }
+        }
+
+        if (matchingConfig != null) {
+            final Map<String, String> params = matchingConfig.pattern.extractParameters(dropwizardName);
+            final CustomMappingBuilder.NameAndLabels nameAndLabels = getNameAndLabels(matchingConfig.mapperConfig, params);
+            nameAndLabels.labelNames.addAll(additionalLabelNames);
+            nameAndLabels.labelValues.addAll(additionalLabelValues);
+            return defaultMetricSampleBuilder.createSample(
+                    nameAndLabels.name, nameSuffix,
+                    nameAndLabels.labelNames,
+                    nameAndLabels.labelValues,
+                    value
+            );
+        }
+
+
+        return defaultMetricSampleBuilder.createSample(
+                dropwizardName, nameSuffix,
+                additionalLabelNames,
+                additionalLabelValues,
+                value
+        );
+    }
+
+    protected CustomMappingBuilder.NameAndLabels getNameAndLabels(final CustomMapperConfig config, final Map<String, String> parameters) {
+        final String metricName = formatTemplate(config.getName(), parameters);
+        final List<String> labels = new ArrayList<>(config.getLabels().size());
+        final List<String> labelValues = new ArrayList<>(config.getLabels().size());
+        for (Map.Entry<String, String> entry : config.getLabels().entrySet()) {
+            labels.add(entry.getKey());
+            labelValues.add(formatTemplate(entry.getValue(), parameters));
+        }
+
+        return new CustomMappingBuilder.NameAndLabels(metricName, labels, labelValues);
+    }
+
+    private String formatTemplate(final String template, final Map<String, String> params) {
+        String result = template;
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            result = result.replace(entry.getKey(), entry.getValue());
+        }
+
+        return result;
+    }
+
+    static class CompiledMapperConfig {
+        final CustomMapperConfig mapperConfig;
+        final CustomGraphiteNamePattern pattern;
+
+        CompiledMapperConfig(final CustomMapperConfig mapperConfig) {
+            this.mapperConfig = mapperConfig;
+            this.pattern = new CustomGraphiteNamePattern(mapperConfig.getMatch());
+        }
+    }
+
+    static class NameAndLabels {
+        final String name;
+        final List<String> labelNames;
+        final List<String> labelValues;
+
+        NameAndLabels(final String name, final List<String> labelNames, final List<String> labelValues) {
+            this.name = name;
+            this.labelNames = labelNames;
+            this.labelValues = labelValues;
+        }
+    }
+}

--- a/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/prometheus/reporter/impl/PrometheusMetricsLabelsMapper.java
+++ b/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/prometheus/reporter/impl/PrometheusMetricsLabelsMapper.java
@@ -18,6 +18,8 @@
 package org.wso2.carbon.si.metrics.prometheus.reporter.impl;
 
 import io.prometheus.client.dropwizard.samplebuilder.MapperConfig;
+import org.wso2.carbon.si.metrics.prometheus.reporter.config.CustomMapperConfig;
+
 import java.util.Map;
 
 /**
@@ -25,13 +27,13 @@ import java.util.Map;
  */
 public class PrometheusMetricsLabelsMapper {
 
-    private Map<String, MapperConfig> metricsLabelMapping;
+    private Map<String, CustomMapperConfig> metricsLabelMapping;
 
-    public Map<String, MapperConfig> getMetricsLabelMapping() {
+    public Map<String, CustomMapperConfig> getMetricsLabelMapping() {
         return metricsLabelMapping;
     }
 
-    public void setMetricsLabelMapping(Map<String, MapperConfig> metricsLabelMapping) {
+    public void setMetricsLabelMapping(Map<String, CustomMapperConfig> metricsLabelMapping) {
         this.metricsLabelMapping = metricsLabelMapping;
     }
 

--- a/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/prometheus/reporter/impl/PrometheusReporter.java
+++ b/components/org.wso2.carbon.si.metrics.core/src/main/java/org/wso2/carbon/si/metrics/prometheus/reporter/impl/PrometheusReporter.java
@@ -36,6 +36,8 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.log4j.Logger;
 import org.wso2.carbon.metrics.core.reporter.impl.AbstractReporter;
+import org.wso2.carbon.si.metrics.prometheus.reporter.config.CustomMapperConfig;
+import org.wso2.carbon.si.metrics.prometheus.reporter.config.CustomMappingBuilder;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.CustomClassLoaderConstructor;
 import org.yaml.snakeyaml.introspector.BeanAccess;
@@ -82,9 +84,9 @@ public class PrometheusReporter extends AbstractReporter {
             yaml.setBeanAccess(BeanAccess.FIELD);
             PrometheusMetricsLabelsMapper metricsLabelsMapping = yaml.loadAs(inputStream,
                                                                                 PrometheusMetricsLabelsMapper.class);
-            List<MapperConfig> metricsMappings = new ArrayList<>(
+            List<CustomMapperConfig> metricsMappings = new ArrayList<>(
                                                                 metricsLabelsMapping.getMetricsLabelMapping().values());
-            SampleBuilder sampleBuilder = new CustomMappingSampleBuilder(metricsMappings);
+            SampleBuilder sampleBuilder = new CustomMappingBuilder(metricsMappings);
             Collector collector = new DropwizardExports(metricRegistry, sampleBuilder);
             collectorRegistry.register(collector);
         } catch (IOException e) {

--- a/components/org.wso2.carbon.si.metrics.core/src/main/resources/configuration.yaml
+++ b/components/org.wso2.carbon.si.metrics.core/src/main/resources/configuration.yaml
@@ -180,3 +180,83 @@ metricsLabelMapping:
       operation: "${2}"
       operationType: "${3}"
       metrics: "${4}"
+
+#Siddhi-io-file Metrics
+
+  siddhi.io.file.apps:
+    match: "io.siddhi.SiddhiApps.*.Siddhi.File"
+    name: "siddhi.file.apps"
+    labels:
+      app_name: "${0}"
+
+  siddhi.io.file.sink.event.count:
+    match: "io.siddhi.SiddhiApps.*.Siddhi.File.Sinks.event.count.(.*).filename.*.*.(.*)"
+    name: "siddhi.file.sink.event.count"
+    labels:
+      app_name: "${0}"
+      file_name: "${1}"
+      mode: "${2}"
+      stream_name: "${3}"
+      file_path: "${4}"
+
+  siddhi.io.file.sink.metrics:
+    match: "io.siddhi.SiddhiApps.*.Siddhi.File.Sinks.*.(.*)"
+    name: "siddhi.file.sink.${1}"
+    labels:
+      app_name: "${0}"
+      file_path: "${2}"
+
+  siddhi.io.file.source.event.count:
+    match: "io.siddhi.SiddhiApps.*.Siddhi.File.Source.event.count.(.*).filename.*.*.(.*)"
+    name: "siddhi.file.source.event.count"
+    labels:
+      app_name: "${0}"
+      file_name: "${1}"
+      mode: "${2}"
+      stream_name: "${3}"
+      file_path: "${4}"
+
+  siddhi.io.file.source.metrics:
+    match: "io.siddhi.SiddhiApps.*.Siddhi.File.Source.*.(.*)"
+    name: "siddhi.file.source.${1}"
+    labels:
+      app_name: "${0}"
+      file_path: "${2}"
+
+
+  siddhi.io.file.archive: # no extension
+    match: "io.siddhi.SiddhiApps.*.Siddhi.File.Operations.Archived.*.(.*).time.(.*).source.(.*).destination"
+    name: "siddhi.file.archive"
+    labels:
+      app_name: "${0}"
+      type: "${1}"
+      time: "${2}"
+      _source: "${3}"
+      destination: "${4}"
+
+  siddhi.io.file.copy: #both source and destination does not have extension
+    match: "io.siddhi.SiddhiApps.*.Siddhi.File.Operations.Copy.(.*).time.(.*).source.(.*).destination"
+    name: "siddhi.file.copy"
+    labels:
+      app_name: "${0}"
+      time: "${1}"
+      _source: "${2}"
+      destination: "${3}"
+
+  siddhi.io.file.delete: #source does not have extension
+    match: "io.siddhi.SiddhiApps.*.Siddhi.File.Operations.Delete.(.*).time.(.*).source"
+    name: "siddhi.file.delete"
+    labels:
+      app_name: "${0}"
+      time: "${1}"
+      _source: "${2}"
+
+  siddhi.io.file.move: #both source and destination does not have extension
+    match: "io.siddhi.SiddhiApps.(.*).Siddhi.File.Operations.Move.(.*).time.(.*).source.(.*).destination"
+    name: "siddhi.file.move"
+    labels:
+      app_name: "${0}"
+      time: "${1}"
+      _source: "${2}"
+      destination: "${3}"
+


### PR DESCRIPTION
## Purpose

- Add custom mapping configuration for Prometheus.
- Add siddhi-io-file mapping configs

## Goals
> Allow Prometheus to map * and (.*) regex pattern so that the user can have dots within the labels.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
#### Previous Implementation

match - org.company.controller.\*.status.*
metrics - org.company.controller.**controller1**.status.**200**
if metrics contains a dot(.) inside the **controller1** (ex:- main.controller1), this mapping will be failed

In the current implementation, we can avoid these kinds of scenarios by using (.*) pattern
match - org.company.controller.(.\*).status.\*
metrics - org.company.controller.**main.controller1**.status.**200**
