### PR TITLE
Add Response interceptor to add custom headers and Upgrade msf4j and transport-http versions

### DIFF
--- a/components/org.wso2.carbon.analytics.msf4j.interceptor.common/pom.xml
+++ b/components/org.wso2.carbon.analytics.msf4j.interceptor.common/pom.xml
@@ -79,6 +79,7 @@
             org.wso2.msf4j.*;version="${msf4j.import.version.range}",
             javax.ws.rs.*;version="${javax.ws.rs.version.range}",
             org.slf4j.*;version="${slf4j.version.range}",
+            org.wso2.transport.http.netty.*,
         </import.package>
         <private.package>
             org.wso2.carbon.analytics.msf4j.interceptor.common.internal,

--- a/components/org.wso2.carbon.analytics.msf4j.interceptor.common/src/main/java/org/wso2/carbon/analytics/msf4j/interceptor/common/AnalyticsResponseInterceptor.java
+++ b/components/org.wso2.carbon.analytics.msf4j.interceptor.common/src/main/java/org/wso2/carbon/analytics/msf4j/interceptor/common/AnalyticsResponseInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.analytics.msf4j.interceptor.common/src/main/java/org/wso2/carbon/analytics/msf4j/interceptor/common/AnalyticsResponseInterceptor.java
+++ b/components/org.wso2.carbon.analytics.msf4j.interceptor.common/src/main/java/org/wso2/carbon/analytics/msf4j/interceptor/common/AnalyticsResponseInterceptor.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.analytics.msf4j.interceptor.common;
+
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.wso2.carbon.analytics.msf4j.interceptor.common.internal.DataHolder;
+import org.wso2.carbon.analytics.msf4j.interceptor.common.util.InterceptorConstants;
+import org.wso2.msf4j.Request;
+import org.wso2.msf4j.Response;
+import org.wso2.msf4j.interceptor.ResponseInterceptor;
+import org.wso2.transport.http.netty.contract.Constants;
+import org.wso2.transport.http.netty.contract.config.ConfigurationBuilder;
+import org.wso2.transport.http.netty.contract.config.TransportsConfiguration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Interceptor to check authentication into si.
+ */
+@Component(
+        service = AnalyticsResponseInterceptor.class,
+        immediate = true
+)
+public class AnalyticsResponseInterceptor implements ResponseInterceptor {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AnalyticsResponseInterceptor.class);
+    private Map<String, String> headerMap = null;
+    private static final String TRANSPORT_ROOT_CONFIG_ELEMENT = "wso2.transport.http";
+
+    @Override
+    public boolean interceptResponse(Request request, Response response) throws Exception {
+        if (headerMap == null) {
+            headerMap = new HashMap<>();
+            TransportsConfiguration transportsConfiguration =
+                    DataHolder.getInstance().getConfigProvider().getConfigurationObject(TRANSPORT_ROOT_CONFIG_ELEMENT,
+                    TransportsConfiguration.class);
+            transportsConfiguration.getListenerConfigurations().forEach(listenerConfiguration -> {
+                if (listenerConfiguration.getResponseHeaderList() != null) {
+                    String[] responseHeaders =  listenerConfiguration.getResponseHeaderList().split(",");
+                    if (responseHeaders.length > 0) {
+                        for (String header : responseHeaders) {
+                            String[] headerKeyValue = header.split(":");
+                            headerMap.put(headerKeyValue[0].trim(), headerKeyValue[1].trim());
+                        }
+                    }
+                }
+                if (listenerConfiguration.getStrictTransportSecurityHeader() != null) {
+                    headerMap.put(InterceptorConstants.HTTP_STRICT_TRANSPORT_SECURITY_HEADER,
+                            listenerConfiguration.getStrictTransportSecurityHeader().trim());
+                    if (!Constants.HTTPS_SCHEME.equalsIgnoreCase(listenerConfiguration.getScheme())) {
+                        LOGGER.warn("HTTP Strict Transport Security header must be used with https scheme");
+                    }
+                }
+            });
+        }
+        if (headerMap != null) {
+            response.setHeaders(headerMap);
+        }
+        return true;
+    }
+}
+

