### PR TITLE
Bump carbon.analytics-common.version 6.1.73 -> 6.1.74-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1726,7 +1726,8 @@
         <siddhi.version>5.1.33</siddhi.version>
         <siddhi.bundle.version>5.1.33</siddhi.bundle.version>
         <siddhi.version.range>[5.0.0, 6.0.0)</siddhi.version.range>
-        <carbon.analytics-common.version>6.1.73</carbon.analytics-common.version>
+        <!-- TODO: remove SNAPSHOT once carbon-analytics-common 6.1.74 is released -->
+        <carbon.analytics-common.version>6.1.74-SNAPSHOT</carbon.analytics-common.version>
         <log4j.version>2.25.4</log4j.version>
         <nimbus.jose.jwt.version>10.9</nimbus.jose.jwt.version>
         <commons.compress.version>1.28.0</commons.compress.version>


### PR DESCRIPTION
## Summary
- Update `carbon.analytics-common.version` from 6.1.73 to 6.1.74-SNAPSHOT to pick up the libthrift 0.23.0.wso2v1 upgrade (CVE-2018-1320, CVE-2019-0205, CVE-2018-11798)
- TODO: remove `-SNAPSHOT` qualifier once carbon-analytics-common 6.1.74 is formally released

## Test plan
- [ ] Maven build passes
- [ ] Verify libthrift 0.23.0.wso2v1 is resolved transitively via the updated analytics-common snapshot