### PR TITLE
Add Siddhi Error Replay for Store Type Errors

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/commons/js/dialog/error-handler-dialog.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/commons/js/dialog/error-handler-dialog.js
@@ -732,8 +732,6 @@ define(['require', 'lodash', 'jquery', 'constants', 'backbone', 'alerts', 'pagin
                 },
 
                 renderOriginalPayload: function(errorEntry) {
-                    console.log(errorEntry);
-                    console.log(errorEntry.eventType);
                     var originalPayload = $('<div></div>');
                     if (errorEntry.eventType === "REPLAYABLE_TABLE_RECORD") {
                         originalPayload.append('<div><h4>Table Record</h4></div>');

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/commons/js/dialog/error-handler-dialog.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/commons/js/dialog/error-handler-dialog.js
@@ -736,7 +736,7 @@ define(['require', 'lodash', 'jquery', 'constants', 'backbone', 'alerts', 'pagin
                         return replay.find("#eventPayload").val();
                     } else if (wrappedErrorEntry.errorEntry.eventType === 'REPLAYABLE_TABLE_RECORD') {
                         var modifiablePayloadJson = JSON.parse(wrappedErrorEntry.modifiablePayloadString);
-                        var editedTableAsArray = replay.find(".eventPayloadTable");
+                        var editedTableAsArray = replay.find(".event-payload-table-input");
                         for (i = 0; i < modifiablePayloadJson.records.length; i++) {
                             for (j = 0; j < modifiablePayloadJson.attributes.length; j++) {
                                 modifiablePayloadJson.records[i][j] = editedTableAsArray[i
@@ -757,16 +757,16 @@ define(['require', 'lodash', 'jquery', 'constants', 'backbone', 'alerts', 'pagin
                         var editableTable = $('<table></table>');
                         var tableHeader = $('<tr></tr>');
                         modifiablePayloadJson.attributes.forEach(function (attribute) {
-                            tableHeader.append('<th><span style="text-transform: capitalize; padding-left: 1em; '
-                                + 'color: white;">' + attribute.name + '</span> <span style="text-transform: lowercase;'
-                                + 'color: white;">(' + attribute.type + ')</span></th>');
+                            tableHeader.append('<th><span class="event-payload-table-header-title">' + attribute.name
+                            + '</span> <span class="event-payload-table-header-type">(' + attribute.type
+                            + ')</span></th>');
                         ;});
                         editableTable.append(tableHeader);
                         modifiablePayloadJson.records.forEach(function (record) {
                             var tableRow = $('<tr></tr>');
                             record.forEach(function (column) {
-                                tableRow.append('<td><input type="text" class="eventPayloadTable" value="' + column +
-                                '" class="configure-server-input"></td>');
+                                tableRow.append('<td><input type="text" class="event-payload-table-input" value="' + column +
+                                '"></td>');
                             });
                             editableTable.append(tableRow);
                         ;});
@@ -781,15 +781,16 @@ define(['require', 'lodash', 'jquery', 'constants', 'backbone', 'alerts', 'pagin
                         var uneditableTable = $('<table></table>');
                         var tableHeader = $('<tr></tr>');
                         unmodifiablePayloadJson.attributes.forEach(function (attribute) {
-                            tableHeader.append('<th><span style="text-transform: capitalize; padding-left: 1em; '
-                                + 'color: white;">' + attribute.name + '</span> <span style="text-transform: lowercase;'
-                                + 'color: white;">(' + attribute.type + ')</span></th>');
+                            tableHeader.append('<th><span class="event-payload-table-header-title">' + attribute.name
+                                + '</span> <span class="event-payload-table-header-type">(' + attribute.type
+                                + ')</span></th>');
                         ;});
                         uneditableTable.append(tableHeader);
                         unmodifiablePayloadJson.records.forEach(function (record) {
                             var tableRow = $('<tr></tr>');
                             record.forEach(function (column) {
-                                tableRow.append('<td>' + column + '</td>');
+                                tableRow.append('<td><input type="text" class="event-payload-table-input" value="'
+                                + column + '" disabled></td>');
                             });
                             uneditableTable.append(tableRow);
                         ;});

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/commons/js/dialog/error-handler-dialog.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/commons/js/dialog/error-handler-dialog.js
@@ -758,7 +758,9 @@ define(['require', 'lodash', 'jquery', 'constants', 'backbone', 'alerts', 'pagin
                         var editableTable = $('<table></table>');
                         var tableHeader = $('<tr></tr>');
                         modifiablePayloadJson.attributes.forEach(function (attribute) {
-                            tableHeader.append('<th>' + attribute.name + '(' + attribute.type + ')</th>');
+                            tableHeader.append('<th><span style="text-transform: capitalize; padding-left: 1em; '
+                                + 'color: white;">' + attribute.name + '</span> <span style="text-transform: lowercase;'
+                                + 'color: white;">(' + attribute.type + ')</span></th>');
                         ;});
                         editableTable.append(tableHeader);
                         modifiablePayloadJson.records.forEach(function (record) {

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/commons/js/dialog/error-handler-dialog.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/commons/js/dialog/error-handler-dialog.js
@@ -683,7 +683,6 @@ define(['require', 'lodash', 'jquery', 'constants', 'backbone', 'alerts', 'pagin
                     modalBody.append(this.renderReplayButtonInDetailedErrorEntry(wrappedErrorEntry));
                     modalBody.append('<br/>');
                     if (!wrappedErrorEntry.isPayloadModifiable) {
-                        // todo
                         // Payload is not modifiable. Show the original payload, in case if the user wants to refer.
                         modalBody.append(this.renderOriginalPayload(errorEntry));
                         modalBody.append('<br/>');
@@ -778,7 +777,23 @@ define(['require', 'lodash', 'jquery', 'constants', 'backbone', 'alerts', 'pagin
                 renderOriginalPayload: function(errorEntry) {
                     var originalPayload = $('<div></div>');
                     if (errorEntry.eventType === "REPLAYABLE_TABLE_RECORD") {
-                        originalPayload.append('<div><h4>Table Record</h4></div>');
+                        var unmodifiablePayloadJson = JSON.parse(errorEntry.originalPayload);
+                        var uneditableTable = $('<table></table>');
+                        var tableHeader = $('<tr></tr>');
+                        unmodifiablePayloadJson.attributes.forEach(function (attribute) {
+                            tableHeader.append('<th><span style="text-transform: capitalize; padding-left: 1em; '
+                                + 'color: white;">' + attribute.name + '</span> <span style="text-transform: lowercase;'
+                                + 'color: white;">(' + attribute.type + ')</span></th>');
+                        ;});
+                        uneditableTable.append(tableHeader);
+                        unmodifiablePayloadJson.records.forEach(function (record) {
+                            var tableRow = $('<tr></tr>');
+                            record.forEach(function (column) {
+                                tableRow.append('<td>' + column + '</td>');
+                            });
+                            uneditableTable.append(tableRow);
+                        ;});
+                        return uneditableTable;
                     } else {
                         originalPayload.append('<div><h4>Original Payload</h4></div>');
                     }

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/commons/js/dialog/error-handler-dialog.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/commons/js/dialog/error-handler-dialog.js
@@ -711,6 +711,7 @@ define(['require', 'lodash', 'jquery', 'constants', 'backbone', 'alerts', 'pagin
 
                 renderReplayButtonInDetailedErrorEntry: function(wrappedErrorEntry) {
                     var self = this;
+                    console.log(wrappedErrorEntry);
                     var replay = $('<div></div>');
                     var replayableWrappedErrorEntry = wrappedErrorEntry;
                     if (wrappedErrorEntry.isPayloadModifiable) {
@@ -738,8 +739,26 @@ define(['require', 'lodash', 'jquery', 'constants', 'backbone', 'alerts', 'pagin
                                                              wrappedErrorEntry.modifiablePayloadString + '</textarea>');
                     } else if (wrappedErrorEntry.errorEntry.eventType === 'REPLAYABLE_TABLE_RECORD') {
                         // todo
-                        return $('<textarea id="eventPayload" rows="4" cols="40" class="payload-content">' +
-                        wrappedErrorEntry.modifiablePayloadString + '</textarea>');
+                        var modifiablePayloadJson = JSON.parse(wrappedErrorEntry.modifiablePayloadString);
+                        var editableTable = $('<table><thead><tr>');
+                        modifiablePayloadJson.attributes.forEach(function (attribute) {
+                            editableTable.append('<th>' + attribute.name + '(' + attribute.type + ')</th>');
+                        ;});
+                        var columnNumber = 0;
+                        editableTable.append('</tr></thead><tbody>');
+                        modifiablePayloadJson.records.forEach(function (record) {
+                            var rowNumber = 0;
+                            editableTable.append('<tr>');
+                            record.forEach(function (column) {
+                                editableTable.append('<td><input type="text" id="eventPayload:' + columnNumber + ' '
+                                + rowNumber + '" value="' + column + '"></td>');
+                                rowNumber = rowNumber + 1;
+                            });
+                            editableTable.append('</tr>');
+                            columnNumber = columnNumber + 1;
+                        ;});
+                        editableTable.append('</tbody></table>')
+                        return editableTable;
                     }
                 },
 

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/commons/js/dialog/error-handler-dialog.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/commons/js/dialog/error-handler-dialog.js
@@ -760,7 +760,7 @@ define(['require', 'lodash', 'jquery', 'constants', 'backbone', 'alerts', 'pagin
                             tableHeader.append('<th><span class="event-payload-table-header-title">' + attribute.name
                             + '</span> <span class="event-payload-table-header-type">(' + attribute.type
                             + ')</span></th>');
-                        ;});
+                        });
                         editableTable.append(tableHeader);
                         modifiablePayloadJson.records.forEach(function (record) {
                             var tableRow = $('<tr></tr>');
@@ -769,7 +769,7 @@ define(['require', 'lodash', 'jquery', 'constants', 'backbone', 'alerts', 'pagin
                                 '"></td>');
                             });
                             editableTable.append(tableRow);
-                        ;});
+                        });
                         return editableTable;
                     }
                 },
@@ -784,7 +784,7 @@ define(['require', 'lodash', 'jquery', 'constants', 'backbone', 'alerts', 'pagin
                             tableHeader.append('<th><span class="event-payload-table-header-title">' + attribute.name
                                 + '</span> <span class="event-payload-table-header-type">(' + attribute.type
                                 + ')</span></th>');
-                        ;});
+                        });
                         uneditableTable.append(tableHeader);
                         unmodifiablePayloadJson.records.forEach(function (record) {
                             var tableRow = $('<tr></tr>');
@@ -793,7 +793,7 @@ define(['require', 'lodash', 'jquery', 'constants', 'backbone', 'alerts', 'pagin
                                 + column + '" disabled></td>');
                             });
                             uneditableTable.append(tableRow);
-                        ;});
+                        });
                         return uneditableTable;
                     } else {
                         originalPayload.append('<div><h4>Original Payload</h4></div>');

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/commons/js/dialog/error-handler-dialog.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/commons/js/dialog/error-handler-dialog.js
@@ -732,7 +732,14 @@ define(['require', 'lodash', 'jquery', 'constants', 'backbone', 'alerts', 'pagin
                 },
 
                 renderOriginalPayload: function(errorEntry) {
-                    var originalPayload = $('<div><h4>Original Payload</h4></div>');
+                    console.log(errorEntry);
+                    console.log(errorEntry.eventType);
+                    var originalPayload = $('<div></div>');
+                    if (errorEntry.eventType === "REPLAYABLE_TABLE_RECORD") {
+                        originalPayload.append('<div><h4>Table Record</h4></div>');
+                    } else {
+                        originalPayload.append('<div><h4>Original Payload</h4></div>');
+                    }
                     if (errorEntry.originalPayload) {
                         originalPayload.append('<div class="payload-content">' + errorEntry.originalPayload + '</div>');
                     } else {

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/commons/js/dialog/error-handler-dialog.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/commons/js/dialog/error-handler-dialog.js
@@ -683,6 +683,7 @@ define(['require', 'lodash', 'jquery', 'constants', 'backbone', 'alerts', 'pagin
                     modalBody.append(this.renderReplayButtonInDetailedErrorEntry(wrappedErrorEntry));
                     modalBody.append('<br/>');
                     if (!wrappedErrorEntry.isPayloadModifiable) {
+                        // todo
                         // Payload is not modifiable. Show the original payload, in case if the user wants to refer.
                         modalBody.append(this.renderOriginalPayload(errorEntry));
                         modalBody.append('<br/>');
@@ -713,9 +714,8 @@ define(['require', 'lodash', 'jquery', 'constants', 'backbone', 'alerts', 'pagin
                     var replay = $('<div></div>');
                     var replayableWrappedErrorEntry = wrappedErrorEntry;
                     if (wrappedErrorEntry.isPayloadModifiable) {
-                        // Payload is not modifiable.
-                        replay.append('<textarea id="eventPayload" rows="4" cols="40" class="payload-content">' +
-                            wrappedErrorEntry.modifiablePayloadString + '</textarea>');
+                        // Payload is modifiable. todo
+                        replay.append(self.renderEditablePayload(wrappedErrorEntry));
                         replay.append('<br/>');
                     }
                     replay.append("<button id='replay' type='button' class='btn btn-primary'>Replay</button>");
@@ -731,6 +731,18 @@ define(['require', 'lodash', 'jquery', 'constants', 'backbone', 'alerts', 'pagin
                     return replay;
                 },
 
+                // todo
+                renderEditablePayload: function(wrappedErrorEntry) {
+                    if (wrappedErrorEntry.errorEntry.eventType === 'PAYLOAD_STRING') {
+                        return $('<textarea id="eventPayload" rows="4" cols="40" class="payload-content">' +
+                                                             wrappedErrorEntry.modifiablePayloadString + '</textarea>');
+                    } else if (wrappedErrorEntry.errorEntry.eventType === 'REPLAYABLE_TABLE_RECORD') {
+                        // todo
+                        return $('<textarea id="eventPayload" rows="4" cols="40" class="payload-content">' +
+                        wrappedErrorEntry.modifiablePayloadString + '</textarea>');
+                    }
+                },
+
                 renderOriginalPayload: function(errorEntry) {
                     var originalPayload = $('<div></div>');
                     if (errorEntry.eventType === "REPLAYABLE_TABLE_RECORD") {
@@ -740,6 +752,7 @@ define(['require', 'lodash', 'jquery', 'constants', 'backbone', 'alerts', 'pagin
                     }
                     if (errorEntry.originalPayload) {
                         originalPayload.append('<div class="payload-content">' + errorEntry.originalPayload + '</div>');
+                        // todo render as html table
                     } else {
                         originalPayload.append('<div>Original payload of the event is not available</div>');
                     }

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/commons/js/dialog/error-handler-dialog.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/commons/js/dialog/error-handler-dialog.js
@@ -711,11 +711,10 @@ define(['require', 'lodash', 'jquery', 'constants', 'backbone', 'alerts', 'pagin
 
                 renderReplayButtonInDetailedErrorEntry: function(wrappedErrorEntry) {
                     var self = this;
-                    console.log(wrappedErrorEntry);
                     var replay = $('<div></div>');
                     var replayableWrappedErrorEntry = wrappedErrorEntry;
                     if (wrappedErrorEntry.isPayloadModifiable) {
-                        // Payload is modifiable. todo
+                        // Payload is modifiable.
                         replay.append(self.renderEditablePayload(wrappedErrorEntry));
                         replay.append('<br/>');
                     }
@@ -723,9 +722,8 @@ define(['require', 'lodash', 'jquery', 'constants', 'backbone', 'alerts', 'pagin
 
                     replay.find("#replay").click(function() {
                         if (wrappedErrorEntry.isPayloadModifiable) {
-                            replayableWrappedErrorEntry.modifiablePayloadString = self.constructModifiablePayloadString(replay, wrappedErrorEntry);
-                            console.log(replayableWrappedErrorEntry.modifiablePayloadString);
-//                            replayableWrappedErrorEntry.modifiablePayloadString = replay.find("#eventPayload").val();
+                            replayableWrappedErrorEntry.modifiablePayloadString =
+                                    self.constructModifiablePayloadString(replay, wrappedErrorEntry);
                         }
                         self.replay([replayableWrappedErrorEntry], self.serverHost, self.serverPort,
                             self.serverUsername, self.serverPassword, true);
@@ -740,25 +738,22 @@ define(['require', 'lodash', 'jquery', 'constants', 'backbone', 'alerts', 'pagin
                     } else if (wrappedErrorEntry.errorEntry.eventType === 'REPLAYABLE_TABLE_RECORD') {
                         var modifiablePayloadJson = JSON.parse(wrappedErrorEntry.modifiablePayloadString);
                         var editedTableAsArray = replay.find(".eventPayloadTable");
-                        console.log(replay.find(".eventPayloadTable"));
                         for (i = 0; i < modifiablePayloadJson.records.length; i++) {
                             for (j = 0; j < modifiablePayloadJson.attributes.length; j++) {
-                                modifiablePayloadJson.records[i][j] = editedTableAsArray[i * modifiablePayloadJson.attributes.length + j].value;
+                                modifiablePayloadJson.records[i][j] = editedTableAsArray[i
+                                        * modifiablePayloadJson.attributes.length + j].value;
                             }
                         }
-                        console.log(JSON.stringify(modifiablePayloadJson));
                         return JSON.stringify(modifiablePayloadJson);
                     }
                     return null;
                 },
 
-                // todo
                 renderEditablePayload: function(wrappedErrorEntry) {
                     if (wrappedErrorEntry.errorEntry.eventType === 'PAYLOAD_STRING') {
                         return $('<textarea id="eventPayload" rows="4" cols="40" class="payload-content">' +
                                                              wrappedErrorEntry.modifiablePayloadString + '</textarea>');
                     } else if (wrappedErrorEntry.errorEntry.eventType === 'REPLAYABLE_TABLE_RECORD') {
-                        // todo
                         var modifiablePayloadJson = JSON.parse(wrappedErrorEntry.modifiablePayloadString);
                         var editableTable = $('<table></table>');
                         var tableHeader = $('<tr></tr>');
@@ -787,7 +782,6 @@ define(['require', 'lodash', 'jquery', 'constants', 'backbone', 'alerts', 'pagin
                     }
                     if (errorEntry.originalPayload) {
                         originalPayload.append('<div class="payload-content">' + errorEntry.originalPayload + '</div>');
-                        // todo render as html table
                     } else {
                         originalPayload.append('<div>Original payload of the event is not available</div>');
                     }

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/css/error-handler.css
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/css/error-handler.css
@@ -57,6 +57,26 @@
     font-weight: bold;
 }
 
+.event-payload-table-input {
+    width: 120px;
+    background-color: #383838;
+    border-style: none;
+    height: 35px;
+    padding-left: 10px;
+    color: #fff;
+}
+
+.event-payload-table-header-title {
+    text-transform: capitalize;
+    padding-left: 1em;
+    color: white;
+}
+
+.event-payload-table-header-type {
+    text-transform: lowercase;
+    color: white;
+}
+
 .error-cause {
     color: #f47b20;
 }

--- a/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/execution/ErrorStoreAccessor.java
+++ b/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/execution/ErrorStoreAccessor.java
@@ -107,7 +107,7 @@ public class ErrorStoreAccessor {
         throw new SiddhiErrorHandlerException(ERROR_STORE_IS_UNAVAILABLE_MESSAGE);
     }
 
-    private static boolean isPayloadEditable(ErrorEntry errorEntry) {
+    private static boolean isPayloadEditable(ErrorEntry errorEntry) { // TODO: 2020-10-02 move to util 
         if (errorEntry.getEventType() == ErroneousEventType.PAYLOAD_STRING) {
             return true;
         } else if(errorEntry.getEventType() == ErroneousEventType.REPLAYABLE_TABLE_RECORD) {

--- a/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/execution/ErrorStoreAccessor.java
+++ b/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/execution/ErrorStoreAccessor.java
@@ -116,7 +116,6 @@ public class ErrorStoreAccessor {
 
         }
         return false;
-        // TODO: 2020-09-29 for ReplayableTableRecord
     }
 
     public static void purgeErrorStore(String retentionDays) throws SiddhiErrorHandlerException {

--- a/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/execution/ErrorStoreAccessor.java
+++ b/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/execution/ErrorStoreAccessor.java
@@ -18,12 +18,8 @@
 
 package org.wso2.carbon.siddhi.error.handler.core.execution;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import io.siddhi.core.util.error.handler.model.ErrorEntry;
 import io.siddhi.core.util.error.handler.store.ErrorStore;
-import io.siddhi.core.util.error.handler.util.ErroneousEventType;
 import org.wso2.carbon.siddhi.error.handler.core.exception.SiddhiErrorHandlerException;
 import org.wso2.carbon.siddhi.error.handler.core.internal.SiddhiErrorHandlerDataHolder;
 import org.wso2.carbon.siddhi.error.handler.core.util.ErrorEntryWrapper;
@@ -33,6 +29,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static org.wso2.carbon.siddhi.error.handler.core.util.SiddhiErrorHandlerUtils.isPayloadEditable;
 
 /**
  * Communicates with the Error Store for Siddhi Error Handler functionalities.
@@ -105,17 +103,6 @@ public class ErrorStoreAccessor {
             }
         }
         throw new SiddhiErrorHandlerException(ERROR_STORE_IS_UNAVAILABLE_MESSAGE);
-    }
-
-    private static boolean isPayloadEditable(ErrorEntry errorEntry) { // TODO: 2020-10-02 move to util 
-        if (errorEntry.getEventType() == ErroneousEventType.PAYLOAD_STRING) {
-            return true;
-        } else if(errorEntry.getEventType() == ErroneousEventType.REPLAYABLE_TABLE_RECORD) {
-            return new JsonParser().parse(errorEntry.getOriginalPayload()).getAsJsonObject().get("isEditable")
-                    .getAsString().equalsIgnoreCase("true");
-
-        }
-        return false;
     }
 
     public static void purgeErrorStore(String retentionDays) throws SiddhiErrorHandlerException {

--- a/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/execution/RePlayer.java
+++ b/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/execution/RePlayer.java
@@ -26,7 +26,8 @@ import io.siddhi.core.stream.input.source.Source;
 import io.siddhi.core.util.error.handler.model.ErrorEntry;
 import io.siddhi.core.util.error.handler.model.ReplayableTableRecord;
 import io.siddhi.core.util.error.handler.store.ErrorStore;
-import io.siddhi.core.util.error.handler.util.*;
+import io.siddhi.core.util.error.handler.util.ErrorHandlerUtils;
+import io.siddhi.core.util.error.handler.util.ErrorOccurrence;
 import org.wso2.carbon.siddhi.error.handler.core.exception.SiddhiErrorHandlerException;
 import org.wso2.carbon.siddhi.error.handler.core.internal.SiddhiErrorHandlerDataHolder;
 
@@ -60,7 +61,7 @@ public class RePlayer {
 
     private static void rePlay(ErrorEntry errorEntry) throws SiddhiErrorHandlerException, InterruptedException {
         SiddhiAppRuntime siddhiAppRuntime = SiddhiErrorHandlerDataHolder.getInstance()
-                .getSiddhiAppRuntimeService().getActiveSiddhiAppRuntimes().get(errorEntry.getSiddhiAppName());
+            .getSiddhiAppRuntimeService().getActiveSiddhiAppRuntimes().get(errorEntry.getSiddhiAppName());
         if (siddhiAppRuntime != null) {
             switch (errorEntry.getEventType()) {
                 case COMPLEX_EVENT:
@@ -135,8 +136,7 @@ public class RePlayer {
         try {
             Object complexEvent = ErrorHandlerUtils.getAsObject(complexEventErrorEntry.getEventAsBytes());
             if (complexEvent instanceof ComplexEvent) {
-                InputHandler inputHandler = siddhiAppRuntime.getInputHandler(complexEventErrorEntry
-                        .getStreamName());
+                InputHandler inputHandler = siddhiAppRuntime.getInputHandler(complexEventErrorEntry.getStreamName());
                 if (inputHandler != null) {
                     ComplexEvent current = (ComplexEvent) complexEvent;
                     while (current != null) {
@@ -144,8 +144,8 @@ public class RePlayer {
                         current = current.getNext();
                     }
                 } else {
-                    throw new SiddhiErrorHandlerException(String.format("Input handler was not found for " +
-                        "stream: %s.", complexEventErrorEntry.getStreamName()));
+                    throw new SiddhiErrorHandlerException(String.format("Input handler was not found for stream: %s.",
+                        complexEventErrorEntry.getStreamName()));
                 }
             } else {
                 throw new SiddhiErrorHandlerException(
@@ -214,7 +214,7 @@ public class RePlayer {
                 }
             } else {
                 throw new SiddhiErrorHandlerException(
-                        "eventAsBytes present in the entry is invalid. It is expected to represent an Event List.");
+                    "eventAsBytes present in the entry is invalid. It is expected to represent an Event List.");
             }
         } catch (IOException | ClassNotFoundException e) {
             throw new SiddhiErrorHandlerException("Failed to get bytes as an Event List.", e);

--- a/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/execution/RePlayer.java
+++ b/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/execution/RePlayer.java
@@ -24,6 +24,7 @@ import io.siddhi.core.event.Event;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.stream.input.source.Source;
 import io.siddhi.core.util.error.handler.model.ErrorEntry;
+import io.siddhi.core.util.error.handler.model.ReplayableTableRecord;
 import io.siddhi.core.util.error.handler.store.ErrorStore;
 import io.siddhi.core.util.error.handler.util.*;
 import org.wso2.carbon.siddhi.error.handler.core.exception.SiddhiErrorHandlerException;
@@ -101,6 +102,7 @@ public class RePlayer {
             Object deserializedTableRecord = ErrorHandlerUtils.getAsObject(complexEventErrorEntry.getEventAsBytes());
             if (deserializedTableRecord instanceof ReplayableTableRecord) {
                 ReplayableTableRecord replayableTableRecord = (ReplayableTableRecord) deserializedTableRecord;
+//                siddhiAppRuntime.getQueries().stream().findFirst().get().getQuery().getInputStream().
                 switch (complexEventErrorEntry.getErrorOccurrence()) {
                     case STORE_ON_TABLE_ADD:
                         siddhiAppRuntime.getTableInputHandler(complexEventErrorEntry.getStreamName())
@@ -115,7 +117,7 @@ public class RePlayer {
                     case STORE_ON_TABLE_DELETE:
                         siddhiAppRuntime.getTableInputHandler(complexEventErrorEntry.getStreamName())
                                 .delete(replayableTableRecord.getComplexEventChunk(),
-                                        replayableTableRecord.getCompiledCondition());
+                                        replayableTableRecord.getCompiledCondition(), null);
                         break;
                     default:
                         throw new SiddhiErrorHandlerException("Unsupported ErrorOccurenceType of " +

--- a/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/execution/RePlayer.java
+++ b/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/execution/RePlayer.java
@@ -61,42 +61,32 @@ public class RePlayer {
     private static void rePlay(ErrorEntry errorEntry) throws SiddhiErrorHandlerException, InterruptedException {
         SiddhiAppRuntime siddhiAppRuntime = SiddhiErrorHandlerDataHolder.getInstance()
                 .getSiddhiAppRuntimeService().getActiveSiddhiAppRuntimes().get(errorEntry.getSiddhiAppName());
-        if (errorEntry.getErrorType() == ErrorType.MAPPING || errorEntry.getErrorType() == ErrorType.TRANSPORT) {
-            if (siddhiAppRuntime != null) {
-                switch (errorEntry.getEventType()) {
-                    case COMPLEX_EVENT:
-                        rePlayComplexEvent(errorEntry, siddhiAppRuntime);
-                        break;
-                    case EVENT:
-                        rePlayEvent(errorEntry, siddhiAppRuntime);
-                        break;
-                    case EVENT_ARRAY:
-                        rePlayEventArray(errorEntry, siddhiAppRuntime);
-                        break;
-                    case EVENT_LIST:
-                        rePlayEventList(errorEntry, siddhiAppRuntime);
-                        break;
-                    case PAYLOAD_STRING:
-                        rePlayPayloadString(errorEntry, siddhiAppRuntime);
-                        break;
-                    default:
-                        // Ideally we won't reach here
-                }
-            }
-        } else {
-            if (siddhiAppRuntime != null) {
-                if (errorEntry.getEventType() == ErroneousEventType.REPLAYABLE_TABLE_RECORD) {
-                    rePlayComplexEventChunk(errorEntry, siddhiAppRuntime);
-                } else {
-                    throw new SiddhiErrorHandlerException("For ErrorType STORE the ErroneousEventType should be " +
-                            "COMPLEX_EVENT_CHUNK but found " + errorEntry.getEventType().toString() + " in " +
-                            errorEntry.getStreamName());
-                }
+        if (siddhiAppRuntime != null) {
+            switch (errorEntry.getEventType()) {
+                case COMPLEX_EVENT:
+                    rePlayComplexEvent(errorEntry, siddhiAppRuntime);
+                    break;
+                case EVENT:
+                    rePlayEvent(errorEntry, siddhiAppRuntime);
+                    break;
+                case EVENT_ARRAY:
+                    rePlayEventArray(errorEntry, siddhiAppRuntime);
+                    break;
+                case EVENT_LIST:
+                    rePlayEventList(errorEntry, siddhiAppRuntime);
+                    break;
+                case PAYLOAD_STRING:
+                    rePlayPayloadString(errorEntry, siddhiAppRuntime);
+                    break;
+                case REPLAYABLE_TABLE_RECORD:
+                    rePlayTableRecord(errorEntry, siddhiAppRuntime);
+                default:
+                    // Ideally we won't reach here
             }
         }
     }
 
-    private static void rePlayComplexEventChunk(ErrorEntry complexEventErrorEntry, SiddhiAppRuntime siddhiAppRuntime)
+    private static void rePlayTableRecord(ErrorEntry complexEventErrorEntry, SiddhiAppRuntime siddhiAppRuntime)
             throws SiddhiErrorHandlerException, InterruptedException {
         try {
             Object deserializedTableRecord = ErrorHandlerUtils.getAsObject(complexEventErrorEntry.getEventAsBytes());

--- a/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/execution/RePlayer.java
+++ b/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/execution/RePlayer.java
@@ -119,6 +119,12 @@ public class RePlayer {
                                 .delete(replayableTableRecord.getComplexEventChunk(),
                                         replayableTableRecord.getCompiledCondition(), null);
                         break;
+                    case STORE_ON_TABLE_UPDATE:
+                        siddhiAppRuntime.getTableInputHandler(complexEventErrorEntry.getStreamName())
+                                .update(replayableTableRecord.getComplexEventChunk(),
+                                        replayableTableRecord.getCompiledCondition(),
+                                        replayableTableRecord.getCompiledUpdateSet(), null);
+                        break;
                     default:
                         throw new SiddhiErrorHandlerException("Unsupported ErrorOccurenceType of " +
                                 complexEventErrorEntry.getErrorOccurrence() + " to replay ComplexEventChunk in "

--- a/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/execution/RePlayer.java
+++ b/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/execution/RePlayer.java
@@ -125,6 +125,13 @@ public class RePlayer {
                                         replayableTableRecord.getCompiledCondition(),
                                         replayableTableRecord.getCompiledUpdateSet(), null);
                         break;
+                    case STORE_ON_TABLE_UPDATE_OR_ADD:
+                        siddhiAppRuntime.getTableInputHandler(complexEventErrorEntry.getStreamName())
+                                .updateOrAdd(replayableTableRecord.getComplexEventChunk(),
+                                        replayableTableRecord.getCompiledCondition(),
+                                        replayableTableRecord.getCompiledUpdateSet(),
+                                        replayableTableRecord.getAddingStreamEventExtractor(), null);
+                        break;
                     default:
                         throw new SiddhiErrorHandlerException("Unsupported ErrorOccurenceType of " +
                                 complexEventErrorEntry.getErrorOccurrence() + " to replay ComplexEventChunk in "

--- a/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/execution/RePlayer.java
+++ b/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/execution/RePlayer.java
@@ -66,6 +66,7 @@ public class RePlayer {
     private static void rePlay(ErrorEntry errorEntry) throws SiddhiErrorHandlerException, InterruptedException {
         SiddhiAppRuntime siddhiAppRuntime = SiddhiErrorHandlerDataHolder.getInstance()
                 .getSiddhiAppRuntimeService().getActiveSiddhiAppRuntimes().get(errorEntry.getSiddhiAppName());
+        // TODO: 2020-09-07  check if replay for stream (in if) or table (in else)
         if (siddhiAppRuntime != null) {
             switch (errorEntry.getEventType()) {
                 case COMPLEX_EVENT:
@@ -89,6 +90,8 @@ public class RePlayer {
         }
     }
 
+    // TODO: 2020-09-07  write rePlayComplexEventChunkToTable function - params chunk, siddhiappruntime
+
     private static void rePlayComplexEvent(ErrorEntry complexEventErrorEntry, SiddhiAppRuntime siddhiAppRuntime)
             throws SiddhiErrorHandlerException, InterruptedException {
         try {
@@ -96,6 +99,7 @@ public class RePlayer {
             if (complexEvent instanceof ComplexEvent) {
                 switch (complexEventErrorEntry.getErrorOccurrence()) {
                     case STORE_ON_TABLE_ADD:
+                        // TODO: 2020-09-07 read chunk itself and send in
                         ComplexEventChunk<StreamEvent> replayAddEventChunk = new ComplexEventChunk<>();
                         replayAddEventChunk.add((StreamEvent) complexEvent);
                         ConcurrentHashMap tableMap = (ConcurrentHashMap) siddhiAppRuntime.getTables();

--- a/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/execution/RePlayer.java
+++ b/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/execution/RePlayer.java
@@ -87,7 +87,7 @@ public class RePlayer {
     }
 
     private static void rePlayTableRecord(ErrorEntry complexEventErrorEntry, SiddhiAppRuntime siddhiAppRuntime)
-            throws SiddhiErrorHandlerException, InterruptedException {
+        throws SiddhiErrorHandlerException, InterruptedException {
         try {
             Object deserializedTableRecord = ErrorHandlerUtils.getAsObject(complexEventErrorEntry.getEventAsBytes());
             if (deserializedTableRecord instanceof ReplayableTableRecord) {
@@ -131,7 +131,7 @@ public class RePlayer {
     }
 
     private static void rePlayComplexEvent(ErrorEntry complexEventErrorEntry, SiddhiAppRuntime siddhiAppRuntime)
-            throws SiddhiErrorHandlerException, InterruptedException {
+        throws SiddhiErrorHandlerException, InterruptedException {
         try {
             Object complexEvent = ErrorHandlerUtils.getAsObject(complexEventErrorEntry.getEventAsBytes());
             if (complexEvent instanceof ComplexEvent) {
@@ -157,7 +157,7 @@ public class RePlayer {
     }
 
     private static void rePlayEvent(ErrorEntry eventErrorEntry, SiddhiAppRuntime siddhiAppRuntime)
-            throws SiddhiErrorHandlerException, InterruptedException {
+        throws SiddhiErrorHandlerException, InterruptedException {
         try {
             Object event = ErrorHandlerUtils.getAsObject(eventErrorEntry.getEventAsBytes());
             if (event instanceof Event) {
@@ -178,7 +178,7 @@ public class RePlayer {
     }
 
     private static void rePlayEventArray(ErrorEntry eventArrayErrorEntry, SiddhiAppRuntime siddhiAppRuntime)
-            throws SiddhiErrorHandlerException, InterruptedException {
+        throws SiddhiErrorHandlerException, InterruptedException {
         try {
             Object eventArray = ErrorHandlerUtils.getAsObject(eventArrayErrorEntry.getEventAsBytes());
             if (eventArray instanceof Event[]) {
@@ -199,7 +199,7 @@ public class RePlayer {
     }
 
     private static void rePlayEventList(ErrorEntry eventListErrorEntry, SiddhiAppRuntime siddhiAppRuntime)
-            throws SiddhiErrorHandlerException, InterruptedException {
+        throws SiddhiErrorHandlerException, InterruptedException {
         try {
             Object eventList = ErrorHandlerUtils.getAsObject(eventListErrorEntry.getEventAsBytes());
             if (eventList instanceof List) {
@@ -222,7 +222,7 @@ public class RePlayer {
     }
 
     private static void rePlayPayloadString(ErrorEntry payloadStringErrorEntry, SiddhiAppRuntime siddhiAppRuntime)
-            throws SiddhiErrorHandlerException {
+        throws SiddhiErrorHandlerException {
         try {
             Object payloadString = ErrorHandlerUtils.getAsObject(payloadStringErrorEntry.getEventAsBytes());
             if (payloadString instanceof String) {

--- a/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/execution/RePlayer.java
+++ b/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/execution/RePlayer.java
@@ -117,8 +117,8 @@ public class RePlayer {
                         break;
                     default:
                         throw new SiddhiErrorHandlerException("Unsupported ErrorOccurenceType of " +
-                                complexEventErrorEntry.getErrorOccurrence() + " to replay ComplexEventChunk in "
-                                + complexEventErrorEntry.getStreamName());
+                            complexEventErrorEntry.getErrorOccurrence() + " to replay ComplexEventChunk in "
+                            + complexEventErrorEntry.getStreamName());
                 }
             } else {
                 throw new SiddhiErrorHandlerException(
@@ -145,11 +145,11 @@ public class RePlayer {
                     }
                 } else {
                     throw new SiddhiErrorHandlerException(String.format("Input handler was not found for " +
-                            "stream: %s.", complexEventErrorEntry.getStreamName()));
+                        "stream: %s.", complexEventErrorEntry.getStreamName()));
                 }
             } else {
                 throw new SiddhiErrorHandlerException(
-                        "eventAsBytes present in the entry is invalid. It is expected to represent a ComplexEvent.");
+                    "eventAsBytes present in the entry is invalid. It is expected to represent a ComplexEvent.");
             }
         } catch (IOException | ClassNotFoundException e) {
             throw new SiddhiErrorHandlerException("Failed to get bytes as a ComplexEvent object.", e);
@@ -166,11 +166,11 @@ public class RePlayer {
                     inputHandler.send((Event) event);
                 } else {
                     throw new SiddhiErrorHandlerException(
-                            String.format("Input handler was not found for stream: %s.", eventErrorEntry.getStreamName()));
+                        String.format("Input handler was not found for stream: %s.", eventErrorEntry.getStreamName()));
                 }
             } else {
                 throw new SiddhiErrorHandlerException(
-                        "eventAsBytes present in the entry is invalid. It is expected to represent an Event.");
+                    "eventAsBytes present in the entry is invalid. It is expected to represent an Event.");
             }
         } catch (IOException | ClassNotFoundException e) {
             throw new SiddhiErrorHandlerException("Failed to get bytes as an Event object.", e);
@@ -187,11 +187,11 @@ public class RePlayer {
                     inputHandler.send((Event[]) eventArray);
                 } else {
                     throw new SiddhiErrorHandlerException(String.format("Input handler was not found for stream: %s.",
-                            eventArrayErrorEntry.getStreamName()));
+                        eventArrayErrorEntry.getStreamName()));
                 }
             } else {
                 throw new SiddhiErrorHandlerException(
-                        "eventAsBytes present in the entry is invalid. It is expected to represent an Event[].");
+                    "eventAsBytes present in the entry is invalid. It is expected to represent an Event[].");
             }
         } catch (IOException | ClassNotFoundException e) {
             throw new SiddhiErrorHandlerException("Failed to get bytes as an Event[].", e);
@@ -210,7 +210,7 @@ public class RePlayer {
                     }
                 } else {
                     throw new SiddhiErrorHandlerException(String.format("Input handler was not found for stream: %s.",
-                            eventListErrorEntry.getStreamName()));
+                        eventListErrorEntry.getStreamName()));
                 }
             } else {
                 throw new SiddhiErrorHandlerException(
@@ -229,21 +229,21 @@ public class RePlayer {
                 if (payloadStringErrorEntry.getErrorOccurrence() == ErrorOccurrence.BEFORE_SOURCE_MAPPING) {
                     // Get sources of the appropriate stream.
                     Optional<List<Source>> sourcesOfStream = siddhiAppRuntime.getSources().stream().filter(sourceList ->
-                            sourceList.stream().anyMatch(source -> Objects.equals(source.getStreamDefinition().getId(),
-                                    payloadStringErrorEntry.getStreamName()))).findFirst();
+                        sourceList.stream().anyMatch(source -> Objects.equals(source.getStreamDefinition().getId(),
+                            payloadStringErrorEntry.getStreamName()))).findFirst();
 
                     if (sourcesOfStream.isPresent() && sourcesOfStream.get().size() == 1) {
                         sourcesOfStream.get().get(0).getMapper().onEvent(payloadString, null, null);
                     } else {
                         throw new SiddhiErrorHandlerException(
-                                "Re-playing can be done only if a single source is associated with the stream.");
+                            "Re-playing can be done only if a single source is associated with the stream.");
                     }
                 } else {
                     throw new SiddhiErrorHandlerException("Unexpected error occurrence for the error.");
                 }
             } else {
                 throw new SiddhiErrorHandlerException(
-                        "eventAsBytes present in the entry is invalid. It is expected to represent a String.");
+                    "eventAsBytes present in the entry is invalid. It is expected to represent a String.");
             }
         } catch (IOException | ClassNotFoundException e) {
             throw new SiddhiErrorHandlerException("Failed to get bytes as a String.", e);

--- a/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/execution/RePlayer.java
+++ b/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/execution/RePlayer.java
@@ -20,9 +20,7 @@ package org.wso2.carbon.siddhi.error.handler.core.execution;
 
 import io.siddhi.core.SiddhiAppRuntime;
 import io.siddhi.core.event.ComplexEvent;
-import io.siddhi.core.event.ComplexEventChunk;
 import io.siddhi.core.event.Event;
-import io.siddhi.core.event.stream.StreamEvent;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.stream.input.source.Source;
 import io.siddhi.core.util.error.handler.model.ErrorEntry;
@@ -105,10 +103,19 @@ public class RePlayer {
                 ReplayableTableRecord replayableTableRecord = (ReplayableTableRecord) deserializedTableRecord;
                 switch (complexEventErrorEntry.getErrorOccurrence()) {
                     case STORE_ON_TABLE_ADD:
-                        ComplexEventChunk<StreamEvent> replayAddEventChunk =
-                                replayableTableRecord.getComplexEventChunk();
                         siddhiAppRuntime.getTableInputHandler(complexEventErrorEntry.getStreamName())
-                                .add(replayAddEventChunk);
+                                .add(replayableTableRecord.getComplexEventChunk());
+                        break;
+                    case STORE_ON_TABLE_FIND:
+                        // TODO: 2020-09-10 Cannot send back a return value. We need to fingure out how to inject the
+                        //  find response into appropriate stream
+//                        siddhiAppRuntime.getTableInputHandler(complexEventErrorEntry.getStreamName())
+//                                .find(replayableTableRecord.getComplexEventChunk());
+                        break;
+                    case STORE_ON_TABLE_DELETE:
+                        siddhiAppRuntime.getTableInputHandler(complexEventErrorEntry.getStreamName())
+                                .delete(replayableTableRecord.getComplexEventChunk(),
+                                        replayableTableRecord.getCompiledCondition());
                         break;
                     default:
                         throw new SiddhiErrorHandlerException("Unsupported ErrorOccurenceType of " +

--- a/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/execution/RePlayer.java
+++ b/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/execution/RePlayer.java
@@ -102,35 +102,28 @@ public class RePlayer {
             Object deserializedTableRecord = ErrorHandlerUtils.getAsObject(complexEventErrorEntry.getEventAsBytes());
             if (deserializedTableRecord instanceof ReplayableTableRecord) {
                 ReplayableTableRecord replayableTableRecord = (ReplayableTableRecord) deserializedTableRecord;
-//                siddhiAppRuntime.getQueries().stream().findFirst().get().getQuery().getInputStream().
                 switch (complexEventErrorEntry.getErrorOccurrence()) {
                     case STORE_ON_TABLE_ADD:
                         siddhiAppRuntime.getTableInputHandler(complexEventErrorEntry.getStreamName())
                                 .add(replayableTableRecord.getComplexEventChunk());
                         break;
-                    case STORE_ON_TABLE_FIND:
-                        // TODO: 2020-09-10 Cannot send back a return value. We need to fingure out how to inject the
-                        //  find response into appropriate stream
-//                        siddhiAppRuntime.getTableInputHandler(complexEventErrorEntry.getStreamName())
-//                                .find(replayableTableRecord.getComplexEventChunk());
-                        break;
                     case STORE_ON_TABLE_DELETE:
                         siddhiAppRuntime.getTableInputHandler(complexEventErrorEntry.getStreamName())
                                 .delete(replayableTableRecord.getComplexEventChunk(),
-                                        replayableTableRecord.getCompiledCondition(), null);
+                                        replayableTableRecord.getCompiledCondition());
                         break;
                     case STORE_ON_TABLE_UPDATE:
                         siddhiAppRuntime.getTableInputHandler(complexEventErrorEntry.getStreamName())
                                 .update(replayableTableRecord.getComplexEventChunk(),
                                         replayableTableRecord.getCompiledCondition(),
-                                        replayableTableRecord.getCompiledUpdateSet(), null);
+                                        replayableTableRecord.getCompiledUpdateSet());
                         break;
                     case STORE_ON_TABLE_UPDATE_OR_ADD:
                         siddhiAppRuntime.getTableInputHandler(complexEventErrorEntry.getStreamName())
                                 .updateOrAdd(replayableTableRecord.getComplexEventChunk(),
                                         replayableTableRecord.getCompiledCondition(),
                                         replayableTableRecord.getCompiledUpdateSet(),
-                                        replayableTableRecord.getAddingStreamEventExtractor(), null);
+                                        replayableTableRecord.getAddingStreamEventExtractor());
                         break;
                     default:
                         throw new SiddhiErrorHandlerException("Unsupported ErrorOccurenceType of " +

--- a/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/util/ErrorEntryWrapper.java
+++ b/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/util/ErrorEntryWrapper.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.siddhi.error.handler.core.util;
 
 import io.siddhi.core.util.error.handler.model.ErrorEntry;
+import io.siddhi.core.util.error.handler.util.ErroneousEventType;
 import io.siddhi.core.util.error.handler.util.ErrorHandlerUtils;
 
 import java.io.IOException;
@@ -37,8 +38,18 @@ public class ErrorEntryWrapper {
         this.errorEntry = errorEntry;
         this.isPayloadModifiable = isPayloadModifiable;
         if (isPayloadModifiable) {
-            this.modifiablePayloadString = (String) ErrorHandlerUtils.getAsObject(errorEntry.getEventAsBytes());
+            this.modifiablePayloadString = constructModifiablePayloadString(errorEntry);
         }
+    }
+
+    private String constructModifiablePayloadString(ErrorEntry errorEntry) throws IOException, ClassNotFoundException {
+        if (errorEntry.getEventType() == ErroneousEventType.PAYLOAD_STRING) {
+            return (String) ErrorHandlerUtils.getAsObject(errorEntry.getEventAsBytes());
+        } else if (errorEntry.getEventType() == ErroneousEventType.REPLAYABLE_TABLE_RECORD) {
+            return errorEntry.getOriginalPayload();
+            // TODO: 2020-09-29 construct json
+        }
+        return null;
     }
 
     public ErrorEntry getErrorEntry() {

--- a/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/util/ErrorEntryWrapper.java
+++ b/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/util/ErrorEntryWrapper.java
@@ -47,7 +47,6 @@ public class ErrorEntryWrapper {
             return (String) ErrorHandlerUtils.getAsObject(errorEntry.getEventAsBytes());
         } else if (errorEntry.getEventType() == ErroneousEventType.REPLAYABLE_TABLE_RECORD) {
             return errorEntry.getOriginalPayload();
-            // TODO: 2020-09-29 construct json
         }
         return null;
     }

--- a/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/util/SiddhiErrorHandlerUtils.java
+++ b/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/util/SiddhiErrorHandlerUtils.java
@@ -18,7 +18,11 @@
 
 package org.wso2.carbon.siddhi.error.handler.core.util;
 
-import com.google.gson.*;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.google.gson.reflect.TypeToken;
 import io.siddhi.core.event.ComplexEvent;
 import io.siddhi.core.event.ComplexEventChunk;

--- a/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/util/SiddhiErrorHandlerUtils.java
+++ b/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/util/SiddhiErrorHandlerUtils.java
@@ -18,11 +18,12 @@
 
 package org.wso2.carbon.siddhi.error.handler.core.util;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
+import com.google.gson.*;
 import com.google.gson.reflect.TypeToken;
+import io.siddhi.core.event.ComplexEventChunk;
 import io.siddhi.core.util.error.handler.model.ErrorEntry;
+import io.siddhi.core.util.error.handler.model.ReplayableTableRecord;
+import io.siddhi.core.util.error.handler.util.ErroneousEventType;
 import io.siddhi.core.util.error.handler.util.ErrorHandlerUtils;
 import org.wso2.carbon.siddhi.error.handler.core.exception.SiddhiErrorHandlerException;
 
@@ -47,21 +48,41 @@ public class SiddhiErrorHandlerUtils {
             if (errorEntryWrapper.isPayloadModifiable()) {
                 ErrorEntry errorEntry = errorEntryWrapper.getErrorEntry();
                 String payloadString = errorEntryWrapper.getModifiablePayloadString();
+                byte[] eventAsBytes = new byte[0];
                 try {
+                    if (errorEntry.getEventType() == ErroneousEventType.PAYLOAD_STRING) {
+                        eventAsBytes = ErrorHandlerUtils.getAsBytes(payloadString);
+                    } else if (errorEntry.getEventType() == ErroneousEventType.REPLAYABLE_TABLE_RECORD) {
+                        ReplayableTableRecord deserializedTableRecord = (ReplayableTableRecord) ErrorHandlerUtils
+                                .getAsObject(errorEntry.getEventAsBytes());
+                        ComplexEventChunk eventChunk = modifyComplexEventChunk(deserializedTableRecord
+                                .getComplexEventChunk(), payloadString);
+                        deserializedTableRecord.setComplexEventChunk(eventChunk);
+                    } else {
+                        throw new SiddhiErrorHandlerException(String.format(
+                                "Unsuitable event type for error entry with id: %s.", errorEntry.getId()));
+                    }
                     errorEntries.add(new ErrorEntry(errorEntry.getId(), errorEntry.getTimestamp(),
-                        errorEntry.getSiddhiAppName(), errorEntry.getStreamName(),
-                        ErrorHandlerUtils.getAsBytes(payloadString),
-                        errorEntry.getCause(), errorEntry.getStackTrace(), errorEntry.getOriginalPayload(),
-                        errorEntry.getErrorOccurrence(), errorEntry.getEventType(), errorEntry.getErrorType()));
-                } catch (IOException e) {
+                            errorEntry.getSiddhiAppName(), errorEntry.getStreamName(), eventAsBytes,
+                            errorEntry.getCause(), errorEntry.getStackTrace(), errorEntry.getOriginalPayload(),
+                            errorEntry.getErrorOccurrence(), errorEntry.getEventType(), errorEntry.getErrorType()));
+                } catch (IOException | ClassNotFoundException e) {
                     throw new SiddhiErrorHandlerException(String.format(
-                        "Failed to get modifiable payload as bytes for error entry with id: %s.", errorEntry.getId()));
+                            "Failed to get modifiable payload as bytes for error entry with id: %s.", errorEntry.getId()));
                 }
             } else {
                 errorEntries.add(errorEntryWrapper.getErrorEntry());
             }
         }
         return errorEntries;
+    }
+
+    private static ComplexEventChunk modifyComplexEventChunk(ComplexEventChunk eventChunk, String modifiedPayloadString) {
+        JsonObject modifiedJson = new JsonParser().parse(modifiedPayloadString).getAsJsonObject();
+        for (JsonElement record: modifiedJson.get("records").getAsJsonArray()) {
+
+        }
+        return eventChunk;
     }
 
     public static long getRetentionStartTimestamp(long currentTimestamp, int retentionDays) {

--- a/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/util/SiddhiErrorHandlerUtils.java
+++ b/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/util/SiddhiErrorHandlerUtils.java
@@ -80,6 +80,16 @@ public class SiddhiErrorHandlerUtils {
         return errorEntries;
     }
 
+    public static boolean isPayloadEditable(ErrorEntry errorEntry) {
+        if (errorEntry.getEventType() == ErroneousEventType.PAYLOAD_STRING) {
+            return true;
+        } else if(errorEntry.getEventType() == ErroneousEventType.REPLAYABLE_TABLE_RECORD) {
+            return new JsonParser().parse(errorEntry.getOriginalPayload()).getAsJsonObject().get("isEditable")
+                    .getAsString().equalsIgnoreCase("true");
+        }
+        return false;
+    }
+
     private static ComplexEventChunk modifyComplexEventChunk(ComplexEventChunk eventChunk,
                                                              String modifiedPayloadString, Gson gson,
                                                              ErrorEntry errorEntry) throws SiddhiErrorHandlerException {

--- a/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/util/SiddhiErrorHandlerUtils.java
+++ b/components/org.wso2.carbon.siddhi.error.handler.core/src/main/java/org/wso2/carbon/siddhi/error/handler/core/util/SiddhiErrorHandlerUtils.java
@@ -38,12 +38,13 @@ import java.util.List;
  * Contains utility methods related to Siddhi Error Handler.
  */
 public class SiddhiErrorHandlerUtils {
+    private static Gson gson = new GsonBuilder().disableHtmlEscaping().create();
+    private static JsonParser jsonParser = new JsonParser();
 
     private SiddhiErrorHandlerUtils() {}
 
     public static List<ErrorEntry> convertToList(JsonArray errorEntryWrappersBody) throws SiddhiErrorHandlerException {
         List<ErrorEntry> errorEntries = new ArrayList<>();
-        Gson gson = new GsonBuilder().disableHtmlEscaping().create(); // TODO: 2020-10-02 make class level static
         Type mapType = new TypeToken<List<ErrorEntryWrapper>>() {}.getType();
         List<ErrorEntryWrapper> errorEntryWrappers = gson.fromJson(errorEntryWrappersBody, mapType);
         for (ErrorEntryWrapper errorEntryWrapper : errorEntryWrappers) {
@@ -84,7 +85,7 @@ public class SiddhiErrorHandlerUtils {
         if (errorEntry.getEventType() == ErroneousEventType.PAYLOAD_STRING) {
             return true;
         } else if(errorEntry.getEventType() == ErroneousEventType.REPLAYABLE_TABLE_RECORD) {
-            return new JsonParser().parse(errorEntry.getOriginalPayload()).getAsJsonObject().get("isEditable")
+            return jsonParser.parse(errorEntry.getOriginalPayload()).getAsJsonObject().get("isEditable")
                     .getAsString().equalsIgnoreCase("true");
         }
         return false;

--- a/components/org.wso2.carbon.streaming.integrator.core/src/main/java/org/wso2/carbon/streaming/integrator/core/siddhi/error/handler/DBErrorStore.java
+++ b/components/org.wso2.carbon.streaming.integrator.core/src/main/java/org/wso2/carbon/streaming/integrator/core/siddhi/error/handler/DBErrorStore.java
@@ -171,6 +171,7 @@ public class DBErrorStore extends ErrorStore {
             stmt.setLong(1, timestamp);
             stmt.setString(2,siddhiAppName);
             stmt.setString(3,streamName);
+            cause = (cause.length() > 1000) ? cause.substring(0,997) + "..." : cause ;
             stmt.setString(5,cause);
             stmt.setString(8,errorOccurrence);
             stmt.setString(9,eventType);

--- a/components/org.wso2.carbon.streaming.integrator.core/src/main/resources/error-store-queries.yaml
+++ b/components/org.wso2.carbon.streaming.integrator.core/src/main/resources/error-store-queries.yaml
@@ -21,7 +21,7 @@ queries:
   -
    mappings:
      IS_TABLE_EXIST: SELECT * FROM {{TABLE_NAME}} limit 1
-     CREATE_TABLE: CREATE TABLE {{TABLE_NAME}} (id INT NOT NULL AUTO_INCREMENT, timestamp BIGINT, siddhiAppName VARCHAR(100), streamName VARCHAR(100), event LONGBLOB, cause VARCHAR(255), stackTrace LONGBLOB, originalPayload LONGBLOB, errorOccurrence VARCHAR(50), eventType VARCHAR(50), errorType VARCHAR(50), PRIMARY KEY (id))
+     CREATE_TABLE: CREATE TABLE {{TABLE_NAME}} (id INT NOT NULL AUTO_INCREMENT, timestamp BIGINT, siddhiAppName VARCHAR(100), streamName VARCHAR(100), event LONGBLOB, cause VARCHAR(1000), stackTrace LONGBLOB, originalPayload LONGBLOB, errorOccurrence VARCHAR(50), eventType VARCHAR(50), errorType VARCHAR(50), PRIMARY KEY (id))
      INSERT: INSERT INTO {{TABLE_NAME}} (timestamp, siddhiAppName, streamName, event, cause, stackTrace, originalPayload, errorOccurrence, eventType, errorType) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      SELECT: SELECT * FROM {{TABLE_NAME}} WHERE siddhiAppName = ?
      SELECT_SINGLE: SELECT * FROM {{TABLE_NAME}} WHERE id = ?
@@ -40,7 +40,7 @@ queries:
   -
    mappings:
      IS_TABLE_EXIST: SELECT * FROM {{TABLE_NAME}} limit 1
-     CREATE_TABLE: CREATE TABLE {{TABLE_NAME}} (id INT NOT NULL AUTO_INCREMENT, timestamp BIGINT, siddhiAppName VARCHAR (100), streamName VARCHAR(100), event LONGBLOB, cause VARCHAR(255), stackTrace LONGBLOB, originalPayload LONGBLOB, errorOccurrence VARCHAR(50), eventType VARCHAR(50), errorType VARCHAR(50), PRIMARY KEY (id))
+     CREATE_TABLE: CREATE TABLE {{TABLE_NAME}} (id INT NOT NULL AUTO_INCREMENT, timestamp BIGINT, siddhiAppName VARCHAR (100), streamName VARCHAR(100), event LONGBLOB, cause VARCHAR(1000), stackTrace LONGBLOB, originalPayload LONGBLOB, errorOccurrence VARCHAR(50), eventType VARCHAR(50), errorType VARCHAR(50), PRIMARY KEY (id))
      INSERT: INSERT INTO {{TABLE_NAME}} (timestamp, siddhiAppName, streamName, event, cause, stackTrace, originalPayload, errorOccurrence, eventType, errorType) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      SELECT: SELECT * FROM {{TABLE_NAME}} WHERE siddhiAppName = ?
      SELECT_SINGLE: SELECT * FROM {{TABLE_NAME}} WHERE id = ?
@@ -59,7 +59,7 @@ queries:
   -
    mappings:
      IS_TABLE_EXIST: SELECT 1 FROM {{TABLE_NAME}} LIMIT 1
-     CREATE_TABLE: CREATE TABLE {{TABLE_NAME}} (id serial primary key, timestamp bigint, siddhiAppName VARCHAR(100), streamName VARCHAR(100), event bigint, cause VARCHAR(255), stackTrace bigint, originalPayload bigint, errorOccurrence VARCHAR(50), eventType VARCHAR(50), errorType VARCHAR(50))
+     CREATE_TABLE: CREATE TABLE {{TABLE_NAME}} (id serial primary key, timestamp bigint, siddhiAppName VARCHAR(100), streamName VARCHAR(100), event bigint, cause VARCHAR(1000), stackTrace bigint, originalPayload bigint, errorOccurrence VARCHAR(50), eventType VARCHAR(50), errorType VARCHAR(50))
      INSERT: INSERT INTO {{TABLE_NAME}} (timestamp, siddhiAppName, streamName, event, cause, stackTrace, originalPayload, errorOccurrence, eventType, errorType) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      SELECT: SELECT * FROM {{TABLE_NAME}} WHERE siddhiAppName = ?
      SELECT_SINGLE: SELECT * FROM {{TABLE_NAME}} WHERE id = ?
@@ -78,7 +78,7 @@ queries:
   -
    mappings:
      IS_TABLE_EXIST: SELECT TOP 1 1 FROM {{TABLE_NAME}}
-     CREATE_TABLE: CREATE TABLE {{TABLE_NAME}} (id INT NOT NULL IDENTITY(1,1) PRIMARY KEY, timestamp bigint, siddhiAppName VARCHAR(100), streamName VARCHAR(100), event VARBINARY(max), cause VARCHAR(255), stackTrace VARBINARY(max), originalPayload VARBINARY(max), errorOccurrence VARCHAR(50), eventType VARCHAR(50), errorType VARCHAR(50))
+     CREATE_TABLE: CREATE TABLE {{TABLE_NAME}} (id INT NOT NULL IDENTITY(1,1) PRIMARY KEY, timestamp bigint, siddhiAppName VARCHAR(100), streamName VARCHAR(100), event VARBINARY(max), cause VARCHAR(1000), stackTrace VARBINARY(max), originalPayload VARBINARY(max), errorOccurrence VARCHAR(50), eventType VARCHAR(50), errorType VARCHAR(50))
      INSERT: INSERT INTO {{TABLE_NAME}} (timestamp, siddhiAppName, streamName, event, cause, stackTrace, originalPayload, errorOccurrence, eventType, errorType) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      SELECT: SELECT * FROM {{TABLE_NAME}} WHERE siddhiAppName = ?
      SELECT_SINGLE: SELECT * FROM {{TABLE_NAME}} WHERE id = ?
@@ -97,7 +97,7 @@ queries:
   -
    mappings:
      IS_TABLE_EXIST: SELECT 1 FROM {{TABLE_NAME}} WHERE rownum=1
-     CREATE_TABLE: CREATE TABLE {{TABLE_NAME}} (id NUMBER(10) NOT NULL, timestamp LONG, siddhiAppName VARCHAR(100), streamName VARCHAR(100), event BLOB, cause VARCHAR(255), stackTrace BLOB, originalPayload BLOB, errorOccurrence VARCHAR(50), eventType VARCHAR(50), errorType VARCHAR(50)); ALTER TABLE {{TABLE_NAME}} ADD (CONSTRAINT err_store_pk PRIMARY KEY (id)); CREATE SEQUENCE err_store_seq START WITH 1;
+     CREATE_TABLE: CREATE TABLE {{TABLE_NAME}} (id NUMBER(10) NOT NULL, timestamp LONG, siddhiAppName VARCHAR(100), streamName VARCHAR(100), event BLOB, cause VARCHAR(1000), stackTrace BLOB, originalPayload BLOB, errorOccurrence VARCHAR(50), eventType VARCHAR(50), errorType VARCHAR(50)); ALTER TABLE {{TABLE_NAME}} ADD (CONSTRAINT err_store_pk PRIMARY KEY (id)); CREATE SEQUENCE err_store_seq START WITH 1;
      INSERT: INSERT INTO {{TABLE_NAME}} (timestamp, siddhiAppName, streamName, event, cause, stackTrace, originalPayload, errorOccurrence, eventType, errorType) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      SELECT: SELECT * FROM {{TABLE_NAME}} WHERE siddhiAppName = ?
      SELECT_SINGLE: SELECT * FROM {{TABLE_NAME}} WHERE id = ?
@@ -116,7 +116,7 @@ queries:
   -
    mappings:
      IS_TABLE_EXIST: SELECT * FROM {{TABLE_NAME}} FETCH FIRST 1 ROWS ONLY
-     CREATE_TABLE: CREATE TABLE {{TABLE_NAME}} (id INTEGER GENERATED BY DEFAULT AS IDENTITY NOT NULL, timestamp BIGINT, siddhiAppName VARCHAR(100), streamName VARCHAR(100), event BLOB(2000000000), cause VARCHAR(255), stackTrace BLOB(2000000000), originalPayload BLOB(2000000000), errorOccurrence VARCHAR(50), eventType VARCHAR(50), errorType VARCHAR(50), PRIMARY KEY (id))
+     CREATE_TABLE: CREATE TABLE {{TABLE_NAME}} (id INTEGER GENERATED BY DEFAULT AS IDENTITY NOT NULL, timestamp BIGINT, siddhiAppName VARCHAR(100), streamName VARCHAR(100), event BLOB(2000000000), cause VARCHAR(1000), stackTrace BLOB(2000000000), originalPayload BLOB(2000000000), errorOccurrence VARCHAR(50), eventType VARCHAR(50), errorType VARCHAR(50), PRIMARY KEY (id))
      INSERT: INSERT INTO {{TABLE_NAME}} (timestamp, siddhiAppName, streamName, event, cause, stackTrace, originalPayload, errorOccurrence, eventType, errorType) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      SELECT: SELECT * FROM {{TABLE_NAME}} WHERE siddhiAppName = ?
      SELECT_SINGLE: SELECT * FROM {{TABLE_NAME}} WHERE id = ?


### PR DESCRIPTION
## Purpose
This PR will enable error replay for database connection errors. Errors occurred during ADD, DELETE, UPDATE, ADDORUPDATE operations can be replayed from the error store explorer as follows

<img width="999" alt="Screenshot 2020-09-22 at 14 58 52" src="https://user-images.githubusercontent.com/24491207/93865862-873ebc00-fce4-11ea-9f4a-4da9b9ac2eb5.png">


## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
> https://github.com/wso2/carbon-analytics/pull/1868

## Test environment
> MacOS Catalina 10.15.6, JDK 1.8.0_201