--- a/components/org.wso2.carbon.analytics.msf4j.interceptor.common/src/main/java/org/wso2/carbon/analytics/msf4j/interceptor/common/util/InterceptorConstants.java
+++ b/components/org.wso2.carbon.analytics.msf4j.interceptor.common/src/main/java/org/wso2/carbon/analytics/msf4j/interceptor/common/util/InterceptorConstants.java
@@ -26,6 +26,8 @@ public class InterceptorConstants {
     public static final String BEARER_PREFIX = "Bearer";
     public static final String BASIC_PREFIX = "Basic";
 
+    public static final String HTTP_STRICT_TRANSPORT_SECURITY_HEADER = "Strict-Transport-Security";
+
     private InterceptorConstants() {
 
     }

--- a/components/org.wso2.carbon.business.rules.core/src/gen/java/org/wso2/carbon/business/rules/core/api/BusinessRulesApi.java
+++ b/components/org.wso2.carbon.business.rules.core/src/gen/java/org/wso2/carbon/business/rules/core/api/BusinessRulesApi.java
@@ -19,6 +19,7 @@ package org.wso2.carbon.business.rules.core.api;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.wso2.carbon.analytics.msf4j.interceptor.common.AnalyticsResponseInterceptor;
 import org.wso2.carbon.analytics.msf4j.interceptor.common.AuthenticationInterceptor;
 import org.wso2.carbon.business.rules.core.api.factories.BusinessRulesApiServiceFactory;
 import org.wso2.msf4j.Microservice;
@@ -40,8 +41,10 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
 import io.swagger.annotations.ApiParam;
+import org.wso2.msf4j.interceptor.annotation.ResponseInterceptor;
 
 @RequestInterceptor(AuthenticationInterceptor.class)
+@ResponseInterceptor(AnalyticsResponseInterceptor.class)
 @io.swagger.annotations.Api(description = "the business-rules API")
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaMSF4JServerCodegen",
         date = "2017-10-11T05:39:16.839Z")

--- a/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/internal/DataProviderAPI.java
+++ b/components/org.wso2.carbon.data.provider/src/main/java/org/wso2/carbon/data/provider/internal/DataProviderAPI.java
@@ -22,11 +22,13 @@ import com.google.gson.JsonElement;
 import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.wso2.carbon.analytics.msf4j.interceptor.common.AnalyticsResponseInterceptor;
 import org.wso2.carbon.analytics.msf4j.interceptor.common.AuthenticationInterceptor;
 import org.wso2.carbon.data.provider.DataProvider;
 import org.wso2.carbon.data.provider.exception.DataProviderException;
 import org.wso2.msf4j.Microservice;
 import org.wso2.msf4j.interceptor.annotation.RequestInterceptor;
+import org.wso2.msf4j.interceptor.annotation.ResponseInterceptor;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -43,6 +45,7 @@ import static org.wso2.carbon.data.provider.utils.DataProviderValueHolder.getDat
  * Data provider api service component.
  */
 @RequestInterceptor(AuthenticationInterceptor.class)
+@ResponseInterceptor(AnalyticsResponseInterceptor.class)
 public class DataProviderAPI implements Microservice {
 
     public static final String API_CONTEXT_PATH = "/apis/data-provider";

--- a/components/org.wso2.carbon.event.simulator.core/src/gen/java/org/wso2/carbon/event/simulator/core/api/DatabaseApi.java
+++ b/components/org.wso2.carbon.event.simulator.core/src/gen/java/org/wso2/carbon/event/simulator/core/api/DatabaseApi.java
@@ -6,6 +6,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.wso2.carbon.analytics.msf4j.interceptor.common.AnalyticsResponseInterceptor;
 import org.wso2.carbon.analytics.msf4j.interceptor.common.AuthenticationInterceptor;
 import org.wso2.carbon.analytics.msf4j.interceptor.common.util.InterceptorConstants;
 import org.wso2.carbon.event.simulator.core.factories.DatabaseApiServiceFactory;
@@ -15,6 +16,7 @@ import org.wso2.carbon.event.simulator.core.model.*;
 import org.wso2.msf4j.Microservice;
 import org.wso2.msf4j.Request;
 import org.wso2.msf4j.interceptor.annotation.RequestInterceptor;
+import org.wso2.msf4j.interceptor.annotation.ResponseInterceptor;
 
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
@@ -27,6 +29,7 @@ import javax.ws.rs.*;
 )
 @Path("/simulation/connectToDatabase")
 @RequestInterceptor(AuthenticationInterceptor.class)
+@ResponseInterceptor(AnalyticsResponseInterceptor.class)
 @io.swagger.annotations.Api(description = "the connectToDatabase API")
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaMSF4JServerCodegen",
         date = "2017-07-20T09:30:14.336Z")

