### PR TITLE
[Extension Installer] Add capability to replace self dependency jars

### DIFF
--- a/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/execution/DependencyInstallerImpl.java
+++ b/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/execution/DependencyInstallerImpl.java
@@ -109,6 +109,10 @@ public class DependencyInstallerImpl implements DependencyInstaller {
                 URL downloadUrl = new URL(download.getUrl());
                 String fileName = FilenameUtils.getName(downloadUrl.getPath());
                 List<File> usageDestinations = generateUsageDestinations(dependency, fileName);
+                if (ExtensionsInstallerUtils.isSelfDependency(dependency)) {
+                    // Delete the jar of the self dependency if exists, to allow downloading latest version.
+                    unInstallUsagesFor(dependency);
+                }
                 downloadOrCopyFilesTo(usageDestinations, downloadUrl);
             } catch (MalformedURLException e) {
                 throw new ExtensionsInstallerException(

--- a/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/execution/DependencyRetrieverImpl.java
+++ b/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/execution/DependencyRetrieverImpl.java
@@ -94,7 +94,7 @@ public class DependencyRetrieverImpl implements DependencyRetriever {
                 if (isDependencyInstalled(dependency)) {
                     installedDependenciesCount++;
                     // Whether the Siddhi jar of the extension itself has been installed or not.
-                    if (isSelfDependency(dependency)) {
+                    if (ExtensionsInstallerUtils.isSelfDependency(dependency)) {
                         isSelfDependencyInstalled = true;
                     }
                 }
@@ -103,13 +103,6 @@ public class DependencyRetrieverImpl implements DependencyRetriever {
                 isSelfDependencyInstalled, installedDependenciesCount, dependencies.size());
         }
         throw new ExtensionsInstallerException("No dependencies were specified.");
-    }
-
-    private boolean isSelfDependency(DependencyConfig dependency) {
-        if (dependency.getName() != null) {
-            return dependency.getName().toLowerCase().startsWith("siddhi-");
-        }
-        return false;
     }
 
     private boolean isDependencyInstalled(DependencyConfig dependency) throws ExtensionsInstallerException {

--- a/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/util/ExtensionsInstallerUtils.java
+++ b/components/org.wso2.carbon.siddhi.extensions.installer.core/src/main/java/org/wso2/carbon/siddhi/extensions/installer/core/util/ExtensionsInstallerUtils.java
@@ -18,12 +18,13 @@
 
 package org.wso2.carbon.siddhi.extensions.installer.core.util;
 
+import org.wso2.carbon.siddhi.extensions.installer.core.config.mapping.models.DependencyConfig;
+import org.wso2.carbon.siddhi.extensions.installer.core.config.mapping.models.ExtensionConfig;
+import org.wso2.carbon.siddhi.extensions.installer.core.config.mapping.models.UsageConfig;
+import org.wso2.carbon.siddhi.extensions.installer.core.config.mapping.models.UsageType;
+import org.wso2.carbon.siddhi.extensions.installer.core.config.mapping.models.UsedByType;
 import org.wso2.carbon.siddhi.extensions.installer.core.constants.ExtensionsInstallerConstants;
 import org.wso2.carbon.siddhi.extensions.installer.core.exceptions.ExtensionsInstallerException;
-import org.wso2.carbon.siddhi.extensions.installer.core.config.mapping.models.ExtensionConfig;
-import org.wso2.carbon.siddhi.extensions.installer.core.config.mapping.models.UsageType;
-import org.wso2.carbon.siddhi.extensions.installer.core.config.mapping.models.UsageConfig;
-import org.wso2.carbon.siddhi.extensions.installer.core.config.mapping.models.UsedByType;
 import org.wso2.carbon.siddhi.extensions.installer.core.models.enums.ExtensionInstallationStatus;
 import org.wso2.carbon.siddhi.extensions.installer.core.models.enums.ExtensionUnInstallationStatus;
 
@@ -213,6 +214,13 @@ public class ExtensionsInstallerUtils {
             }
         }
         throw new ExtensionsInstallerException(String.format("Invalid value: %s for 'usedBy' property.", usage));
+    }
+
+    public static boolean isSelfDependency(DependencyConfig dependency) {
+        if (dependency.getName() != null) {
+            return dependency.getName().toLowerCase().startsWith("siddhi-");
+        }
+        return false;
     }
 
 }


### PR DESCRIPTION
## Purpose
- In Extension Installer, self dependency of an extension is a `siddhi-...` jar file (eg: `siddhi-io-http` for HTTP extension). 
- When we send an update to such a self dependency via the `extensionDependencies.json` file, installing the extension should replace the self dependency with the latest one. 

This PR provides this ability by deleting the self dependency and downloading it with the appropriate values provided in `extensionDependencies.json` file.

**Note:** To make this effective, `lookupRegex` inside the `extensionDependencies.json` should **not** have versions specified in it. Eg:, instead of `"lookupRegex": "siddhi([_-])io([_-])http([_-])2.2.2.jar"`, we should put `"lookupRegex": "siddhi([_-])io([_-])http([_-])[0-9].[0-9].[0-9].jar"`.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes