### PR TITLE
Set editor console line length to a lower value

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/js/output-console/service-console-manager.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/js/output-console/service-console-manager.js
@@ -45,7 +45,8 @@ define(['require', 'log', 'jquery', 'lodash', 'console','workspace','toolEditor'
                 parentDiv.scrollTop = parentDiv.scrollHeight;
                 var childLength = this.$el.children().size();
                 //console.log("Count="+);
-                if (childLength > 2500) {
+                if (childLength > 500) {
+                    $(this.$el).children().first().remove();
                     $(this.$el).children().first().remove();
                 }
             },


### PR DESCRIPTION
## Purpose
Lower the line count to decide on deleting to cater scenarios where high line count leads to freeze the editor

## Goals
Improve the performance

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