--- a/components/org.wso2.carbon.event.simulator.core/src/gen/java/org/wso2/carbon/event/simulator/core/api/FeedApi.java
+++ b/components/org.wso2.carbon.event.simulator.core/src/gen/java/org/wso2/carbon/event/simulator/core/api/FeedApi.java
@@ -6,6 +6,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.wso2.carbon.analytics.msf4j.interceptor.common.AnalyticsResponseInterceptor;
 import org.wso2.carbon.analytics.msf4j.interceptor.common.AuthenticationInterceptor;
 import org.wso2.carbon.event.simulator.core.exception.FileOperationsException;
 import org.wso2.carbon.event.simulator.core.factories.FeedApiServiceFactory;
@@ -13,6 +14,7 @@ import org.wso2.carbon.event.simulator.core.model.InlineResponse200;
 import org.wso2.msf4j.Microservice;
 import org.wso2.msf4j.Request;
 import org.wso2.msf4j.interceptor.annotation.RequestInterceptor;
+import org.wso2.msf4j.interceptor.annotation.ResponseInterceptor;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -34,6 +36,7 @@ import javax.ws.rs.core.Response;
 )
 @Path("/simulation/feed")
 @RequestInterceptor(AuthenticationInterceptor.class)
+@ResponseInterceptor(AnalyticsResponseInterceptor.class)
 @io.swagger.annotations.Api(description = "the feed API")
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaMSF4JServerCodegen",
         date = "2017-07-20T09:30:14.336Z")

--- a/components/org.wso2.carbon.event.simulator.core/src/gen/java/org/wso2/carbon/event/simulator/core/api/FilesApi.java
+++ b/components/org.wso2.carbon.event.simulator.core/src/gen/java/org/wso2/carbon/event/simulator/core/api/FilesApi.java
@@ -5,6 +5,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.wso2.carbon.analytics.msf4j.interceptor.common.AnalyticsResponseInterceptor;
 import org.wso2.carbon.analytics.msf4j.interceptor.common.AuthenticationInterceptor;
 import org.wso2.carbon.event.simulator.core.exception.FileOperationsException;
 import org.wso2.carbon.event.simulator.core.factories.FilesApiServiceFactory;
@@ -33,6 +34,7 @@ import javax.ws.rs.core.Response;
 
 import io.swagger.annotations.ApiParam;
 import org.wso2.msf4j.interceptor.annotation.RequestInterceptor;
+import org.wso2.msf4j.interceptor.annotation.ResponseInterceptor;
 
 
 @Component(
@@ -42,6 +44,7 @@ import org.wso2.msf4j.interceptor.annotation.RequestInterceptor;
 )
 @Path("/simulation/files")
 @RequestInterceptor(AuthenticationInterceptor.class)
+@ResponseInterceptor(AnalyticsResponseInterceptor.class)
 @io.swagger.annotations.Api(description = "the files API")
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaMSF4JServerCodegen",
         date = "2017-07-20T09:30:14.336Z")

--- a/components/org.wso2.carbon.event.simulator.core/src/gen/java/org/wso2/carbon/event/simulator/core/api/SingleApi.java
+++ b/components/org.wso2.carbon.event.simulator.core/src/gen/java/org/wso2/carbon/event/simulator/core/api/SingleApi.java
@@ -9,6 +9,7 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.wso2.carbon.analytics.msf4j.interceptor.common.AnalyticsResponseInterceptor;
 import org.wso2.carbon.analytics.msf4j.interceptor.common.AuthenticationInterceptor;
 import org.wso2.carbon.event.simulator.core.factories.SingleApiServiceFactory;
 import org.wso2.carbon.event.simulator.core.model.*;
@@ -27,6 +28,7 @@ import org.wso2.msf4j.Microservice;
 import org.wso2.msf4j.formparam.FormDataParam;
 import org.wso2.msf4j.formparam.FileInfo;
 import org.wso2.msf4j.interceptor.annotation.RequestInterceptor;
+import org.wso2.msf4j.interceptor.annotation.ResponseInterceptor;
 
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
@@ -40,6 +42,7 @@ import javax.ws.rs.*;
 )
 @Path("/simulation/single")
 @RequestInterceptor(AuthenticationInterceptor.class)
+@ResponseInterceptor(AnalyticsResponseInterceptor.class)
 @io.swagger.annotations.Api(description = "the single API")
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaMSF4JServerCodegen",
                             date = "2017-07-20T09:30:14.336Z")

