### PR TITLE
Add confirmation when switching back to source view

### DIFF
--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/commons/js/dialog/confirm-switch-to-code-dialog.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/commons/js/dialog/confirm-switch-to-code-dialog.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+define(['jquery', './modal-dialog'], function ($, ModalDialog) {
+    var ConfirmSwitchToCode = function (options) {
+        this._options = options;
+        this._$container = $(_.get(options, 'container', 'body'));
+        this._initialized = false;
+    };
+    ConfirmSwitchToCode.prototype = Object.create(ModalDialog.prototype);
+    ConfirmSwitchToCode.prototype.constructor = ConfirmSwitchToCode;
+    ConfirmSwitchToCode.prototype.init = function () {
+        if (this._initialized) {
+            return;
+        }
+        var confirm = $("<button type='button' class='btn btn-default" +
+            " confirm-switch-to-code-dialog-btn'>Confirm</button>");
+        var cancelBtn = $("<button type='button' class='btn btn-default'" +
+            " data-dismiss='modal'>Cancel</button>");
+        this._confirm = confirm;
+        this.getFooter().empty();
+        this.getFooter().append(confirm, cancelBtn);
+        this._initialized = true;
+        this._$modalContainer.addClass("confirm-switch-to-code-dialog");
+    }
+
+    ConfirmSwitchToCode.prototype.askConfirmation = function (options) {
+        var self = this;
+        this.init();
+        this.setTitle("Confirm to switch to code view");
+        var body = this.getBody();
+        body.empty();
+        body.append($("<p><br>Async API spec contains changes, do you want to save them ? <br>Your changes will " +
+            "be lost if you switch to source view without saving.</p>"))
+        this._confirm.unbind('click');
+        this._confirm.click(function (e) {
+            options.self.sourceContainer.show();
+            options.self.asyncAPIViewContainer.hide();
+            $(options.self.toggleControlsContainer[0]).find('.toggle-view-button').removeClass('hide-div');
+            $(options.self.toggleControlsContainer[0]).find('.wizard-view-button').removeClass('hide-div');
+            var asyncAPIAddUpdateButton = $(options.self.toggleControlsContainer[0]).find('.async-api-add-update-button');
+            asyncAPIAddUpdateButton.addClass('hide-div');
+            var codeViewButton = $(options.self.toggleControlsContainer[0]).find('#asyncbtn-to-code-view');
+            codeViewButton.addClass('hide-div');
+            var asyncAPIViewButton = $(options.self.toggleControlsContainer[0]).find('#asyncbtn-asyncapi-view');
+            asyncAPIViewButton.removeClass('hide-div');
+            self.hide();
+        });
+        this.show();
+    }
+    return ConfirmSwitchToCode;
+});

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/commons/js/dialog/module.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/commons/js/dialog/module.js
@@ -4,11 +4,11 @@
 define(['./save-to-file-dialog', './replace-confirm-dialog', './open-file-dialog','./extension-install-dialog', './error-handler-dialog', './close-confirm-dialog',
         './import-file-dialog', './export-file-dialog', './settings-dialog', './close-all-confirm-dialog',
         './delete-confirm-dialog', './open-sample-file-dialog', './export-dialog', './sample-event-dialog',
-        './query-store-dialog', './deploy-file-dialog', './export-dialog', './generate-stream-dialog'],
+        './query-store-dialog', './deploy-file-dialog', './export-dialog', './generate-stream-dialog', './confirm-switch-to-code-dialog'],
     function (SaveToFileDialog, ReplaceConfirmDialog, OpenFileDialog, ExtensionInstallDialog, ErrorHandlerDialog, CloseConfirmDialog, ImportFileDialog,
               ExportFileDialog, SettingsDialog, CloseAllConfirmDialog, DeleteConfirmDialog, OpenSampleFileDialog,
               DockerExportDialog, SampleEventDialog, QueryStoreDialog, DeployFileDialog, ExportDialog,
-              GenerateStreamDialog) {
+              GenerateStreamDialog, ConfirmSwitchToCode) {
         return {
             save_to_file_dialog: SaveToFileDialog,
             open_file_dialog: OpenFileDialog,
@@ -26,6 +26,7 @@ define(['./save-to-file-dialog', './replace-confirm-dialog', './open-file-dialog
             query_store_api: QueryStoreDialog,
             deploy_file_dialog: DeployFileDialog,
             export_dialog: ExportDialog,
-            generate_stream_dialog: GenerateStreamDialog
+            generate_stream_dialog: GenerateStreamDialog,
+            confirm_switch_to_code: ConfirmSwitchToCode
         };
     });

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/commons/js/workspace/workspace.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/commons/js/workspace/workspace.js
@@ -715,6 +715,14 @@ define(['ace/ace', 'jquery', 'lodash', 'log', 'dialogs', './service-client', 'we
                 this._closeFileConfirmDialog.askConfirmation(options);
             };
 
+            this.confirmSwitchToCodeDialog = function (options) {
+                if (_.isNil(this._confirmSwitchToCodeDialog)) {
+                    this._confirmSwitchToCodeDialog = new Dialogs.confirm_switch_to_code();
+                    this._confirmSwitchToCodeDialog.render();
+                }
+                this._confirmSwitchToCodeDialog.askConfirmation(options);
+            };
+
             this.openCloseAllFileConfirmDialog = function (options) {
                 if (_.isNil(this._closeAllFileConfirmDialog)) {
                     this._closeAllFileConfirmDialog = new Dialogs.CloseAllConfirmDialog();
@@ -811,6 +819,8 @@ define(['ace/ace', 'jquery', 'lodash', 'log', 'dialogs', './service-client', 'we
                 this);
 
             app.commandManager.registerHandler('open-close-file-confirm-dialog', this.openCloseFileConfirmDialog, this);
+
+            app.commandManager.registerHandler('confirm-switch-to-code-dialog', this.confirmSwitchToCodeDialog, this);
 
             app.commandManager.registerHandler('sample-event', this.handleSampleEvent);
 

--- a/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/js/async-api/async-api-generator.js
+++ b/components/org.wso2.carbon.siddhi.editor.core/src/main/resources/web/editor/js/async-api/async-api-generator.js
@@ -47,7 +47,7 @@ define(['require', 'jquery', 'lodash', 'log', 'smart_wizard', 'app/source-editor
 
             var asyncAPIYAMLViewDynamicId = "async-api-view-yaml-container-id-" + $(this.__$parent_el_container).attr('id');
             $(this.asyncAPIYamlContainer[0]).attr('id', asyncAPIYAMLViewDynamicId);
-
+            self.inGenerator = true;
             self.__options = initOpts;
             self.__app = initOpts.application;
             self.__editorInstance = initOpts.editorInstance;
@@ -217,18 +217,20 @@ define(['require', 'jquery', 'lodash', 'log', 'smart_wizard', 'app/source-editor
 
                 $('.toggle-controls-container #asyncbtn-to-code-view').on('click', function (e) {
                     e.preventDefault();
-                    self.sourceContainer.show();
-                    self.__app.workspaceManager.updateMenuItems();
-                    self.asyncAPIViewContainer.hide();
-                    $(self.toggleControlsContainer[0]).find('.toggle-view-button').removeClass('hide-div');
-                    $(self.toggleControlsContainer[0]).find('.wizard-view-button').removeClass('hide-div');
-                    var asyncAPIAddUpdateButton = $(self.toggleControlsContainer[0])
-                        .find('.async-api-add-update-button');
-                    asyncAPIAddUpdateButton.addClass('hide-div');
-                    var codeViewButton = $(self.toggleControlsContainer[0]).find('#asyncbtn-to-code-view');
-                    codeViewButton.addClass('hide-div');
-                    var AsyncAPIViewButton = $(self.toggleControlsContainer[0]).find('#asyncbtn-asyncapi-view');
-                    AsyncAPIViewButton.removeClass('hide-div');
+                    if (self.inGenerator) {
+                        self.sourceContainer.show();
+                        self.__app.workspaceManager.updateMenuItems();
+                        self.asyncAPIViewContainer.hide();
+                        $(self.toggleControlsContainer[0]).find('.toggle-view-button').removeClass('hide-div');
+                        $(self.toggleControlsContainer[0]).find('.wizard-view-button').removeClass('hide-div');
+                        var asyncAPIAddUpdateButton = $(self.toggleControlsContainer[0])
+                            .find('.async-api-add-update-button');
+                        asyncAPIAddUpdateButton.addClass('hide-div');
+                        var codeViewButton = $(self.toggleControlsContainer[0]).find('#asyncbtn-to-code-view');
+                        codeViewButton.addClass('hide-div');
+                        var AsyncAPIViewButton = $(self.toggleControlsContainer[0]).find('#asyncbtn-asyncapi-view');
+                        AsyncAPIViewButton.removeClass('hide-div');
+                    }
                 });
             }
         };
@@ -459,7 +461,6 @@ define(['require', 'jquery', 'lodash', 'log', 'smart_wizard', 'app/source-editor
                     }
                 }
             }
-            console.log(asyncAPIJSON.toString());
             yaml.safeLoad(JSON.stringify(asyncAPIJSON));
             var options = _.cloneDeep(self.__options)
             options.asyncAPIDefYaml = yaml.safeDump(yaml.safeLoad(JSON.stringify(asyncAPIJSON)));
@@ -467,6 +468,7 @@ define(['require', 'jquery', 'lodash', 'log', 'smart_wizard', 'app/source-editor
             options.fromGenerator = true;
             options.editorInstance = self.__editorInstance;
             options.parentEl = this.__$parent_el_container;
+            self.inGenerator = false;
             this.asyncAPI = new AsyncAPI(options);
         }
 


### PR DESCRIPTION
## Purpose
> $subject

## Goals
> When theres a change in the Async API yaml, it will require a confirmation from the user to switch back to source code. If not, the changes wont reflect in the Siddhi app's @AsyncAPI annotation.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes