### PR TITLE
Bump okhttp version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1677,8 +1677,8 @@
         <json.version>3.0.0.wso2v1</json.version>
         <libthrift.version>0.9.2.wso2v1</libthrift.version>
         <httpclient.version>4.3.2.wso2v1</httpclient.version>
-        <okhttp.version>3.8.0.wso2v2</okhttp.version>
-        <okio.version>1.13.0.wso2v1</okio.version>
+        <okhttp.version>4.12.0.wso2v2</okhttp.version>
+        <okio.version>3.9.0.wso2v1</okio.version>
         <apache.commons.io.version>2.4</apache.commons.io.version>
         <wso2.slf4j.version>1.5.10.wso2v1</wso2.slf4j.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>


### PR DESCRIPTION
$subject

This is to fix the following issue when using the sample here. https://ei.docs.wso2.com/en/latest/streaming-integrator/samples/PublishHttpOAuthRequestWithoutAccessToken/
```
Exception in thread "pool-6-thread-1" java.lang.NoSuchMethodError: 'okhttp3.RequestBody okhttp3.RequestBody.create(byte[], okhttp3.MediaType)'. Possibly a version mismatch with the OkHttp version
```

Tested the following samples with this change to verify that this is working
1. https://ei.docs.wso2.com/en/latest/streaming-integrator/samples/PublishHttpOAuthRequestWithoutAccessToken/
2. https://ei.docs.wso2.com/en/latest/streaming-integrator/samples/PublishHttpOAuthRequestWithOAuthUser/
3. https://ei.docs.wso2.com/en/latest/streaming-integrator/samples/PublishHttpOAuthRequest/
4. https://ei.docs.wso2.com/en/latest/streaming-integrator/samples/PublishHttpOAuthRequestResponse/
5. https://ei.docs.wso2.com/en/latest/streaming-integrator/samples/PublishHttpOAuthRequestWithRefreshToken/
6. https://ei.docs.wso2.com/en/latest/streaming-integrator/samples/PublishKafkaInCustomAvroFormat/
