### PR TITLE
Fix: revert jackson version to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1637,28 +1637,6 @@
                 <artifactId>docker-client</artifactId>
                 <classifier>shaded</classifier>
                 <version>${com.spotify.docker.client.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.fasterxml.jackson.core</groupId>
-                        <artifactId>jackson-databind</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.fasterxml.jackson.core</groupId>
-                        <artifactId>jackson-core</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.fasterxml.jackson.core</groupId>
-                        <artifactId>jackson-annotations</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.commons</groupId>
-                        <artifactId>commons-compress</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.google.guava</groupId>
-                        <artifactId>guava</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>net.minidev</groupId>
@@ -1912,8 +1890,8 @@
         <!--MSF4J related-->
         <msf4j.version>2.8.12</msf4j.version>
         <msf4j.import.version.range>[2.7.0, 3.0.0)</msf4j.import.version.range>
-        <com.fasterxml.jackson.core.version>2.18.6</com.fasterxml.jackson.core.version>
-        <com.fasterxml.jackson.databind.version>2.18.6</com.fasterxml.jackson.databind.version>
+        <com.fasterxml.jackson.core.version>2.16.0</com.fasterxml.jackson.core.version>
+        <com.fasterxml.jackson.databind.version>2.16.0</com.fasterxml.jackson.databind.version>
         <com.fasterxml.jackson.core.version.range>[2.15.0, 2.20.0)</com.fasterxml.jackson.core.version.range>
         <io.swagger.version>1.6.7</io.swagger.version>
         <javax.ws.rs-api.version>2.0</javax.ws.rs-api.version>


### PR DESCRIPTION
## Summary
- Reverts jackson-core/databind from 2.18.6 back to 2.16.0 (bumped by trivy fix PR #2023)
- Jackson 2.18.x causes `ClassNotFoundException: com.fasterxml.jackson.core.JsonProcessingException` at OSGi runtime in the tooling test distribution
- The `event.simulator.core` bundle can't resolve jackson classes, causing `SimulatorAPITestcase.testSingleAPI` to fail with HTTP 500
- Also removes the jackson exclusions from docker-client that were only needed to force 2.18.6

## Test plan
- [ ] Verify `SimulatorAPITestcase.testSingleAPI` passes (currently fails with `expected [200] but found [500]`)
- [ ] Verify all 37 tooling OSGi tests pass
- [ ] Verify all 73 SI OSGi tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal library versions to improve system stability and compatibility
  * Adjusted dependency management configuration to optimize library integration and transitive artifact handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->