### PR TITLE
Pack json path libraries in editor core

### DIFF
--- a/features/org.wso2.carbon.siddhi.editor.core.feature/pom.xml
+++ b/features/org.wso2.carbon.siddhi.editor.core.feature/pom.xml
@@ -140,6 +140,22 @@
                                     <symbolicName>jaxen</symbolicName>
                                     <version>${jaxen.version}</version>
                                 </bundle>
+                                <bundle>
+                                    <symbolicName>json-path</symbolicName>
+                                    <version>${jayway.jsonpath.version}</version>
+                                </bundle>
+                                <bundle>
+                                    <symbolicName>net.minidev.json-smart</symbolicName>
+                                    <version>${net.minidev.version}</version>
+                                </bundle>
+                                <bundle>
+                                    <symbolicName>net.minidev.accessors-smart</symbolicName>
+                                    <version>${accessors.smart.version}</version>
+                                </bundle>
+                                <bundle>
+                                    <symbolicName>org.objectweb.asm</symbolicName>
+                                    <version>${asm.version}</version>
+                                </bundle>
                             </bundles>
                         </configuration>
                     </execution>


### PR DESCRIPTION
$subject.
These libraries are needed for the editor and these are present only inside the streaming.integrator.core. If this is used an OOM is sometimes observed in the SI tooling. Thus adding these json path libraries to the editor to use inside the tooling