### PR TITLE
[1.3.x] Fixes the issue on DAS message trace error when output is set to be JSON on the event publisher

### DIFF
--- a/components/analytics-data-agents/org.wso2.carbon.analytics.message.tracer.handler/pom.xml
+++ b/components/analytics-data-agents/org.wso2.carbon.analytics.message.tracer.handler/pom.xml
@@ -84,16 +84,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>

--- a/components/analytics-data-agents/org.wso2.carbon.analytics.message.tracer.handler/pom.xml
+++ b/components/analytics-data-agents/org.wso2.carbon.analytics.message.tracer.handler/pom.xml
@@ -78,5 +78,25 @@
             <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/components/analytics-data-agents/org.wso2.carbon.analytics.message.tracer.handler/src/main/java/org/wso2/carbon/analytics/message/tracer/handler/util/HandlerUtils.java
+++ b/components/analytics-data-agents/org.wso2.carbon.analytics.message.tracer.handler/src/main/java/org/wso2/carbon/analytics/message/tracer/handler/util/HandlerUtils.java
@@ -101,45 +101,54 @@ public class HandlerUtils {
     public static String getUserNameIN(MessageContext messageContext) {
         //getting username from messageContext
         String userName = "";
-        if(messageContext == null) {
+        if (messageContext == null) {
             return userName;
         }
-        HttpServletRequest request = (HttpServletRequest) messageContext.getProperty(HTTPConstants.MC_HTTP_SERVLETREQUEST);
+        HttpServletRequest request = (HttpServletRequest) messageContext
+                .getProperty(HTTPConstants.MC_HTTP_SERVLETREQUEST);
         HttpSession session;
         if (request != null && (session = request.getSession(false)) != null) {
             String tenantDomain = (String) session.getAttribute(MultitenantConstants.TENANT_DOMAIN);
             userName = (String) session.getAttribute(ServerConstants.USER_LOGGED_IN);
-            if(userName != null && tenantDomain != null && !MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(tenantDomain)){
+            if (userName != null && tenantDomain != null && !MultitenantConstants.SUPER_TENANT_DOMAIN_NAME
+                    .equalsIgnoreCase(tenantDomain)) {
                 userName = userName + tenantDomain;
             }
         }
-        if(userName != null && !userName.isEmpty()) {
+        if (userName != null && !userName.isEmpty()) {
             return userName;
         } else {
             Object transportHeaders = messageContext.getProperty(MessageContext.TRANSPORT_HEADERS);
-            if(transportHeaders != null) {
-                String basicAuthHeader = (String)((Map)transportHeaders).get("Authorization");
-                if(basicAuthHeader != null && !basicAuthHeader.isEmpty()) {
-
-                    String basicAuthHeaderValue = new String(Base64.decodeBase64(basicAuthHeader.replace("Basic", "").trim().getBytes()));
-                    String[] basicAuth = basicAuthHeaderValue.split(":");
-                    if(basicAuth.length >= 2) {
-                        userName = basicAuth[0];
-                        return userName;
+            if (transportHeaders != null) {
+                String basicAuthHeader = (String) ((Map) transportHeaders).get("Authorization");
+                if (basicAuthHeader != null && !basicAuthHeader.isEmpty()) {
+                    if (basicAuthHeader.contains("Basic")) {
+                        String basicAuthHeaderValue = new String(
+                                Base64.decodeBase64(basicAuthHeader.replace("Basic", "").trim().getBytes()));
+                        String[] basicAuth = basicAuthHeaderValue.split(":");
+                        if (basicAuth.length >= 2) {
+                            userName = basicAuth[0];
+                            return userName;
+                        }
+                    } else {
+                        return "";
                     }
                 }
             }
         }
-        if(MessageTracerConstants.AUTHENTICATION_ADMIN.equalsIgnoreCase(messageContext.getAxisService().getName()) &&
-           MessageTracerConstants.MESSAGE_DIRECTION.equalsIgnoreCase(messageContext.getAxisMessage().getDirection())
-           && MessageTracerConstants.AUTHENTICATION_OPERATION.equalsIgnoreCase(messageContext.getAxisOperation().getName().getLocalPart())) {
+        if (MessageTracerConstants.AUTHENTICATION_ADMIN.equalsIgnoreCase(messageContext.getAxisService().getName())
+                && MessageTracerConstants.MESSAGE_DIRECTION
+                .equalsIgnoreCase(messageContext.getAxisMessage().getDirection())
+                && MessageTracerConstants.AUTHENTICATION_OPERATION
+                .equalsIgnoreCase(messageContext.getAxisOperation().getName().getLocalPart())) {
             try {
                 OMElement responsePayload = messageContext.getEnvelope().getBody().getFirstElement();
-                if(responsePayload != null) {
-                    userName = responsePayload.getFirstChildWithName(new QName(responsePayload.getNamespace().getNamespaceURI()
-                            , "username", responsePayload.getNamespace().getPrefix())).getText();
+                if (responsePayload != null) {
+                    userName = responsePayload.getFirstChildWithName(
+                            new QName(responsePayload.getNamespace().getNamespaceURI(), "username",
+                                    responsePayload.getNamespace().getPrefix())).getText();
                 }
-            }catch (Exception e) {
+            } catch (Exception e) {
                 LOG.error("Error while trying to get the user name form authentication request", e);
             }
             return userName;
@@ -151,27 +160,28 @@ public class HandlerUtils {
     public static String getUserNameOUT(MessageContext messageContext) {
         //getting username from messageContext
         String userName = "";
-        if(messageContext == null) {
+        if (messageContext == null) {
             return userName;
         }
         userName = CarbonContext.getThreadLocalCarbonContext().getUsername();
-        if(userName != null && !userName.isEmpty()) {
+        if (userName != null && !userName.isEmpty()) {
             return userName;
         } else {
             Object transportHeaders = messageContext.getProperty(MessageContext.TRANSPORT_HEADERS);
-            if(transportHeaders != null) {
-                String basicAuthHeader = (String)((Map)transportHeaders).get("Authorization");
-                if(basicAuthHeader != null && !basicAuthHeader.isEmpty()) {
-                    String basicAuthHeaderValue = new String(Base64.decodeBase64(basicAuthHeader.replace("Basic", "").trim().getBytes()));
+            if (transportHeaders != null) {
+                String basicAuthHeader = (String) ((Map) transportHeaders).get("Authorization");
+                if (basicAuthHeader != null && !basicAuthHeader.isEmpty()) {
+                    String basicAuthHeaderValue = new String(
+                            Base64.decodeBase64(basicAuthHeader.replace("Basic", "").trim().getBytes()));
                     String[] basicAuth = basicAuthHeaderValue.split(":");
-                    if(basicAuth.length >= 2) {
+                    if (basicAuth.length >= 2) {
                         userName = basicAuth[0];
                         return userName;
                     }
                 }
             }
+            //returning empty value if unable to fetch the username
+            return "";
         }
-        //returning empty value if unable to fetch the username
-        return "";
     }
 }

--- a/components/analytics-data-agents/org.wso2.carbon.analytics.message.tracer.handler/src/test/java/org/wso2/carbon/analytics/message/tracer/handler/HandlerUtilsTest.java
+++ b/components/analytics-data-agents/org.wso2.carbon.analytics.message.tracer.handler/src/test/java/org/wso2/carbon/analytics/message/tracer/handler/HandlerUtilsTest.java
@@ -1,0 +1,110 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.analytics.message.tracer.handler;
+
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.OMNamespace;
+import org.apache.axiom.soap.SOAPBody;
+import org.apache.axiom.soap.SOAPEnvelope;
+import org.apache.axis2.context.MessageContext;
+
+import org.apache.axis2.description.AxisMessage;
+import org.apache.axis2.description.AxisOperation;
+import org.apache.axis2.description.AxisService;
+import org.apache.axis2.transport.http.HTTPConstants;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.wso2.carbon.analytics.message.tracer.handler.util.HandlerUtils;
+import org.wso2.carbon.analytics.message.tracer.handler.util.MessageTracerConstants;
+import org.wso2.carbon.utils.ServerConstants;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import javax.xml.namespace.QName;
+import java.util.HashMap;
+
+public class HandlerUtilsTest {
+
+    @Test
+    public void testGetUserNameIN() {
+        MessageContext messageContext = null;
+        Assert.assertEquals(HandlerUtils.getUserNameIN(messageContext), "");
+
+        messageContext = Mockito.mock(MessageContext.class);
+        HttpSession session = Mockito.mock(HttpSession.class);
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+
+        Mockito.when(messageContext.getProperty(HTTPConstants.MC_HTTP_SERVLETREQUEST)).thenReturn(request);
+        Mockito.when(request.getSession(false)).thenReturn(session);
+        Mockito.when(session.getAttribute(MultitenantConstants.TENANT_DOMAIN)).thenReturn("carbon.super");
+        Mockito.when(session.getAttribute(ServerConstants.USER_LOGGED_IN)).thenReturn("admin");
+        Assert.assertEquals(HandlerUtils.getUserNameIN(messageContext), "admin");
+
+        Mockito.when(session.getAttribute(MultitenantConstants.TENANT_DOMAIN)).thenReturn("@wso2.com");
+        Mockito.when(session.getAttribute(ServerConstants.USER_LOGGED_IN)).thenReturn("admin");
+        Assert.assertEquals(HandlerUtils.getUserNameIN(messageContext), "admin@wso2.com");
+
+        Mockito.when(session.getAttribute(MultitenantConstants.TENANT_DOMAIN)).thenReturn("carbon.super");
+        Mockito.when(session.getAttribute(ServerConstants.USER_LOGGED_IN)).thenReturn("");
+        HashMap transportHeaders = new HashMap();
+        transportHeaders.put("Authorization", "Basic YWRtaW46YWRtaW4=");
+        Mockito.when(messageContext.getProperty(MessageContext.TRANSPORT_HEADERS)).thenReturn(transportHeaders);
+        Assert.assertEquals(HandlerUtils.getUserNameIN(messageContext), "admin");
+
+        transportHeaders.put("Authorization", " ");
+        Mockito.when(messageContext.getProperty(MessageContext.TRANSPORT_HEADERS)).thenReturn(transportHeaders);
+        Assert.assertEquals(HandlerUtils.getUserNameIN(messageContext), "");
+
+        transportHeaders.put("Authorization", null);
+        AxisService axisService = Mockito.mock(AxisService.class);
+        Mockito.when(messageContext.getAxisService()).thenReturn(axisService);
+        Mockito.when(axisService.getName()).thenReturn(MessageTracerConstants.AUTHENTICATION_ADMIN);
+
+        AxisMessage axisMessage = Mockito.mock(AxisMessage.class);
+        Mockito.when(messageContext.getAxisMessage()).thenReturn(axisMessage);
+        Mockito.when(axisMessage.getDirection()).thenReturn(MessageTracerConstants.MESSAGE_DIRECTION);
+
+        AxisOperation axisOperation = Mockito.mock(AxisOperation.class);
+        Mockito.when(messageContext.getAxisOperation()).thenReturn(axisOperation);
+        QName qName = Mockito.mock(QName.class);
+        Mockito.when(axisOperation.getName()).thenReturn(qName);
+        Mockito.when(qName.getLocalPart()).thenReturn(MessageTracerConstants.AUTHENTICATION_OPERATION);
+
+        OMElement responsePayload = Mockito.mock(OMElement.class);
+        SOAPEnvelope soapEnvelope = Mockito.mock(SOAPEnvelope.class);
+        Mockito.when(messageContext.getEnvelope()).thenReturn(soapEnvelope);
+
+        SOAPBody soapBody = Mockito.mock(SOAPBody.class);
+        Mockito.when(soapEnvelope.getBody()).thenReturn(soapBody);
+        Mockito.when(soapBody.getFirstElement()).thenReturn(responsePayload);
+
+        OMNamespace omNamespace = Mockito.mock(OMNamespace.class);
+        Mockito.when(responsePayload.getNamespace()).thenReturn(omNamespace);
+
+        Mockito.when(omNamespace.getNamespaceURI()).thenReturn("http://abc.com/namespace");
+        Mockito.when(omNamespace.getPrefix()).thenReturn("ns1");
+
+        QName qName1 = new QName(responsePayload.getNamespace().getNamespaceURI(), "username",
+                responsePayload.getNamespace().getPrefix());
+        Mockito.when(responsePayload.getFirstChildWithName(qName1)).thenReturn(responsePayload);
+        Mockito.when(responsePayload.getText()).thenReturn("admin");
+        Assert.assertEquals(HandlerUtils.getUserNameIN(messageContext), "admin");
+    }
+}

--- a/components/analytics-data-agents/org.wso2.carbon.analytics.message.tracer.handler/src/test/resources/testng.xml
+++ b/components/analytics-data-agents/org.wso2.carbon.analytics.message.tracer.handler/src/test/resources/testng.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suite name="Analytics Message Tracer Handler Test Suite" parallel="methods" thread-count="1">
+    <test name="Analytics Message Tracer Handler Tests">
+        <classes>
+            <class name="org.wso2.carbon.analytics.message.tracer.handler.HandlerUtilsTest"/>
+        </classes>
+    </test>
+</suite>

--- a/pom.xml
+++ b/pom.xml
@@ -1058,6 +1058,14 @@
                 <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
                 <version>${apache.felix.scr.ds.annotations.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-all</artifactId>
+                <version>${mockito.all.version}</version>
+                <scope>test</scope>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 
@@ -1486,6 +1494,7 @@
         <import.package.version.commons.logging>[1.2.0,2.0.0)</import.package.version.commons.logging>
         <pax.logging.api.version>1.10.1</pax.logging.api.version>
         <imp.package.version.osgi.services>[1.2.0,2.0.0)</imp.package.version.osgi.services>
+        <mockito.all.version>1.10.19</mockito.all.version>
     </properties>
 
     <pluginRepositories>


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/11555

## Goals
Fixing an issue in APIM 3.2.0 when message tracing is enabled and using an event publisher with logger output set to JSON.

## Approach
Although the basic auth header is not present, **getUserNameIN** function will check for the header that is causing the error. So only checking the basic auth header if it is already present in the message context solved the problem.

## Test environment
- OS: Ubuntu 20.04.2 LTS
- JDK 1.8.0_251