--- a/components/org.wso2.carbon.siddhi.store.api.rest/src/main/java/org/wso2/carbon/siddhi/store/api/rest/SiddhiStoreDataHolder.java
+++ b/components/org.wso2.carbon.siddhi.store.api.rest/src/main/java/org/wso2/carbon/siddhi/store/api/rest/SiddhiStoreDataHolder.java
@@ -19,6 +19,7 @@
 
 package org.wso2.carbon.siddhi.store.api.rest;
 
+import org.wso2.carbon.analytics.msf4j.interceptor.common.AnalyticsResponseInterceptor;
 import org.wso2.carbon.analytics.msf4j.interceptor.common.AuthenticationInterceptor;
 import org.wso2.carbon.config.provider.ConfigProvider;
 import org.wso2.carbon.streaming.integrator.common.SiddhiAppRuntimeService;
@@ -30,6 +31,7 @@ public class SiddhiStoreDataHolder {
     private SiddhiAppRuntimeService siddhiAppRuntimeService;
     private ConfigProvider configProvider;
     private AuthenticationInterceptor authenticationInterceptor;
+    private AnalyticsResponseInterceptor analyticsResponseInterceptor;
 
     private static SiddhiStoreDataHolder  instance = new SiddhiStoreDataHolder();
 
@@ -63,5 +65,13 @@ public class SiddhiStoreDataHolder {
 
     public void setAuthenticationInterceptor(AuthenticationInterceptor authenticationInterceptor) {
         this.authenticationInterceptor = authenticationInterceptor;
+    }
+
+    public AnalyticsResponseInterceptor getAnalyticsResponseInterceptor() {
+        return analyticsResponseInterceptor;
+    }
+
+    public void setAnalyticsResponseInterceptor(AnalyticsResponseInterceptor analyticsResponseInterceptor) {
+        this.analyticsResponseInterceptor = analyticsResponseInterceptor;
     }
 }

--- a/components/org.wso2.carbon.streaming.integrator.core/src/gen/java/org/wso2/carbon/streaming/integrator/core/api/RunTimeApi.java
+++ b/components/org.wso2.carbon.streaming.integrator.core/src/gen/java/org/wso2/carbon/streaming/integrator/core/api/RunTimeApi.java
@@ -17,11 +17,13 @@
 package org.wso2.carbon.streaming.integrator.core.api;
 
 import org.osgi.service.component.annotations.Component;
+import org.wso2.carbon.analytics.msf4j.interceptor.common.AnalyticsResponseInterceptor;
 import org.wso2.carbon.analytics.msf4j.interceptor.common.AuthenticationInterceptor;
 import org.wso2.carbon.streaming.integrator.core.factories.RunTimeApiServiceFactory;
 import org.wso2.msf4j.Microservice;
 import org.wso2.msf4j.Request;
 import org.wso2.msf4j.interceptor.annotation.RequestInterceptor;
+import org.wso2.msf4j.interceptor.annotation.ResponseInterceptor;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -40,6 +42,7 @@ import javax.ws.rs.core.Response;
 @Path("/nodeDetails")
 
 @RequestInterceptor(AuthenticationInterceptor.class)
+@ResponseInterceptor(AnalyticsResponseInterceptor.class)
 @io.swagger.annotations.Api(description = "the runTime API")
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaMSF4JServerCodegen",
                             date = "2018-02-20T10:49:25.745Z")

--- a/components/org.wso2.carbon.streaming.integrator.core/src/gen/java/org/wso2/carbon/streaming/integrator/core/api/SiddhiAppsApi.java
+++ b/components/org.wso2.carbon.streaming.integrator.core/src/gen/java/org/wso2/carbon/streaming/integrator/core/api/SiddhiAppsApi.java
@@ -18,6 +18,7 @@ package org.wso2.carbon.streaming.integrator.core.api;
 
 import io.swagger.annotations.ApiParam;
 import org.osgi.service.component.annotations.Component;
+import org.wso2.carbon.analytics.msf4j.interceptor.common.AnalyticsResponseInterceptor;
 import org.wso2.carbon.analytics.msf4j.interceptor.common.AuthenticationInterceptor;
 import org.wso2.carbon.streaming.integrator.core.factories.SiddhiAppsApiServiceFactory;
 import org.wso2.carbon.streaming.integrator.core.model.InlineResponse200;
