### PR TITLE
fix: revert log4j version to 2.22.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1743,7 +1743,7 @@
         <siddhi.bundle.version>5.1.32</siddhi.bundle.version>
         <siddhi.version.range>[5.0.0, 6.0.0)</siddhi.version.range>
         <carbon.analytics-common.version>6.1.70</carbon.analytics-common.version>
-        <log4j.version>2.24.3</log4j.version>
+        <log4j.version>2.22.1</log4j.version>
         <nimbus.jose.jwt.version>10.9</nimbus.jose.jwt.version>
         <commons.compress.version>1.28.0</commons.compress.version>
         <woodstox.core.version>7.1.1</woodstox.core.version>


### PR DESCRIPTION
## Summary
- `log4j-slf4j-impl:2.24.3` requires `org.apache.logging.log4j.message` version `[2.24.0,3.0.0)`
- The OSGi runtime provides log4j via `pax-logging-log4j2:2.1.0-wso2v3` which exports an older version
- This causes `BundleException: Could not resolve module: org.apache.logging.log4j.slf4j.impl` and prevents the Carbon container from starting, failing all OSGi integration tests

## Changes
- `log4j.version`: `2.24.3` → `2.22.1` (compatible with pax-logging)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated logging library dependency version from 2.24.3 to 2.22.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->