### PR TITLE
Fix business rules deployment issue when only configured in one node

### DIFF
--- a/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/services/TemplateManagerService.java
+++ b/components/org.wso2.carbon.business.rules.core/src/main/java/org/wso2/carbon/business/rules/core/services/TemplateManagerService.java
@@ -1493,17 +1493,13 @@ public class TemplateManagerService implements BusinessRulesService {
             Object templates = nodes.get(node);
             if (templates instanceof List) {
                 List templateList = (List) templates;
-                if (!templateList.contains(ruleTemplateUUID.toString())) {
-                    return new ArrayList<String>(nodes.keySet());
-                } else {
-                    for (Object uuid : templateList) {
-                        if (ruleTemplateUUID.equals(uuid.toString())) {
-                            nodeList.add(node);
-                            break;
-                        }
-                    }
+                if (templateList.contains(ruleTemplateUUID)) {
+                    nodeList.add(node);
                 }
             }
+        }
+        if (nodeList.isEmpty()) {
+            return new ArrayList<String>(nodes.keySet());
         }
         return nodeList;
     }


### PR DESCRIPTION
## Purpose
> Fix the deployment issue in business rule when there are multiple server nodes provided in deployment.yaml file and ruleTemplateUUID has been configured to deploy in only one or selected node(s).

## Goals
> Fix the deployment issue in business rule when there are multiple server nodes provided in deployment.yaml file and ruleTemplateUUID has been configured to deploy in only one or selected node(s).

## Approach
> With this fix, if the ruleTemplateUUID is provided in deployment.yaml to deploy in a specific node. the business rules which create using that template will deploy on those specified nodes. 
> If the ruleTemplateUUID is not provided in the deployment.yaml file then the business rules which create using the template will be deployed in all the nodes which are configured in deployment.yaml

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
> https://github.com/wso2/carbon-analytics/pull/1384

## Test environment
> Oracle JDK 1.8.0_221
 