@@ -27,6 +28,7 @@ import org.wso2.carbon.streaming.integrator.core.util.StatsEnable;
 import org.wso2.msf4j.Microservice;
 import org.wso2.msf4j.Request;
 import org.wso2.msf4j.interceptor.annotation.RequestInterceptor;
+import org.wso2.msf4j.interceptor.annotation.ResponseInterceptor;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -51,6 +53,7 @@ import javax.ws.rs.core.Response;
 )
 @Path("/siddhi-apps")
 @RequestInterceptor(AuthenticationInterceptor.class)
+@ResponseInterceptor(AnalyticsResponseInterceptor.class)
 @io.swagger.annotations.Api(description = "The siddhi-apps API")
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaMSF4JServerCodegen",
         date = "2017-05-31T15:43:24.557Z")

--- a/components/org.wso2.carbon.streaming.integrator.statistics/src/gen/java/org/wso2/carbon/streaming/integrator/statistics/api/StatisticsApi.java
+++ b/components/org.wso2.carbon.streaming.integrator.statistics/src/gen/java/org/wso2/carbon/streaming/integrator/statistics/api/StatisticsApi.java
@@ -28,6 +28,7 @@ import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.analytics.msf4j.interceptor.common.AnalyticsResponseInterceptor;
 import org.wso2.carbon.analytics.msf4j.interceptor.common.AuthenticationInterceptor;
 import org.wso2.carbon.streaming.integrator.core.util.StatsEnable;
 import org.wso2.carbon.streaming.integrator.statistics.factories.StatisticsApiServiceFactory;
@@ -35,6 +36,7 @@ import org.wso2.carbon.streaming.integrator.statistics.internal.OperatingSystemM
 import org.wso2.msf4j.Microservice;
 import org.wso2.msf4j.Request;
 import org.wso2.msf4j.interceptor.annotation.RequestInterceptor;
+import org.wso2.msf4j.interceptor.annotation.ResponseInterceptor;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -52,6 +54,7 @@ import javax.ws.rs.core.Response;
 )
 @Path("/statistics")
 @RequestInterceptor(AuthenticationInterceptor.class)
