### PR TITLE
fix: remove non-existent log4j-api orbit wrapper dependency

### DIFF
--- a/components/org.wso2.carbon.data.provider/src/test/java/org/wso2/carbon/data/provider/RDBMSQueriesIT.java
+++ b/components/org.wso2.carbon.data.provider/src/test/java/org/wso2/carbon/data/provider/RDBMSQueriesIT.java
@@ -75,7 +75,9 @@ public class RDBMSQueriesIT {
     @AfterClass
     public static void shutdown() {
         log.info("== RDBMS Queries tests completed ==");
-        microservicesRunner.stop();
+        if (microservicesRunner != null) {
+            microservicesRunner.stop();
+        }
     }
 
     @BeforeMethod

--- a/features/org.wso2.siddhi.feature/pom.xml
+++ b/features/org.wso2.siddhi.feature/pom.xml
@@ -48,16 +48,6 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.orbit.org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.antlr</groupId>
@@ -217,10 +207,6 @@
                                     <!--<symbolicName>org.apache.logging.log4j.core</symbolicName>-->
                                     <!--<version>${log4j.version}</version>-->
                                 <!--</bundle>-->
-                                <bundle>
-                                    <symbolicName>org.apache.logging.log4j.api</symbolicName>
-                                    <version>${log4j.orbit.version}</version>
-                                </bundle>
                                 <bundle>
                                     <symbolicName>org.apache.logging.log4j.slf4j.impl</symbolicName>
                                     <version>${log4j.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -395,11 +395,7 @@
                 <artifactId>commons-lang3</artifactId>
                 <version>${commons-lang3.orbit.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.wso2.orbit.org.apache.logging.log4j</groupId>
-                <artifactId>log4j-api</artifactId>
-                <version>${log4j.orbit.version}</version>
-            </dependency>
+
             <!-- OSGi test -->
             <dependency>
                 <groupId>org.awaitility</groupId>
@@ -1732,7 +1728,6 @@
         <siddhi.version.range>[5.0.0, 6.0.0)</siddhi.version.range>
         <carbon.analytics-common.version>6.1.73</carbon.analytics-common.version>
         <log4j.version>2.25.4</log4j.version>
-        <log4j.orbit.version>2.25.4.wso2v1</log4j.orbit.version>
         <nimbus.jose.jwt.version>10.9</nimbus.jose.jwt.version>
         <commons.compress.version>1.28.0</commons.compress.version>
         <woodstox.core.version>7.1.1</woodstox.core.version>


### PR DESCRIPTION
## Summary

- **Root cause:** PR #2028 introduced `org.wso2.orbit.org.apache.logging.log4j:log4j-api:2.25.4.wso2v1` as an explicit dependency in `org.wso2.siddhi.feature`, but this orbit artifact has never been published to WSO2 Nexus (or Maven Central). This caused the release build to fail immediately with a dependency resolution error on `org.wso2.siddhi.feature`.
- **Fix:** Revert to the pre-#2028 pattern — `log4j-api` resolves transitively through `log4j-slf4j-impl`, which already brings in the correct `2.25.4` version via the root pom's `<dependencyManagement>`. No orbit wrapper is needed since `log4j-api` ships with native OSGi bundle headers.

## Changes

- Remove `<exclusion>` of `log4j-api` from `log4j-slf4j-impl` in `features/org.wso2.siddhi.feature/pom.xml`
- Remove explicit `org.wso2.orbit.org.apache.logging.log4j:log4j-api` dependency and `<bundle>` entry from the feature assembly
- Remove `log4j.orbit.version` property and its `<dependencyManagement>` entry from root `pom.xml`

## Test plan

- [ ] `mvn clean install -DskipTests` passes
- [ ] Release build (`mvn release:prepare`) resolves all dependencies successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)