### PR TITLE
Fix an issue when deleting siddhi app in SI tooling

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/commons/js/dialog/delete-confirm-dialog.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/commons/js/dialog/delete-confirm-dialog.js
@@ -298,10 +298,10 @@ define(['require', 'lodash', 'jquery', 'log', 'backbone', 'file_browser',
                                     app.tabController.removeTab(fileTab, undefined, true);
                                     deleteAppModal.modal('hide');
                                     log.debug('file deleted successfully');
-                                    callback(true);
                                     app.commandManager.dispatch("open-folder", data.path);
                                     app.eventSimulator.getFeedSimulator().updateFeedCreationButtonAndNotification();
                                     app.commandManager.dispatch("remove-siddhi-apps-on-delete", trimmedSiddhiAppName);
+                                    callback(true);
                                     alertSuccess();
                                 } else {
                                     callback(false);

--- a/components/org.wso2.carbon.streaming.integrator.core/src/main/java/org/wso2/carbon/streaming/integrator/core/internal/asyncapi/util/Utils.java
+++ b/components/org.wso2.carbon.streaming.integrator.core/src/main/java/org/wso2/carbon/streaming/integrator/core/internal/asyncapi/util/Utils.java
@@ -32,6 +32,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -116,12 +117,17 @@ public class Utils {
             fileList.add(generateZipEntry(node.getAbsoluteFile().toString(), sourceFileUri));
         }
         if (node.isDirectory()) {
-            File[] subNote = node.listFiles()[0].listFiles();
-            if (subNote != null) {
-                for (File file : subNote) {
-                    generateFileList(sourceFileUri, file, fileList);
+            File[] subNodes = node.listFiles();
+            if (subNodes != null && subNodes.length > 0)
+                for (File subNode : subNodes) {
+                    File[] files = subNode.listFiles();
+                    if (files != null) {
+                        for (File file : files) {
+                            generateFileList(sourceFileUri, file, fileList);
+                        }
+                    }
                 }
-            }
+
         }
     }
 


### PR DESCRIPTION
close https://github.com/wso2/streaming-integrator-tooling/issues/116

## Purpose
 This will fix an issue observed in SI tooling runtime, when deleting a siddhi app without loading it to the editor canvas.


## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
