### PR TITLE
Fix mysql connector artifact reference in OSGi tests

### DIFF
--- a/components/streaming-integrator-osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/DBPersistenceStoreTestcase.java
+++ b/components/streaming-integrator-osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/DBPersistenceStoreTestcase.java
@@ -121,7 +121,7 @@ public class DBPersistenceStoreTestcase {
                 copyCarbonYAMLOption(),
                 copyOracleJDBCJar(),
                 CarbonDistributionOption.copyOSGiLibBundle(maven(
-                        "mysql", "mysql-connector-java").versionAsInProject()),
+                        "com.mysql", "mysql-connector-j").versionAsInProject()),
                 CarbonDistributionOption.copyOSGiLibBundle(maven(
                         "org.postgresql", "postgresql").versionAsInProject()),
                 CarbonDistributionOption.copyOSGiLibBundle(maven(

--- a/components/streaming-integrator-osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/IncrementalDBPersistenceStoreTestcase.java
+++ b/components/streaming-integrator-osgi-tests/src/test/java/org/wso2/carbon/analytics/test/osgi/IncrementalDBPersistenceStoreTestcase.java
@@ -120,7 +120,7 @@ public class IncrementalDBPersistenceStoreTestcase {
                 copyCarbonYAMLOption(),
                 copyOracleJDBCJar(),
                 CarbonDistributionOption.copyOSGiLibBundle(maven(
-                        "mysql", "mysql-connector-java").versionAsInProject()),
+                        "com.mysql", "mysql-connector-j").versionAsInProject()),
                 CarbonDistributionOption.copyOSGiLibBundle(maven(
                         "org.postgresql", "postgresql").versionAsInProject()),
                 CarbonDistributionOption.copyOSGiLibBundle(maven(


### PR DESCRIPTION
## Summary
- The trivy vulnerability fix changed the MySQL connector dependency from `mysql:mysql-connector-java` to `com.mysql:mysql-connector-j` in the pom, but didn't update the pax-exam `@Configuration` methods in `DBPersistenceStoreTestcase` and `IncrementalDBPersistenceStoreTestcase`
- This caused `maven("mysql", "mysql-connector-java").versionAsInProject()` to fail silently, preventing the pax-exam container from starting for these test classes
- The release build fails with "Container never started" because only 5 out of 10 OSGi test containers start successfully

## Test plan
- [ ] Trigger a release build and verify all 10 pax-exam containers start
- [ ] Verify OSGi tests report 73+ tests passed (vs 0 currently)
- [ ] Verify BUILD SUCCESS for the `carbon-analytics-streaming-integrator-osgi-tests` module

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MySQL JDBC driver dependencies in OSGi test configurations to use the latest connector version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->