### PR TITLE
Add hikaricp as an import package in streaming integrator core

### DIFF
--- a/components/org.wso2.carbon.streaming.integrator.core/pom.xml
+++ b/components/org.wso2.carbon.streaming.integrator.core/pom.xml
@@ -302,6 +302,7 @@
             org.wso2.carbon.database.query.manager.*; version="${carbon.analytics-common.version.range}",
             javax.management.*,
             javax.ws.rs.*;version="${javax.ws.rs.version.range}",
+            com.zaxxer.*;version="${hikaricp.version.range}",
             *;resolution:=optional
         </import.package>
         <carbon.component>

--- a/pom.xml
+++ b/pom.xml
@@ -1783,6 +1783,7 @@
 
         <antlr4.runtime.version>4.11.1</antlr4.runtime.version>
         <hikari.version>3.3.1</hikari.version>
+        <hikaricp.version.range>[2.6.1,4.0.0)</hikaricp.version.range>
 
         <!-- json dependencies -->
         <gson.version>2.9.1</gson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1783,7 +1783,7 @@
 
         <antlr4.runtime.version>4.11.1</antlr4.runtime.version>
         <hikari.version>3.3.1</hikari.version>
-        <hikaricp.version.range>[2.6.1,4.0.0)</hikaricp.version.range>
+        <hikaricp.version.range>[3.3.1,4.0.0)</hikaricp.version.range>
 
         <!-- json dependencies -->
         <gson.version>2.9.1</gson.version>


### PR DESCRIPTION
## Purpose
This PR adds hikaricp as an import package in the org.wso2.carbon.streaming.integrator.core POM file.

Fixes https://github.com/wso2/api-manager/issues/2373