### PR TITLE
Fix design view store annotation values not showing properly

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/js/design-view/form-builder/forms/table-form.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/js/design-view/form-builder/forms/table-form.js
@@ -73,7 +73,7 @@ define(['log', 'jquery', 'lodash', 'attribute', 'storeAnnotation', 'handlebar', 
             } else {
                 $('#tableName').val(name);
                 var attributeList = tableObject.getAttributeList();
-                self.formUtils.renderAttributeTemplate(attributeList)
+                self.formUtils.renderAttributeTemplate(attributeList, propertyDiv.find('#define-attribute'))
                 self.formUtils.selectTypesOfSavedAttributes(attributeList);
             }
 


### PR DESCRIPTION
## Purpose
Currently only the name of the store is shown in the design view when setting button is clicked

## Goals
Show the properties properly

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

