### PR TITLE
Add support to get datasource related config from FileConfigManager

### DIFF
--- a/components/org.wso2.carbon.streaming.integrator.common/src/main/java/org/wso2/carbon/streaming/integrator/common/utils/SPConstants.java
+++ b/components/org.wso2.carbon.streaming.integrator.common/src/main/java/org/wso2/carbon/streaming/integrator/common/utils/SPConstants.java
@@ -29,6 +29,9 @@ public class SPConstants {
     public static final String EXTENSIONS_NAMESPACE = "extensions";
     public static final String REFS_NAMESPACE = "refs";
 
+    public static final String DATASOURCES_ROOT_ELEMENT = "wso2.datasources";
+    public static final String DATASOURCE_NAMESPACE = "dataSources";
+
     private SPConstants() {
     }
 }


### PR DESCRIPTION
## Purpose
The persisted aggregation of siddhi has a requirement to read the datasource configuration which is there in deployment.yaml. So this improvement will support returning ConfigReader which contains the given datasource properties.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
https://github.com/siddhi-io/siddhi/pull/1702/files