+@ResponseInterceptor(AnalyticsResponseInterceptor.class)
 @io.swagger.annotations.Api(description = "The statistics API")
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaMSF4JServerCodegen", date = "2017-09-11T07:22:13.522Z")
 public class StatisticsApi implements Microservice   {

--- a/components/org.wso2.carbon.streaming.integrator.statistics/src/gen/java/org/wso2/carbon/streaming/integrator/statistics/api/SystemDetailsApi.java
+++ b/components/org.wso2.carbon.streaming.integrator.statistics/src/gen/java/org/wso2/carbon/streaming/integrator/statistics/api/SystemDetailsApi.java
@@ -27,12 +27,14 @@ import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.analytics.msf4j.interceptor.common.AnalyticsResponseInterceptor;
 import org.wso2.carbon.analytics.msf4j.interceptor.common.AuthenticationInterceptor;
 import org.wso2.carbon.streaming.integrator.statistics.factories.SystemDetailsApiServiceFactory;
 import org.wso2.carbon.streaming.integrator.statistics.internal.service.ConfigServiceComponent;
 import org.wso2.msf4j.Microservice;
 import org.wso2.msf4j.Request;
 import org.wso2.msf4j.interceptor.annotation.RequestInterceptor;
+import org.wso2.msf4j.interceptor.annotation.ResponseInterceptor;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.NotFoundException;
@@ -42,6 +44,7 @@ import javax.ws.rs.core.Response;
 
 @Path("/system-details")
 @RequestInterceptor(AuthenticationInterceptor.class)
+@ResponseInterceptor(AnalyticsResponseInterceptor.class)
 @Component(
         name = "org.wso2.carbon.streaming.integrator.statistic.api.SystemDetailsApi",
         service = Microservice.class,

--- a/components/org.wso2.siddhi.parser/src/main/java/org/wso2/siddhi/parser/service/SiddhiParserApi.java
+++ b/components/org.wso2.siddhi.parser/src/main/java/org/wso2/siddhi/parser/service/SiddhiParserApi.java
@@ -47,7 +47,7 @@ import org.wso2.carbon.config.ConfigurationException;
 import org.wso2.carbon.config.provider.ConfigProvider;
 import org.wso2.carbon.kernel.config.model.CarbonConfiguration;
 import org.wso2.msf4j.MicroservicesRunner;
-import org.wso2.msf4j.config.TransportsFileConfiguration;
+import org.wso2.transport.http.netty.contract.config.TransportsConfiguration;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -77,7 +77,7 @@ public class SiddhiParserApi {
     private static final Logger log = LoggerFactory.getLogger(SiddhiParserApi.class);
     private static final String TRANSPORT_ROOT_CONFIG_ELEMENT = "wso2.transport.http";
     private static final String SIDDHI_PARSER_ACTIVATION_SYS_PROPERTY = "siddhi-parser";
-    private static TransportsFileConfiguration transportsFileConfiguration;
+    private static TransportsConfiguration transportsConfiguration;
     private static MicroservicesRunner microservicesRunner;
     private static volatile boolean microserviceActive;
     private static SiddhiAppCreator appCreator = new NatsSiddhiAppCreator();
@@ -203,8 +203,8 @@ public class SiddhiParserApi {
      */
     @Activate
     protected void start(BundleContext bundleContext) throws Exception {
-        if (transportsFileConfiguration != null) {
-            microservicesRunner = new MicroservicesRunner(transportsFileConfiguration);
+        if (transportsConfiguration != null) {
+            microservicesRunner = new MicroservicesRunner(transportsConfiguration);
         }
         String toolIdentifier = System.getProperty(SIDDHI_PARSER_ACTIVATION_SYS_PROPERTY);
         Optional.ofNullable(toolIdentifier)
@@ -257,10 +257,10 @@ public class SiddhiParserApi {
     protected void registerConfigProvider(ConfigProvider configProvider) {
         SiddhiParserDataHolder.setConfigProvider(configProvider);
         try {
-            transportsFileConfiguration = configProvider.getConfigurationObject(TRANSPORT_ROOT_CONFIG_ELEMENT,
-                    TransportsFileConfiguration.class);
+            transportsConfiguration = configProvider.getConfigurationObject(TRANSPORT_ROOT_CONFIG_ELEMENT,
+                    TransportsConfiguration.class);
             CarbonConfiguration carbonConfig = configProvider.getConfigurationObject(CarbonConfiguration.class);
-            transportsFileConfiguration.getListenerConfigurations().forEach(
+            transportsConfiguration.getListenerConfigurations().forEach(
                     listenerConfiguration -> listenerConfiguration.setPort(
                             listenerConfiguration.getPort() + carbonConfig.getPortsConfig().getOffset()));
         } catch (ConfigurationException e) {

--- a/pom.xml
+++ b/pom.xml
@@ -1722,7 +1722,7 @@
         <carbon.kernel.pax.version>5.2.13</carbon.kernel.pax.version>
 
         <netty.version>4.1.34.Final</netty.version>
-        <org.wso2.transport.http.netty.version>6.1.9</org.wso2.transport.http.netty.version>
+        <org.wso2.transport.http.netty.version>6.3.24</org.wso2.transport.http.netty.version>
         <commons-vfs2.wso2.version>2.2-wso2v1</commons-vfs2.wso2.version>
         <carbon.transport.package.import.version.range>[6.0.0, 7.0.0)</carbon.transport.package.import.version.range>
 
@@ -1792,7 +1792,7 @@
         <common.collections4.version>4.1</common.collections4.version>
 
         <!--MSF4J related-->
-        <msf4j.version>2.7.7</msf4j.version>
+        <msf4j.version>2.8.2</msf4j.version>
         <msf4j.import.version.range>[2.7.0, 3.0.0)</msf4j.import.version.range>
         <com.fasterxml.jackson.core.version>2.9.8</com.fasterxml.jackson.core.version>
         <com.fasterxml.jackson.core.version.range>[2.9.0, 2.10.0)</com.fasterxml.jackson.core.version.range>


### PR DESCRIPTION
## Purpose
> $subject

> The response interceptor will read the deployment yaml and and add the headers to the HTTP response.
Users have to configure HSTS header values in netty-transports.yaml under listener configurations as follows.

wso2.transport.http:
....
...
  listenerConfigurations:
   ...
   ...
    -
      id: "msf4j-https"
      host: "0.0.0.0"
      port: 9740
      scheme: https
      keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
      keyStorePassword: wso2carbon
      certPass: wso2carbon
      strictTransportSecurityHeader: max-age=342352535; includeSubDomains
      responseHeaderList: "Feature-Policy: microphone 'none'; geolocation 'none', Referrer-Policy: no-referrer"

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes