### PR TITLE
fix: revert commons-fileupload version to 1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1946,7 +1946,7 @@
         <owasp.encoder.version>1.2.0.wso2v2</owasp.encoder.version>
         <apache.httpcomponents.version>4.3.1.wso2v1</apache.httpcomponents.version>
         <apache.commons.csv.version>1.4</apache.commons.csv.version>
-        <apache.commons.fileupload.version>1.6.0</apache.commons.fileupload.version>
+        <apache.commons.fileupload.version>1.5</apache.commons.fileupload.version>
         <fabricator.wso2v1.version>2.1.4.wso2v1</fabricator.wso2v1.version>
         <generex.wso2v1.version>1.0.0.wso2v1</generex.wso2v1.version>
         <mysql.connector.version>8.0.33</mysql.connector.version>


### PR DESCRIPTION
## Summary
- `commons-fileupload:commons-fileupload:1.6.0` does not exist — the last release under the old coordinates is `1.5`
- The trivy fix incorrectly bumped this to a non-existent version
- This causes P2 feature installation failure: `org.apache.commons.commons-fileupload [1.6.0]` bundle not found

## Changes
- `apache.commons.fileupload.version`: `1.6.0` → `1.5`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency library version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->